### PR TITLE
Make `IsotropicTracerVarianceDissipationRate` more general

### DIFF
--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -392,6 +392,17 @@ for `tracer_name` in `model.tracers`. The isotropic variance dissipation rate is
 where c is the tracer concentration, κ is the tracer diffusivity and ∇ is the gradient operator.
 
 Here `tracer_name` is needed even when passing `tracer` in order to get the appropriate Prandtl number.
+When passing `tracer`, this function should be used as
+
+```julia
+grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
+model = NonhydrostaticModel(grid=grid, tracers=:b, closure=SmagorinskyLilly())
+
+b̄ = Field(Average(model.tracers.b, dims=(1,2)))
+b′ = model.tracers.b - b̄
+
+χb = IsotropicTracerVarianceDissipationRate(model, :b, tracer=b′)
+```
 """
 function IsotropicTracerVarianceDissipationRate(model, tracer_name; tracer = nothing, location = (Center, Center, Center))
     validate_dissipative_closure(model.closure)

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -5,7 +5,7 @@ export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity, DirectionalErtelPotentialVorticity
 export IsotropicTracerVarianceDissipationRate
 
-using ..TKEBudgetTerms: validate_location
+using Oceanostics: validate_location, validate_dissipative_closure
 
 using Oceananigans
 using Oceananigans.Operators
@@ -166,7 +166,7 @@ function RossbyNumber(model; location = (Face, Face, Face),
 end
 #---
 
-#++++ Potential vorticity
+#+++ Potential vorticity
 @inline function potential_vorticity_in_thermal_wind_fff(i, j, k, grid, u, v, b, p)
 
     dVdx =  ℑzᵃᵃᶠ(i, j, k, grid, ∂xᶠᶠᶜ, v) # F, F, C → F, F, F
@@ -348,9 +348,9 @@ function DirectionalErtelPotentialVorticity(model, direction; location = (Face, 
     return KernelFunctionOperation{Face, Face, Face}(directional_ertel_potential_vorticity_fff, model.grid;
                                                      computed_dependencies=(u, v, w, b), parameters=(; f_dir, dir_x, dir_y, dir_z))
 end
-#----
+#---
 
-#+++++ Tracer variance dissipation
+#+++ Tracer variance dissipation
 using Oceanostics: _calc_nonlinear_κᶜᶜᶜ
 import Oceananigans.TurbulenceClosures: calc_nonlinear_κᶜᶜᶜ
 using Oceananigans.TurbulenceClosures: calc_nonlinear_νᶜᶜᶜ
@@ -390,18 +390,23 @@ for `tracer_name` in `model.tracers`. The isotropic variance dissipation rate is
     2κ (∇c ⋅ ∇c)
 
 where c is the tracer concentration, κ is the tracer diffusivity and ∇ is the gradient operator.
+
+Here `tracer_name` is needed even when passing `tracer` in order to get the appropriate Prandtl number.
 """
-function IsotropicTracerVarianceDissipationRate(model, tracer_name; location = (Center, Center, Center))
+function IsotropicTracerVarianceDissipationRate(model, tracer_name; tracer = nothing, location = (Center, Center, Center))
+    validate_dissipative_closure(model.closure)
     tracer_index = findfirst(n -> n === tracer_name, propertynames(model.tracers))
 
     parameters = (; model.closure,
                   model.buoyancy,
                   id = Val(tracer_index))
 
+    tracer = tracer == nothing ? model.tracers[tracer_name] : tracer
+
     return KernelFunctionOperation{Center, Center, Center}(isotropic_tracer_variance_dissipation_rate_ccc, model.grid;
-                                                           computed_dependencies=(model.tracers[tracer_name], model.velocities, model.tracers),
+                                                           computed_dependencies=(tracer, model.velocities, model.tracers),
                                                            parameters=parameters)
 end
-#-----
+#---
 
 end # module

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -18,6 +18,8 @@ export IsotropicTracerVarianceDissipationRate
 #+++ Utils for validation
 # Right now, all kernels must be located at ccc
 using Oceananigans.TurbulenceClosures: AbstractScalarDiffusivity, ThreeDimensionalFormulation
