### PR TITLE
Allow user to pass a buoyancy field to `RichardsonNumber`

### DIFF
--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -15,9 +15,8 @@ using Oceananigans.Grids: Center, Face
 @inline fψ²(i, j, k, grid, f, ψ) = @inbounds f(i, j, k, grid, ψ)^2
 
 
-function RichardsonNumber(model; N²_bg=0, dUdz_bg=0, dVdz_bg=0)
+function RichardsonNumber(model; b=model.tracers.b, N²_bg=0, dUdz_bg=0, dVdz_bg=0)
     u, v, w = model.velocities
-    b = model.tracers.b
 
     dBdz_tot = ∂z(b) + N²_bg
     dUdz_tot = ∂z(u) + dUdz_bg


### PR DESCRIPTION
Right now `RichardsonNumber` cannot be used for models with `SeawaterBuoyancy` as it assumes `model.tracers.b` exists.

This PR allows users to pass in a `b` so that `BuoyancyField(model)` can be passed in. In particular I'm trying to revive https://github.com/CliMA/LESbrary.jl/blob/master/examples/three_layer_constant_fluxes.jl

Hoping to tag v0.6.2 once this is merged if that's okay.