### PR TITLE
Renamed TurbulentKineticEnergyTerms to TKEBudgetTerms

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
 authors = ["tomchor <tomaschor@gmail.com>"]
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"

--- a/sandbox/test_consructors.jl
+++ b/sandbox/test_consructors.jl
@@ -4,13 +4,12 @@ using Oceanostics
 grid = RegularRectilinearGrid(size=(4,4,4), extent=(1,1,1))
 model = IncompressibleModel(grid=grid)
 u, v, w = model.velocities
-ν = model.closure.ν
 
-ke = Oceanostics.TKEEquationTerms.KineticEnergy(model, u, v, w)
+ke = Oceanostics.KineticEnergy(model, u, v, w)
 
-SPx = Oceanostics.TKEEquationTerms.ShearProduction_x(model, u, v, w, 0, 0, 0)
-SPy = Oceanostics.TKEEquationTerms.ShearProduction_y(model, u, v, w, 0, 0, 0)
-SPz = Oceanostics.TKEEquationTerms.ShearProduction_z(model, u, v, w, 0, 0, 0)
+SPx = Oceanostics.XShearProduction(model, u, v, w, 0, 0, 0)
+SPy = Oceanostics.YShearProduction(model, u, v, w, 0, 0, 0)
+SPz = Oceanostics.ZShearProduction(model, u, v, w, 0, 0, 0)
 
-ε_iso = Oceanostics.TKEEquationTerms.IsotropicViscousDissipation(model, ν, u, v, w)
-ε_ani = Oceanostics.TKEEquationTerms.AnisotropicViscousDissipation(model, ν, ν, ν, u, v, w)
+#ε_iso = Oceanostics.IsotropicViscousDissipation(model, ν, u, v, w)
+#ε_ani = Oceanostics.AnisotropicViscousDissipation(model, ν, ν, ν, u, v, w)

--- a/sandbox/test_consructors.jl
+++ b/sandbox/test_consructors.jl
@@ -6,11 +6,11 @@ model = IncompressibleModel(grid=grid)
 u, v, w = model.velocities
 ν = model.closure.ν
 
-ke = Oceanostics.TurbulentKineticEnergyTerms.KineticEnergy(model, u, v, w)
+ke = Oceanostics.TKEEquationTerms.KineticEnergy(model, u, v, w)
 
-SPx = Oceanostics.TurbulentKineticEnergyTerms.ShearProduction_x(model, u, v, w, 0, 0, 0)
-SPy = Oceanostics.TurbulentKineticEnergyTerms.ShearProduction_y(model, u, v, w, 0, 0, 0)
-SPz = Oceanostics.TurbulentKineticEnergyTerms.ShearProduction_z(model, u, v, w, 0, 0, 0)
+SPx = Oceanostics.TKEEquationTerms.ShearProduction_x(model, u, v, w, 0, 0, 0)
+SPy = Oceanostics.TKEEquationTerms.ShearProduction_y(model, u, v, w, 0, 0, 0)
+SPz = Oceanostics.TKEEquationTerms.ShearProduction_z(model, u, v, w, 0, 0, 0)
 
-ε_iso = Oceanostics.TurbulentKineticEnergyTerms.IsotropicViscousDissipation(model, ν, u, v, w)
-ε_ani = Oceanostics.TurbulentKineticEnergyTerms.AnisotropicViscousDissipation(model, ν, ν, ν, u, v, w)
+ε_iso = Oceanostics.TKEEquationTerms.IsotropicViscousDissipation(model, ν, u, v, w)
+ε_ani = Oceanostics.TKEEquationTerms.AnisotropicViscousDissipation(model, ν, ν, ν, u, v, w)

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -6,10 +6,10 @@ export AnisotropicViscousDissipationRate, AnisotropicPseudoViscousDissipationRat
 export PressureRedistribution_x, PressureRedistribution_y, PressureRedistribution_z
 export ShearProduction_x, ShearProduction_y, ShearProduction_z
 
-include("TKEEquationTerms.jl")
+include("TKEBudgetTerms.jl")
 include("FlowDiagnostics.jl")
 include("progress_messengers.jl")
 
-using .TKEEquationTerms
+using .TKEBudgetTerms
 
 end # module

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -6,10 +6,10 @@ export AnisotropicViscousDissipationRate, AnisotropicPseudoViscousDissipationRat
 export PressureRedistribution_x, PressureRedistribution_y, PressureRedistribution_z
 export ShearProduction_x, ShearProduction_y, ShearProduction_z
 
-include("TurbulentKineticEnergyTerms.jl")
+include("TKEEquationTerms.jl")
 include("FlowDiagnostics.jl")
 include("progress_messengers.jl")
 
-using .TurbulentKineticEnergyTerms
+using .TKEEquationTerms
 
 end # module

--- a/src/TKEBudgetTerms.jl
+++ b/src/TKEBudgetTerms.jl
@@ -1,4 +1,4 @@
-module TKEEquationTerms
+module TKEBudgetTerms
 
 export TurbulentKineticEnergy, KineticEnergy
 export IsotropicViscousDissipationRate, IsotropicPseudoViscousDissipationRate

--- a/src/TKEEquationTerms.jl
+++ b/src/TKEEquationTerms.jl
@@ -1,4 +1,4 @@
-module TurbulentKineticEnergyTerms
+module TKEEquationTerms
 
 export TurbulentKineticEnergy, KineticEnergy
 export IsotropicViscousDissipationRate, IsotropicPseudoViscousDissipationRate


### PR DESCRIPTION
Renamed this module because to be more accurate. TKE (`(u^2+v^2+w^2)/2`) only has three terms. These are the terms for the TKE equation.

I just wanted to some feedback to see if this is better for other people.

CC @glwagner @ali-ramadhan 