### PR TITLE
Updates Oceanostics to Oceananigans 0.68

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
 authors = ["tomchor <tomaschor@gmail.com>"]
-version = "0.6.2"
+version = "0.7.0"
 
 [deps]
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
@@ -9,5 +9,5 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Oceananigans = "^0.64, 0.65, 0.66, 0.67"
+Oceananigans = "^0.68"
 julia = "^1.6"

--- a/src/TKEBudgetTerms.jl
+++ b/src/TKEBudgetTerms.jl
@@ -11,7 +11,7 @@ using Oceananigans.Operators
 using Oceananigans.AbstractOperations
 using Oceananigans.AbstractOperations: KernelFunctionOperation
 using Oceananigans.Grids: Center, Face
-using Oceananigans.Fields: KernelComputedField, ZeroField
+using Oceananigans.Fields: ZeroField
 
 # Some useful operators
 @inline ψ²(i, j, k, grid, ψ) = @inbounds ψ[i, j, k]^2
@@ -22,8 +22,6 @@ using Oceananigans.Fields: KernelComputedField, ZeroField
 @inline fψ²(i, j, k, grid, f, ψ) = @inbounds f(i, j, k, grid, ψ)^2
 
 @inline fψ_plus_gφ²(i, j, k, grid, f, ψ, g, φ) = @inbounds (f(i, j, k, grid, ψ) + g(i, j, k, grid, φ))^2
-
-
 
 #++++ Turbulent kinetic energy
 @inline function turbulent_kinetic_energy_ccc(i, j, k, grid, u, v, w, U, V, W)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ end
 include("test_progress_messengers.jl")
 
 function computed_operation(op)
-    op_cf = ComputedField(op)
+    op_cf = Field(op)
     compute!(op_cf)
     return op_cf
 end
@@ -42,14 +42,14 @@ end
 
 function test_vel_only_diagnostics(model)
     u, v, w = model.velocities
-    U = AveragedField(u, dims=(1, 2))
-    V = AveragedField(v, dims=(1, 2))
-    W = AveragedField(w, dims=(1, 2))
+    U = Field(Average(u, dims=(1, 2)))
+    V = Field(Average(v, dims=(1, 2)))
+    W = Field(Average(w, dims=(1, 2)))
 
 
     @test begin
         tke_op = KineticEnergy(model)
-        ke_c = ComputedField(tke_op)
+        ke_c = Field(tke_op)
         compute!(ke_c)
         tke_op isa AbstractOperation
     end
@@ -57,28 +57,28 @@ function test_vel_only_diagnostics(model)
 
     @test begin
         op = TurbulentKineticEnergy(model, U=U, V=V, W=W)
-        tke_c = ComputedField(op)
+        tke_c = Field(op)
         compute!(tke_c)
         op isa AbstractOperation
     end
 
     @test begin
         op = XShearProduction(model, u, v, w, U, V, W)
-        XSP = ComputedField(op)
+        XSP = Field(op)
         compute!(XSP)
         op isa AbstractOperation
     end
 
     @test begin
         op = YShearProduction(model, u, v, w, U, V, W)
-        YSP = ComputedField(op)
+        YSP = Field(op)
         compute!(YSP)
         op isa AbstractOperation
     end
 
     @test begin
         op = ZShearProduction(model, u, v, w, U, V, W)
-        ZSP = ComputedField(op)
+        ZSP = Field(op)
         compute!(ZSP)
         op isa AbstractOperation
     end
@@ -86,14 +86,14 @@ function test_vel_only_diagnostics(model)
 
     @test begin
         op = RossbyNumber(model;)
-        Ro = ComputedField(op)
+        Ro = Field(op)
         compute!(Ro)
         op isa AbstractOperation
     end
 
     @test begin
         op = RossbyNumber(model; dUdy_bg=1, dVdx_bg=1, f=1e-4)
-        Ro = ComputedField(op)
+        Ro = Field(op)
         compute!(Ro)
         op isa AbstractOperation
     end


### PR DESCRIPTION
This PR updates Oceanostics tests to Oceananigans 0.68, which has new syntax for computed and averaged fields.