### PR TITLE
Migrate quantities from KernelComputedFields to AbstractOperations

### DIFF
--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -26,47 +26,50 @@ function RichardsonNumber(model; N²_bg=0, dUdz_bg=0, dVdz_bg=0)
 end
 
 
-function RossbyNumber(model; dUdy_bg=0, dVdx_bg=0)
+function RossbyNumber(model; dUdy_bg=0, dVdx_bg=0, f=nothing)
     u, v, w = model.velocities
-    f₀ = model.coriolis.f
+    if f==nothing
+        f = model.coriolis.f
+    end
 
     dUdy_tot = ∂y(u) + dUdy_bg
     dVdx_tot = ∂x(v) + dVdx_bg
 
-    return (dVdx_tot - dUdy_tot) / f₀
+    return (dVdx_tot - dUdy_tot) / f
 end
 
 
 
 #++++ Potential vorticity
-function potential_vorticity_in_thermal_wind_fff(i, j, k, grid, u, v, b, f₀)
-    i, j, k = @index(Global, NTuple)
+function potential_vorticity_in_thermal_wind_fff(i, j, k, grid, u, v, b, f)
 
     dVdx =  ℑzᵃᵃᶠ(i, j, k, grid, ∂xᶠᵃᵃ, v) # F, F, C → F, F, F
     dUdy =  ℑzᵃᵃᶠ(i, j, k, grid, ∂yᵃᶠᵃ, u) # F, F, C → F, F, F
     dbdz = ℑxyᶠᶠᵃ(i, j, k, grid, ∂zᵃᵃᶠ, b) # C, C, F → F, F, F
 
-    pv_barot = (f₀ + dVdx - dUdy) * dbdz
+    pv_barot = (f + dVdx - dUdy) * dbdz
 
     dUdz = ℑyᵃᶠᵃ(i, j, k, grid, ∂zᵃᵃᶠ, u) # F, C, F → F, F, F
     dVdz = ℑxᶠᵃᵃ(i, j, k, grid, ∂zᵃᵃᶠ, v) # C, F, F → F, F, F
 
-    pv_baroc = -f₀*(dUdz^2 + dVdz^2)
+    pv_baroc = -f*(dUdz^2 + dVdz^2)
 
     return pv_barot + pv_baroc
 end
 
-function ThermalWindPotentialVorticityᶠᶠᶠ(model)
+function ThermalWindPotentialVorticityᶠᶠᶠ(model; f=nothing)
     u, v, w = model.velocities
     b = model.tracers.b
-    f₀ = model.coriolis.f
+    if f==nothing
+        f = model.coriolis.f
+    end
     return KernelFunctionOperation{Face, Face, Face}(potential_vorticity_in_thermal_wind_fff, model.grid;
-                                                     computed_dependencies=(u, v, w, b), parameters=f₀)
+                                                     computed_dependencies=(u, v, w, b), parameters=f)
 end
 
 
 
-function ertel_potential_vorticity_fff(i, j, k, grid, u, v, w, b, f₀)
+function ertel_potential_vorticity_fff(i, j, k, grid, u, v, w, b, f)
 
     dWdy =  ℑxᶠᵃᵃ(i, j, k, grid, ∂yᵃᶠᵃ, w) # C, C, F  → C, F, F  → F, F, F
     dVdz =  ℑxᶠᵃᵃ(i, j, k, grid, ∂zᵃᵃᶠ, v) # C, F, C  → C, F, F  → F, F, F
@@ -81,35 +84,37 @@ function ertel_potential_vorticity_fff(i, j, k, grid, u, v, w, b, f₀)
     dVdx =  ℑzᵃᵃᶠ(i, j, k, grid, ∂xᶠᵃᵃ, v) # C, F, C  → F, F, C → F, F, F
     dUdy =  ℑzᵃᵃᶠ(i, j, k, grid, ∂yᵃᶠᵃ, u) # F, C, C  → F, F, C → F, F, F
     dbdz = ℑxyᶠᶠᵃ(i, j, k, grid, ∂zᵃᵃᶠ, b) # C, C, C  → C, C, F → F, F, F
