### PR TITLE
Run CI only on commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   - push
-  - pull_request
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}


### PR DESCRIPTION
This PR removes the directive to run CI on PRs. 
I'm doing this because the same CI is run twice every time I commit (since a PR is always associated with a commit). Now it only runs once per commit.