### PR TITLE
Cleanup and mean components for TKE (+ basic tests)

### DIFF
--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -101,7 +101,7 @@ end
 function AnisotropicBuoyancyMixingRate(model, b, κx, κy, κz, N²₀; location = (Center, Center, Center), kwargs...)
     if location == (Center, Center, Center)
         return KernelComputedField(Center, Center, Center, anisotropic_buoyancy_mixing_rate_ccc!, model;
-                                   computed_dependencies=(b,), 
+                                   computed_dependencies=(b,),
                                    parameters=(κx=κx, κy=κy, κz=κz, N²₀=N²₀), kwargs...)
     else
         error("AnisotropicBuoyancyMixingRate only supports location = (Center, Center, Center) for now.")

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -1,23 +1,22 @@
 module FlowDiagnostics
 
-
 using Oceananigans.Operators
 using KernelAbstractions: @index, @kernel
 using Oceananigans.Grids: Center, Face
 using Oceananigans.Fields: KernelComputedField
 
+# Some useful operators
+@inline fψ²(i, j, k, grid, f, ψ) = @inbounds f(i, j, k, grid, ψ)^2
 
 @kernel function richardson_number_ccf!(Ri, grid, u, v, b, params)
     i, j, k = @index(Global, NTuple)
 
-    dBdz_tot = ∂zᵃᵃᶠ(i, j, k, grid, b) + params.N2_bg # dbdz(c, c, f)
+    dBdz_tot = ∂zᵃᵃᶠ(i, j, k, grid, b)        + params.N2_bg   # dbdz(c, c, f)
     dUdz_tot = ℑxᶜᵃᵃ(i, j, k, grid, ∂zᵃᵃᶠ, u) + params.dUdz_bg # dudz(f, c, f) → dudz(c, c, f)
     dVdz_tot = ℑyᵃᶜᵃ(i, j, k, grid, ∂zᵃᵃᶠ, v) + params.dVdz_bg # dvdz(c, f, f) → dvdz(c, c, f)
 
     @inbounds Ri[i, j, k] = dBdz_tot / (dUdz_tot^2 + dVdz_tot^2)
 end
-
-
 
 
 @kernel function rossby_number_ffc!(Ro, grid, u, v, params)
@@ -28,8 +27,6 @@ end
 
     @inbounds Ro[i, j, k] = (dVdx_tot - dUdy_tot) / params.f₀
 end
-
-
 
 
 @kernel function potential_vorticity_in_thermal_wind_fff!(PV, grid, u, v, b, f₀)
@@ -48,7 +45,6 @@ end
 
     @inbounds PV[i, j, k] = pv_barot[i, j, k] + pv_baroc[i, j, k]
 end
-
 
 
 @kernel function ertel_potential_vorticity_fff!(PV, grid, u, v, w, b, f₀)
@@ -73,33 +69,22 @@ end
 end
 
 
-
-
-
-@kernel function wp_ccc!(wp, grid, w, p)
-    i, j, k = @index(Global, NTuple)
-    @inbounds wp[i, j, k] = ℑzᵃᵃᶜ(i, j, k, grid, w) * p[i, j, k]
-end
-
-
-
 #+++++ Mixing of buoyancy
-@inline fψ²(i, j, k, grid, f, ψ) = @inbounds f(i, j, k, grid, ψ)^2
-
 @kernel function isotropic_buoyancy_mixing_rate_ccc!(mixing_rate, grid, b, κᵇ, N²₀)
     i, j, k = @index(Global, NTuple)
     dbdx² = ℑxᶜᵃᵃ(i, j, k, grid, fψ², ∂xᶠᵃᵃ, b) # C, C, C  → F, C, C  → C, C, C
     dbdy² = ℑyᵃᶜᵃ(i, j, k, grid, fψ², ∂yᵃᶠᵃ, b) # C, C, C  → C, F, C  → C, C, C
     dbdz² = ℑzᵃᵃᶜ(i, j, k, grid, fψ², ∂zᵃᵃᶠ, b) # C, C, C  → C, C, F  → C, C, C
 
-    @inbounds mixing_rate[i, j, k] = κᵇ[i,j,k]*(dbdx² + dbdy² + dbdz²)/N²₀
+    @inbounds mixing_rate[i, j, k] = κᵇ[i,j,k] * (dbdx² + dbdy² + dbdz²) / N²₀
 end
