### PR TITLE
Fixes `TracerVarianceDissipationRate` on GPUs

### DIFF
--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -351,10 +351,7 @@ end
 
 #+++ Tracer variance dissipation
 for diff_flux in (:diffusive_flux_x, :diffusive_flux_y, :diffusive_flux_z)
-    # Unroll the loop over a tuple. This is necessary because no arrays can be dynamically
-    # allocated inside a GPU Kernel, so something like
-    # `sum(diff_flux(ijk, closure) for closure in closure_tuple)`
-    # doesn't work, since it allocates a dynamically-sized Array.
+    # Unroll the loop over a tuple
     @eval @inline $diff_flux(i, j, k, grid, closure_tuple::Tuple, diffusivity_fields, args...) = 
         $diff_flux(i, j, k, grid, closure_tuple[1], diffusivity_fields[1], args...) + 
         $diff_flux(i, j, k, grid, closure_tuple[2:end], diffusivity_fields[2:end], args...)

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -351,9 +351,8 @@ end
 
 #+++ Tracer variance dissipation
 for diff_flux in (:diffusive_flux_x, :diffusive_flux_y, :diffusive_flux_z)
-    # "Inner-outer" form makes the compiler "unroll" the loop over a tuple. This is
-    # necessary because no arrays can be dynamically allocated inside a GPU Kernel, so
-    # something like
+    # Unroll the loop over a tuple. This is necessary because no arrays can be dynamically
+    # allocated inside a GPU Kernel, so something like
     # `sum(diff_flux(ijk, closure) for closure in closure_tuple)`
     # doesn't work, since it allocates a dynamically-sized Array.
     @eval @inline $diff_flux(i, j, k, grid, closure_tuple::Tuple, diffusivity_fields, args...) = 

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -42,8 +42,7 @@ using Oceananigans.TurbulenceClosures: νᶜᶜᶜ, calc_nonlinear_κᶜᶜᶜ
 @inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple{}, K::Tuple{}, clock) = zero(eltype(grid))
 @inline _calc_nonlinear_κᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple{}, args...) = zero(eltype(grid))
 
-# Unroll the loop over a tuple. This is necessary because no arrays can be dynamically
-# allocated inside a GPU Kernel, so something like
+# Unroll the loop over a tuple
 @inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple, K::Tuple, clock) =
      νᶜᶜᶜ(i, j, k, grid, closure_tuple[1],     K[1],     clock) + 
     _νᶜᶜᶜ(i, j, k, grid, closure_tuple[2:end], K[2:end], clock)

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -39,8 +39,8 @@ using Oceananigans.TurbulenceClosures: νᶜᶜᶜ, calc_nonlinear_κᶜᶜᶜ
 @inline _calc_nonlinear_κᶜᶜᶜ(args...) = calc_nonlinear_κᶜᶜᶜ(args...)
 
 # End point
-@inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple{}, K::Tuple{}, clock) = zero(eltype(grid))
-@inline _calc_nonlinear_κᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple{}, args...) = zero(eltype(grid))
+@inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple{}, K::Tuple{}, clock) = zero(grid)
+@inline _calc_nonlinear_κᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple{}, args...) = zero(grid)
 
 # Unroll the loop over a tuple
 @inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple, K::Tuple, clock) =

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -42,7 +42,7 @@ using Oceananigans.TurbulenceClosures: νᶜᶜᶜ, calc_nonlinear_κᶜᶜᶜ
 @inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple{}, K::Tuple{}, clock) = zero(eltype(grid))
 @inline _calc_nonlinear_κᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple{}, args...) = zero(eltype(grid))
 
-# "Inner-outer" form (hopefully) makes the compiler "unroll" the loop over a tuple:
+# "Inner-outer" form makes the compiler "unroll" the loop over a tuple:
 @inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple, K::Tuple, clock) =
      νᶜᶜᶜ(i, j, k, grid, closure_tuple[1],     K[1],     clock) + 
     _νᶜᶜᶜ(i, j, k, grid, closure_tuple[2:end], K[2:end], clock)

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -42,7 +42,8 @@ using Oceananigans.TurbulenceClosures: νᶜᶜᶜ, calc_nonlinear_κᶜᶜᶜ
 @inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple{}, K::Tuple{}, clock) = zero(eltype(grid))
 @inline _calc_nonlinear_κᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple{}, args...) = zero(eltype(grid))
 
-# "Inner-outer" form makes the compiler "unroll" the loop over a tuple:
+# Unroll the loop over a tuple. This is necessary because no arrays can be dynamically
+# allocated inside a GPU Kernel, so something like
 @inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple, K::Tuple, clock) =
      νᶜᶜᶜ(i, j, k, grid, closure_tuple[1],     K[1],     clock) + 
     _νᶜᶜᶜ(i, j, k, grid, closure_tuple[2:end], K[2:end], clock)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,8 @@ using Oceanostics.TKEBudgetTerms: turbulent_kinetic_energy_ccc
 using Oceanostics.FlowDiagnostics
 using Oceanostics: SimpleProgressMessenger, SingleLineProgressMessenger, make_message
 
+include("test_budgets.jl")
+
 # Default grid for all tests
 grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
 
@@ -252,8 +254,13 @@ scalar_diff = ScalarDiffusivity(ν=1e-6, κ=1e-7)
         test_progress_messenger(model, TimedProgressMessenger(; LES=LES))
     end
 
-    rtol = 0.005
-    @info "Testing tracer variance budget with a tolerance of $(100*rtol)%"
-    include("test_budgets.jl")
-    test_tracer_variance_budget(N=4, κ=2, rtol=rtol)
+
+    closures = [ScalarDiffusivity(ν=1, κ=1),
+                (HorizontalScalarDiffusivity(κ=2), VerticalScalarDiffusivity(κ=1/2)),
+                (ScalarDiffusivity(ν=1, κ=1), SmagorinskyLilly()),
+                ]
+    for closure in closures
+        @info "Testing tracer variance budget with closure $closure"
+        test_tracer_variance_budget(N=4, κ=2, rtol=0.005, closure=closure)
+    end
 end

--- a/test/test_budgets.jl
+++ b/test/test_budgets.jl
@@ -1,8 +1,7 @@
 using Oceananigans.TurbulenceClosures: HorizontalFormulation, VerticalFormulation
 using Oceananigans.Fields: @compute
 
-function test_tracer_variance_budget(; N=4, κ=2, rtol=0.01)
-    closure = ScalarDiffusivity(HorizontalFormulation(), κ=κ)
+function test_tracer_variance_budget(; N=4, κ=1, rtol=0.01, closure = ScalarDiffusivity(HorizontalFormulation(), κ=κ))
 
     grid = RectilinearGrid(topology=(Periodic, Periodic, Periodic),
                            size=(N,N,N), extent=(1,1,1))


### PR DESCRIPTION
Closes https://github.com/tomchor/Oceanostics.jl/issues/111

This PR also adds tracer variance budget testing for different closures.