-    pv_z = (f₀ + dVdx - dUdy) * dbdz
+    pv_z = (f + dVdx - dUdy) * dbdz
 
     return pv_x + pv_y + pv_z
 end
 
-function ErtelPotentialVorticityᶠᶠᶠ(model)
+function ErtelPotentialVorticityᶠᶠᶠ(model; f=nothing)
     u, v, w = model.velocities
     b = model.tracers.b
-    f₀ = model.coriolis.f
+    if f==nothing
+        f = model.coriolis.f
+    end
     return KernelFunctionOperation{Face, Face, Face}(ertel_potential_vorticity_fff, model.grid;
-                                                     computed_dependencies=(u, v, w, b), parameters=f₀)
+                                                     computed_dependencies=(u, v, w, b), parameters=f)
 end
 #----
 
 
 
 #+++++ Mixing of buoyancy
-@kernel function isotropic_buoyancy_mixing_rate_ccc!(mixing_rate, grid, b, κᵇ, N²₀)
-    i, j, k = @index(Global, NTuple)
+function isotropic_buoyancy_mixing_rate_ccc(i, j, k, grid, b, κᵇ, N²₀)
+
     dbdx² = ℑxᶜᵃᵃ(i, j, k, grid, fψ², ∂xᶠᵃᵃ, b) # C, C, C  → F, C, C  → C, C, C
     dbdy² = ℑyᵃᶜᵃ(i, j, k, grid, fψ², ∂yᵃᶠᵃ, b) # C, C, C  → C, F, C  → C, C, C
     dbdz² = ℑzᵃᵃᶜ(i, j, k, grid, fψ², ∂zᵃᵃᶠ, b) # C, C, C  → C, C, F  → C, C, C
 
-    @inbounds mixing_rate[i, j, k] = κᵇ[i,j,k] * (dbdx² + dbdy² + dbdz²) / N²₀
+    return κᵇ[i,j,k] * (dbdx² + dbdy² + dbdz²) / N²₀
 end
 
 function IsotropicBuoyancyMixingRate(model, b, κᵇ, N²₀; location = (Center, Center, Center), kwargs...)
     if location == (Center, Center, Center)
