### PR TITLE
Introduces `RossbyNumber` for a general coordinate system and fixes a bug in `ErtelPotentialVorticity`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
 authors = ["tomchor <tomaschor@gmail.com>"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -112,7 +112,8 @@ function ErtelPotentialVorticity(model; location = (Face, Face, Face))
 
     coriolis = model.coriolis
     if coriolis isa FPlane
-        fx = fy = fz = model.coriolis.f
+        fx = fy = 0
+        fz = model.coriolis.f
     elseif coriolis isa ConstantCartesianCoriolis
         fx = coriolis.fx
         fy = coriolis.fy
@@ -125,7 +126,6 @@ function ErtelPotentialVorticity(model; location = (Face, Face, Face))
                                                      computed_dependencies=(u, v, w, b), parameters=(; fx, fy, fz))
 end
 #----
-
 
 #+++++ Tracer variance dissipation
 @inline function isotropic_tracer_variance_dissipation_rate_ccc(i, j, k, grid, c, velocities, p)

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -98,7 +98,7 @@ function RossbyNumber(model; location = (Face, Face, Face),
 
     parameters = (; fx, fy, fz, dWdy_bg, dVdz_bg, dUdz_bg, dWdx_bg, dUdy_bg, dVdx_bg)
     return KernelFunctionOperation{Face, Face, Face}(rossby_number_fff, model.grid;
-                                                     computed_dependencies=(u, v, w), parameters=(; fx, fy, fz))
+                                                     computed_dependencies=(u, v, w), parameters=parameters)
 end
 #---
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,7 +67,7 @@ function test_vel_only_diagnostics(model)
     end
 
     @test begin
-        op = RossbyNumber(model; dUdy_bg=1, dVdx_bg=1, f=1e-4)
+        op = RossbyNumber(model; dUdy_bg=1, dVdx_bg=1)
         Ro = Field(op)
         compute!(Ro)
         op isa AbstractOperation


### PR DESCRIPTION
This PR expands `RossbyNumber` to work with a general coordinate system, which is useful for dealing with rotated domains such as [this one](https://clima.github.io/OceananigansDocumentation/stable/generated/tilted_bottom_boundary_layer/).

It also fixes a bug in `ErtelPotentialVorticity` when using `FPlane`: https://github.com/tomchor/Oceanostics.jl/blob/87b29733b0ad25409ec3f5ec3a6b699b9bc38bb8/src/FlowDiagnostics.jl#L114-L115