### PR TITLE
Adds DirectionalErtelPotentialVorticity

### DIFF
--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -1,7 +1,7 @@
 module FlowDiagnostics
 
 export RichardsonNumber, RossbyNumber
-export ErtelPotentialVorticity, ThermalWindPotentialVorticity
+export ErtelPotentialVorticity, ThermalWindPotentialVorticity, DirectionalErtelPotentialVorticity
 export IsotropicBuoyancyMixingRate, AnisotropicBuoyancyMixingRate
 export IsotropicTracerVarianceDissipationRate, AnisotropicTracerVarianceDissipationRate
 

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -212,6 +212,10 @@ end
     return (params.f_dir + ω_dir) * dbddir
 end
 
+
+"""
+Calculates the contribution from a given `direction` to the Ertel Potential Vorticty
+"""
 function DirectionalErtelPotentialVorticity(model, direction; location = (Face, Face, Face))
     validate_location(location, "DirectionalErtelPotentialVorticity", (Face, Face, Face))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,7 +102,7 @@ function test_buoyancy_diagnostics(model)
     @test PVtw isa AbstractOperation
     @test compute!(Field(PVtw)) isa Field
 
-    DEPV = DirectionalErtelPotentialVorticity(model, direction=(0, 0, 1))
+    DEPV = DirectionalErtelPotentialVorticity(model, (0, 0, 1))
     @test DEPV isa AbstractOperation
     @test compute!(Field(DEPV)) isa Field
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,6 +102,10 @@ function test_buoyancy_diagnostics(model)
     @test PVtw isa AbstractOperation
     @test compute!(Field(PVtw)) isa Field
 
+    DEPV = DirectionalErtelPotentialVorticity(model, direction=(0, 0, 1))
+    @test DEPV isa AbstractOperation
+    @test compute!(Field(DEPV)) isa Field
+
     return nothing
 end
 


### PR DESCRIPTION
This PR adds `DirectionalErtelPotentialVorticity`, which computes the contribution to the Ertel PV from a specific direction. This is useful for rotated domains, especially when studying symmetric instabilities, and it's not trivial to implement since it needs several sines and cosines that don't compile on a GPU using abstract operations.

I don't love the name `DirectionalErtelPotentialVorticity` but I couldn't find a better one. So I'm open to name suggestions here.