-        return KernelComputedField(Center, Center, Center, isotropic_buoyancy_mixing_rate_ccc!, model;
+        return KernelFunctionOperation{Center, Center, Center}(isotropic_buoyancy_mixing_rate_ccc, model.grid;
                                    computed_dependencies=(b, κᵇ), parameters=N²₀, kwargs...)
     else
         error("IsotropicBuoyancyMixingRate only supports location = (Center, Center, Center) for now.")
@@ -117,18 +122,18 @@ function IsotropicBuoyancyMixingRate(model, b, κᵇ, N²₀; location = (Center
 end
 
 
-@kernel function anisotropic_buoyancy_mixing_rate_ccc!(mixing_rate, grid, b, params)
-    i, j, k = @index(Global, NTuple)
+function anisotropic_buoyancy_mixing_rate_ccc(mixing_rate, grid, b, params)
+
     dbdx² = ℑxᶜᵃᵃ(i, j, k, grid, fψ², ∂xᶠᵃᵃ, b) # C, C, C  → F, C, C  → C, C, C
     dbdy² = ℑyᵃᶜᵃ(i, j, k, grid, fψ², ∂yᵃᶠᵃ, b) # C, C, C  → C, F, C  → C, C, C
     dbdz² = ℑzᵃᵃᶜ(i, j, k, grid, fψ², ∂zᵃᵃᶠ, b) # C, C, C  → C, C, F  → C, C, C
 
-    @inbounds mixing_rate[i, j, k] = (params.κx*dbdx² + params.κy*dbdy² + params.κz*dbdz²)/params.N²₀
+    return (params.κx*dbdx² + params.κy*dbdy² + params.κz*dbdz²)/params.N²₀
 end
 
 function AnisotropicBuoyancyMixingRate(model, b, κx, κy, κz, N²₀; location = (Center, Center, Center), kwargs...)
     if location == (Center, Center, Center)
-        return KernelComputedField(Center, Center, Center, anisotropic_buoyancy_mixing_rate_ccc!, model;
+        return KernelFunctionOperation{Center, Center, Center}(anisotropic_buoyancy_mixing_rate_ccc, model.grid;
                                    computed_dependencies=(b,),
                                    parameters=(κx=κx, κy=κy, κz=κz, N²₀=N²₀), kwargs...)
     else

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -61,7 +61,7 @@ function ThermalWindPotentialVorticityᶠᶠᶠ(model)
     b = model.tracers.b
     f₀ = model.coriolis.f
     return KernelFunctionOperation{Face, Face, Face}(potential_vorticity_in_thermal_wind_fff, model.grid;
-                         computed_dependencies=(u, v, w, b), parameters=f₀)
+                                                     computed_dependencies=(u, v, w, b), parameters=f₀)
 end
 
 
@@ -91,7 +91,7 @@ function ErtelPotentialVorticityᶠᶠᶠ(model)
     b = model.tracers.b
     f₀ = model.coriolis.f
     return KernelFunctionOperation{Face, Face, Face}(ertel_potential_vorticity_fff, model.grid;
-                         computed_dependencies=(u, v, w, b), parameters=f₀)
+                                                     computed_dependencies=(u, v, w, b), parameters=f₀)
 end
 #----
 

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -1,6 +1,11 @@
 module FlowDiagnostics
 
+export RichardsonNumber, RossbyNumber
+export ErtelPotentialVorticityᶠᶠᶠ, ThermalWindPotentialVorticityᶠᶠᶠ
+
 using Oceananigans.Operators
+using Oceananigans.AbstractOperations
+using Oceananigans.AbstractOperations: KernelFunctionOperation
 using KernelAbstractions: @index, @kernel
 using Oceananigans.Grids: Center, Face
 using Oceananigans.Fields: KernelComputedField
@@ -8,28 +13,33 @@ using Oceananigans.Fields: KernelComputedField
 # Some useful operators
 @inline fψ²(i, j, k, grid, f, ψ) = @inbounds f(i, j, k, grid, ψ)^2
 
-@kernel function richardson_number_ccf!(Ri, grid, u, v, b, params)
-    i, j, k = @index(Global, NTuple)
 
-    dBdz_tot = ∂zᵃᵃᶠ(i, j, k, grid, b)        + params.N2_bg   # dbdz(c, c, f)
-    dUdz_tot = ℑxᶜᵃᵃ(i, j, k, grid, ∂zᵃᵃᶠ, u) + params.dUdz_bg # dudz(f, c, f) → dudz(c, c, f)
-    dVdz_tot = ℑyᵃᶜᵃ(i, j, k, grid, ∂zᵃᵃᶠ, v) + params.dVdz_bg # dvdz(c, f, f) → dvdz(c, c, f)
+function RichardsonNumber(model; N²_bg=0, dUdz_bg=0, dVdz_bg=0)
+    u, v, w = model.velocities
+    b = model.tracers.b
 
-    @inbounds Ri[i, j, k] = dBdz_tot / (dUdz_tot^2 + dVdz_tot^2)
+    dBdz_tot = ∂z(b) + N²_bg
+    dUdz_tot = ∂z(u) + dUdz_bg
+    dVdz_tot = ∂z(v) + dVdz_bg
+
+    return dBdz_tot / (dUdz_tot^2 + dVdz_tot^2)
 end
 
 
-@kernel function rossby_number_ffc!(Ro, grid, u, v, params)
-    i, j, k = @index(Global, NTuple)
+function RossbyNumber(model; dUdy_bg=0, dVdx_bg=0)
+    u, v, w = model.velocities
+    f₀ = model.coriolis.f
 
-    dUdy_tot = ∂yᵃᶠᵃ(i, j, k, grid, u) + params.dUdy_bg
-    dVdx_tot = ∂xᶠᵃᵃ(i, j, k, grid, v) + params.dVdx_bg
+    dUdy_tot = ∂y(u) + dUdy_bg
+    dVdx_tot = ∂x(v) + dVdx_bg
 
-    @inbounds Ro[i, j, k] = (dVdx_tot - dUdy_tot) / params.f₀
+    return (dVdx_tot - dUdy_tot) / f₀
 end
 
 
-@kernel function potential_vorticity_in_thermal_wind_fff!(PV, grid, u, v, b, f₀)
+
+#++++ Potential vorticity
+function potential_vorticity_in_thermal_wind_fff(i, j, k, grid, u, v, b, f₀)
     i, j, k = @index(Global, NTuple)
 
     dVdx =  ℑzᵃᵃᶠ(i, j, k, grid, ∂xᶠᵃᵃ, v) # F, F, C → F, F, F
@@ -43,12 +53,20 @@ end
 
     pv_baroc = -f₀*(dUdz^2 + dVdz^2)
 
-    @inbounds PV[i, j, k] = pv_barot[i, j, k] + pv_baroc[i, j, k]
+    return pv_barot + pv_baroc
+end
+
+function ThermalWindPotentialVorticityᶠᶠᶠ(model)
+    u, v, w = model.velocities
+    b = model.tracers.b
+    f₀ = model.coriolis.f
+    return KernelFunctionOperation{Face, Face, Face}(potential_vorticity_in_thermal_wind_fff, model.grid;
+                         computed_dependencies=(u, v, w, b), parameters=f₀)
 end
 
 
-@kernel function ertel_potential_vorticity_fff!(PV, grid, u, v, w, b, f₀)
-    i, j, k = @index(Global, NTuple)
+
+function ertel_potential_vorticity_fff(i, j, k, grid, u, v, w, b, f₀)
 
     dWdy =  ℑxᶠᵃᵃ(i, j, k, grid, ∂yᵃᶠᵃ, w) # C, C, F  → C, F, F  → F, F, F
     dVdz =  ℑxᶠᵃᵃ(i, j, k, grid, ∂zᵃᵃᶠ, v) # C, F, C  → C, F, F  → F, F, F
@@ -65,8 +83,18 @@ end
     dbdz = ℑxyᶠᶠᵃ(i, j, k, grid, ∂zᵃᵃᶠ, b) # C, C, C  → C, C, F → F, F, F
     pv_z = (f₀ + dVdx - dUdy) * dbdz
 
-    @inbounds PV[i, j, k] = pv_x + pv_y + pv_z
+    return pv_x + pv_y + pv_z
 end
+
+function ErtelPotentialVorticityᶠᶠᶠ(model)
+    u, v, w = model.velocities
+    b = model.tracers.b
+    f₀ = model.coriolis.f
+    return KernelFunctionOperation{Face, Face, Face}(ertel_potential_vorticity_fff, model.grid;
+                         computed_dependencies=(u, v, w, b), parameters=f₀)
+end
+#----
+
 
 
 #+++++ Mixing of buoyancy

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using Oceananigans
 using Oceanostics
+using Oceanostics.FlowDiagnostics
 
 @testset "Oceanostics" begin
     topo = (Periodic, Periodic, Bounded)
@@ -17,5 +18,19 @@ using Oceanostics
 
     tke = TurbulentKineticEnergy(model, U=U, V=V)
     @test tke isa KernelComputedField
+    
+    model = NonhydrostaticModel(grid=grid, coriolis=FPlane(1e-4), buoyancy=BuoyancyTracer(), tracers=:b)
+
+    Ro = RossbyNumber(model; dUdy_bg=1, dVdx_bg=1)
+    @test Ro isa Oceananigans.AbstractOperations.AbstractOperation
+
+    Ri = RichardsonNumber(model; N²_bg=1, dUdz_bg=1, dVdz_bg=1)
+    @test Ri isa Oceananigans.AbstractOperations.AbstractOperation
+
+    PVe = ErtelPotentialVorticityᶠᶠᶠ(model)
+    @test PVe isa Oceananigans.AbstractOperations.AbstractOperation
+
+    PVtw = ThermalWindPotentialVorticityᶠᶠᶠ(model)
+    @test PVtw isa Oceananigans.AbstractOperations.AbstractOperation
 end
 


### PR DESCRIPTION
The idea is that 

- Quantities that can be represented with `AbstractOperations` that can currently be compiled on GPUs should become simple `AbstractOperations`
- Quantities that are too complex to be represented with `AbstractOperations`  on GPUs (like TKE dissipation rate) become `KernelFunctionOperations`

Started this with `FlowDiagnostics`.

Closes https://github.com/tomchor/Oceanostics.jl/issues/21