+using Oceananigans.Grids: Center, Face
+
 validate_location(location, type, valid_location=(Center, Center, Center)) =
     location != valid_location &&
         error("$type only supports location = $valid_location for now.")

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -4,7 +4,6 @@ using DocStringExtensions
 #++++ TKEBudgetTerms exports
 export TurbulentKineticEnergy, KineticEnergy
 export IsotropicViscousDissipationRate, IsotropicPseudoViscousDissipationRate
-export AnisotropicPseudoViscousDissipationRate
 export XPressureRedistribution, YPressureRedistribution, ZPressureRedistribution
 export XShearProductionRate, YShearProductionRate, ZShearProductionRate
 #----
@@ -12,15 +11,26 @@ export XShearProductionRate, YShearProductionRate, ZShearProductionRate
 #++++ FlowDiagnostics exports
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity
-export IsotropicBuoyancyMixingRate, AnisotropicBuoyancyMixingRate
-export IsotropicTracerVarianceDissipationRate, AnisotropicTracerVarianceDissipationRate
+export IsotropicBuoyancyMixingRate
+export IsotropicTracerVarianceDissipationRate
 #----
 
-using Oceananigans.TurbulenceClosures: νᶜᶜᶜ, calc_nonlinear_κᶜᶜᶜ
+#+++ Utils for validation
+# Right now, all kernels must be located at ccc
+using Oceananigans.TurbulenceClosures: AbstractScalarDiffusivity, ThreeDimensionalFormulation
+validate_location(location, type, valid_location=(Center, Center, Center)) =
+    location != valid_location &&
+        error("$type only supports location = $valid_location for now.")
+
+validate_dissipative_closure(closure) = error("Cannot calculate dissipation rate for $closure")
+validate_dissipative_closure(::AbstractScalarDiffusivity{<:Any, ThreeDimensionalFormulation}) = nothing
+validate_dissipative_closure(closure_tuple::Tuple) = Tuple(validate_dissipative_closure(c) for c in closure_tuple)
+#---
 
 #####
 ##### A few utils for closure tuples:
 #####
+using Oceananigans.TurbulenceClosures: νᶜᶜᶜ, calc_nonlinear_κᶜᶜᶜ
 
 # Fallbacks that capture "single closure" case
 @inline _νᶜᶜᶜ(args...) = νᶜᶜᶜ(args...)

--- a/src/TKEBudgetTerms.jl
+++ b/src/TKEBudgetTerms.jl
@@ -14,6 +14,7 @@ using Oceananigans.Grids: Center, Face
 using Oceananigans.Fields: ZeroField
 
 using Oceanostics: _νᶜᶜᶜ
+using Oceanostics: validate_location, validate_dissipative_closure
 
 # Some useful operators
 @inline ψ²(i, j, k, grid, ψ) = @inbounds ψ[i, j, k]^2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,6 +156,13 @@ function test_tracer_diagnostics(model)
     @test χ_iso isa AbstractOperation
     @test χ_iso_field isa Field
 
+    b̄ = Field(Average(model.tracers.b, dims=(1,2)))
+    b′ = model.tracers.b - b̄
+    χ_iso = IsotropicTracerVarianceDissipationRate(model, :b, tracer=b′)
+    χ_iso_field = compute!(Field(χ_iso))
+    @test χ_iso isa AbstractOperation
+    @test χ_iso_field isa Field
+
     return nothing
 end
 


### PR DESCRIPTION
This PR generalizes `IsotropicTracerVarianceDissipationRate` so that we can also calculate dissipation rates for the fluctuation around a mean among other things. In addition to being able to use it like this, where the disspation rate is calculated using the full buoyancy field:

```julia
IsotropicTracerVarianceDissipationRate(model, :b)
```

we also do this:

```julia
b̄ = Field(Average(b, dims=(1,2)))
b′ = b - b̄
IsotropicTracerVarianceDissipationRate(model, :b, tracer=b′)
```

In addition to this change, this PR also reorganizes a few utility functions and introduces a safety check in `IsotropicTracerVarianceDissipationRate`.