### PR TITLE
Changed order of operations in kernel for TKE dissipation rate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
 authors = ["tomchor <tomaschor@gmail.com>"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"


### PR DESCRIPTION
@glwagner I think we discussed this at some point. Interpolating a quantity and then squaring it is different from squaring it and then interpolating (and I think the latter is preferred). CC'ing you because I think you might be using a kernel for ε that [interpolates and then squares](https://github.com/CliMA/LESbrary.jl/blob/cf31b0ec20219d5ad698af334811d448c27213b0/src/TurbulenceStatistics/viscous_dissipation.jl#L52-L64).


Just as a reference I'm plotting the different between both for a simulation of mine. I don't think the difference is negligible:

![Screenshot from 2021-04-09 09-54-42](https://user-images.githubusercontent.com/13205162/114223362-94d82e00-9924-11eb-8eae-dc7ab876c6dd.png)

(I'd expect the square->interpolate values to be generally smaller than the interpolate->square values, but I'm not 100% sure that should be the case)