+
 function IsotropicBuoyancyMixingRate(model, b, κᵇ, N²₀; location = (Center, Center, Center), kwargs...)
     if location == (Center, Center, Center)
         return KernelComputedField(Center, Center, Center, isotropic_buoyancy_mixing_rate_ccc!, model;
                                    computed_dependencies=(b, κᵇ), parameters=N²₀, kwargs...)
     else
-        throw(Exception)
+        error("IsotropicBuoyancyMixingRate only supports location = (Center, Center, Center) for now.")
     end
 end
 
@@ -112,17 +97,16 @@ end
 
     @inbounds mixing_rate[i, j, k] = (params.κx*dbdx² + params.κy*dbdy² + params.κz*dbdz²)/params.N²₀
 end
+
 function AnisotropicBuoyancyMixingRate(model, b, κx, κy, κz, N²₀; location = (Center, Center, Center), kwargs...)
     if location == (Center, Center, Center)
         return KernelComputedField(Center, Center, Center, anisotropic_buoyancy_mixing_rate_ccc!, model;
                                    computed_dependencies=(b,), 
                                    parameters=(κx=κx, κy=κy, κz=κz, N²₀=N²₀), kwargs...)
     else
-        throw(Exception)
+        error("AnisotropicBuoyancyMixingRate only supports location = (Center, Center, Center) for now.")
     end
 end
 #-----
-
-
 
 end # module

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -1,7 +1,11 @@
 module Oceanostics
 
+export TurbulentKineticEnergy, KineticEnergy
+
 include("TurbulentKineticEnergyTerms.jl")
 include("FlowDiagnostics.jl")
 include("progress_messengers.jl")
+
+using .TurbulentKineticEnergyTerms
 
 end # module

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -1,6 +1,10 @@
 module Oceanostics
 
 export TurbulentKineticEnergy, KineticEnergy
+export IsotropicViscousDissipationRate, IsotropicPseudoViscousDissipationRate
+export AnisotropicViscousDissipationRate, AnisotropicPseudoViscousDissipationRate
+export PressureRedistribution_x, PressureRedistribution_y, PressureRedistribution_z
+export ShearProduction_x, ShearProduction_y, ShearProduction_z
 
 include("TurbulentKineticEnergyTerms.jl")
 include("FlowDiagnostics.jl")

--- a/src/TurbulentKineticEnergyTerms.jl
+++ b/src/TurbulentKineticEnergyTerms.jl
@@ -1,6 +1,10 @@
 module TurbulentKineticEnergyTerms
 
 export TurbulentKineticEnergy, KineticEnergy
+export IsotropicViscousDissipationRate, IsotropicPseudoViscousDissipationRate
+export AnisotropicViscousDissipationRate, AnisotropicPseudoViscousDissipationRate
+export PressureRedistribution_x, PressureRedistribution_y, PressureRedistribution_z
+export ShearProduction_x, ShearProduction_y, ShearProduction_z
 
 using Oceananigans.Operators
 using KernelAbstractions: @index, @kernel

--- a/src/TurbulentKineticEnergyTerms.jl
+++ b/src/TurbulentKineticEnergyTerms.jl
@@ -289,6 +289,9 @@ function ShearProduction_z(model, u, v, w, U, V, W; location = (Center, Center, 
         error("ShearProduction_z only supports location = (Center, Center, Center) for now.")
     end
 end
+
+ShearProduction_z(model; U=ZeroField(), V=ZeroField(), W=ZeroField(), kwargs...) =
+    ShearProduction_z(model, model.velocities..., U, V, W; kwargs...)
 #----
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,20 @@
 using Test
+using Oceananigans
 using Oceanostics
 
 @testset "Oceanostics" begin
-    # Write your tests here.
-end
+    topo = (Periodic, Periodic, Bounded)
+    grid = RegularRectilinearGrid(topology=topo, size=(4, 5, 6), extent=(1, 1, 1))
+    model = IncompressibleModel(grid=grid)
 
+    u, v, w = model.velocities
+
+    U = AveragedField(u, dims=(1, 2))
+    V = AveragedField(u, dims=(1, 2))
+
+    ke = KineticEnergy(model)
+    @test ke isa KernelComputedField
+
+    tke = TurbulentKineticEnergy(model, U=U, V=V)
+    @test tke isa KernelComputedField
+end


### PR DESCRIPTION
This PR does a bit of cleanup and adds support for mean components for `TurbulentKineticEnergy`, i.e. (u - U)^2. The `KineticEnergy` constructor preserves the old behavior.

It also adds some very basic tests.