### PR TITLE
Improve calculation of budgets in `test_budgets.jl`

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.8.3"
 manifest_format = "2.0"
-project_hash = "affa3e6bad394eedc6ee6613a6fe61f171ebdbc9"
+project_hash = "f5a2de967a260bf554301b56dfcb02ad06ee5743"
 
 [[deps.AMGX]]
 deps = ["AMGX_jll", "CEnum", "CUDA", "JSON", "Libdl", "SparseArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
 authors = ["tomchor <tomaschor@gmail.com>"]
-version = "0.10.2"
+version = "0.10.3"
 
 [deps]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -16,7 +15,9 @@ julia = "^1.6"
 
 [extras]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "CUDA"]
+test = ["Test", "CUDA", "Random", "Statistics"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,6 +263,6 @@ scalar_diff = ScalarDiffusivity(ν=1e-6, κ=1e-7)
                 ]
     for closure in closures
         @info "Testing tracer variance budget with closure $closure"
-        test_tracer_variance_budget(N=4, κ=2, rtol=0.005, closure=closure)
+        test_tracer_variance_budget(N=32, rtol=0.005, closure=closure)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,6 +263,6 @@ scalar_diff = ScalarDiffusivity(ν=1e-6, κ=1e-7)
                 ]
     for closure in closures
         @info "Testing tracer variance budget with closure $closure"
-        test_tracer_variance_budget(N=64, rtol=0.005, closure=closure)
+        test_tracer_variance_budget(N=64, rtol=0.01, closure=closure)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,6 +263,6 @@ scalar_diff = ScalarDiffusivity(ν=1e-6, κ=1e-7)
                 ]
     for closure in closures
         @info "Testing tracer variance budget with closure $closure"
-        test_tracer_variance_budget(N=32, rtol=0.005, closure=closure)
+        test_tracer_variance_budget(N=64, rtol=0.005, closure=closure)
     end
 end

--- a/test/test_budgets.jl
+++ b/test/test_budgets.jl
@@ -1,7 +1,11 @@
 using Oceananigans.TurbulenceClosures: HorizontalFormulation, VerticalFormulation
 using Oceananigans.Fields: @compute
+using Oceananigans.Grids: min_Δx
 using Random
 using Statistics
+
+import Oceananigans.Fields: Field
+Field(a::Number) = a
 
 function periodic_locations(N_locations, flip_z=true)
     Random.seed!(772)
@@ -15,11 +19,10 @@ function periodic_locations(N_locations, flip_z=true)
     return x₀, y₀, z₀
 end
 
-function test_tracer_variance_budget(; N=4, κ=1, rtol=0.01, closure = ScalarDiffusivity(HorizontalFormulation(), κ=κ))
+function test_tracer_variance_budget(; N=8, rtol=0.01, closure = ScalarDiffusivity(κ=κ))
 
     grid = RectilinearGrid(topology=(Periodic, Periodic, Periodic), size=(N,N,N), extent=(1,1,1))
-    model = NonhydrostaticModel(grid=grid, tracers=:c, closure=closure,
-                                auxiliary_fields=(; ∫∫χdVdt=0.0, ∫χdV_prev=0.0))
+    model = NonhydrostaticModel(grid=grid, tracers=:c, closure=closure)
 
     # A kind of convoluted way to create x-periodic, resolved initial noise
     σx = 4grid.Δxᶜᵃᵃ # x length scale of the noise
@@ -35,20 +38,25 @@ function test_tracer_variance_budget(; N=4, κ=1, rtol=0.01, closure = ScalarDif
     c = model.tracers.c
     c.data.parent .-= mean(c)
 
-    simulation = Simulation(model; Δt=grid.Δxᶜᵃᵃ^2/κ/20, stop_time=0.1)
+    κ = diffusivity(model.closure, model.diffusivity_fields, Val(:c))
+    @compute κ = κ isa Tuple ? Field(sum(κ)) : κ
+    Δt = min_Δx(grid)^2/maximum(κ)/20
+    simulation = Simulation(model; Δt=Δt, stop_time=0.1)
 
     χ  = Oceanostics.FlowDiagnostics.TracerVarianceDissipationRate(model, :c)
 
+    ∫∫χdVdt = Ref(0.0)
+    ∫χdV_prev = Ref(0.0)
     @compute ∫χdV   = Field(Integral(χ))
     @compute ∫c²dV  = Field(Integral(c^2))
 
     ∫c²dV_t⁰ = parent(∫c²dV)[1,1,1]
     function accumulate_χ(sim)
-        increment = sim.Δt * model.auxiliary_fields.∫χdV_prev
-        model.auxiliary_fields = (; model.auxiliary_fields..., ∫∫χdVdt = model.auxiliary_fields.∫∫χdVdt + increment)
+        increment = sim.Δt * ∫χdV_prev[]
+        ∫∫χdVdt[] += increment
 
         compute!(∫χdV)
-        model.auxiliary_fields = (; model.auxiliary_fields..., ∫χdV_prev = parent(∫χdV)[1,1,1])
+        ∫χdV_prev[] = parent(∫χdV)[1,1,1]
         return nothing
     end
     simulation.callbacks[:integrate_χ] = Callback(accumulate_χ)
@@ -57,7 +65,7 @@ function test_tracer_variance_budget(; N=4, κ=1, rtol=0.01, closure = ScalarDif
 
     compute!(∫c²dV)
     ∫c²dV_tᶠ = parent(∫c²dV)[1,1,1]
-    ∫∫χdVdt_tᶠ = ∫c²dV_t⁰- model.auxiliary_fields.∫∫χdVdt
+    ∫∫χdVdt_tᶠ = ∫c²dV_t⁰- ∫∫χdVdt[]
     abs_error = (abs(∫∫χdVdt_tᶠ - ∫c²dV_tᶠ)/∫c²dV_t⁰)
 
     @info "Error in c² decrease is $abs_error"

--- a/test/test_budgets.jl
+++ b/test/test_budgets.jl
@@ -19,9 +19,9 @@ function periodic_locations(N_locations, flip_z=true)
     return x₀, y₀, z₀
 end
 
-function test_tracer_variance_budget(; N=8, rtol=0.01, closure = ScalarDiffusivity(κ=κ))
+function test_tracer_variance_budget(; N=16, rtol=0.01, closure = ScalarDiffusivity(κ=κ))
 
-    grid = RectilinearGrid(topology=(Periodic, Periodic, Periodic), size=(N,N,N), extent=(1,1,1))
+    grid = RectilinearGrid(topology=(Periodic, Flat, Periodic), size=(N,N), extent=(1,1))
     model = NonhydrostaticModel(grid=grid, tracers=:c, closure=closure)
 
     # A kind of convoluted way to create x-periodic, resolved initial noise

--- a/test/test_budgets.jl
+++ b/test/test_budgets.jl
@@ -1,11 +1,25 @@
 using Oceananigans.TurbulenceClosures: HorizontalFormulation, VerticalFormulation
 using Oceananigans.Fields: @compute
+using Random
+using Statistics
+
+function periodic_locations(N_locations, flip_z=true)
+    Random.seed!(772)
+    reflections = [-2;;-1;;0;;1;;2]
+
+    x₀ = rand(N_locations) .+ reflections
+    y₀ = rand(N_locations) .+ reflections
+    z₀ = rand(N_locations) .+ reflections
+
+    flip_z && (z₀ = -z₀)
+    return x₀, y₀, z₀
+end
 
 function test_tracer_variance_budget(; N=4, κ=1, rtol=0.01, closure = ScalarDiffusivity(HorizontalFormulation(), κ=κ))
 
-    grid = RectilinearGrid(topology=(Periodic, Periodic, Periodic),
-                           size=(N,N,N), extent=(1,1,1))
-    model = NonhydrostaticModel(grid=grid, tracers=:c, closure=closure, auxiliary_fields=(; ∫∫χdVdt=0.0))
+    grid = RectilinearGrid(topology=(Periodic, Periodic, Periodic), size=(N,N,N), extent=(1,1,1))
+    model = NonhydrostaticModel(grid=grid, tracers=:c, closure=closure,
+                                auxiliary_fields=(; ∫∫χdVdt=0.0, ∫χdV_prev=0.0))
 
     # A kind of convoluted way to create x-periodic, resolved initial noise
     σx = 4grid.Δxᶜᵃᵃ # x length scale of the noise
@@ -13,18 +27,16 @@ function test_tracer_variance_budget(; N=4, κ=1, rtol=0.01, closure = ScalarDif
     σz = 4grid.Δzᵃᵃᶜ # z length scale of the noise
 
     N_gaussians = 20 # How many Gaussians do we want sprinkled throughout the domain?
-    x₀ = grid.Lx * rand(N_gaussians); y₀ = grid.Ly * rand(N_gaussians); z₀ = -grid.Lz * rand(N_gaussians) # Locations of the Gaussians
-
-    xₚ = x₀ .+ (grid.Lx .* [-2;;-1;;0;;1;;2]) # Make that noise periodic by "infinite" horizontal reflection
-    yₚ = y₀ .+ (grid.Ly .* [-2;;-1;;0;;1;;2]) # Make that noise periodic by "infinite" horizontal reflection
-    zₚ = z₀ .+ (grid.Lz .* [-2;;-1;;0;;1;;2]) # Make that noise periodic by "infinite" horizontal reflection
+    Random.seed!(772)
+    xₚ, yₚ, zₚ = periodic_locations(N_gaussians)
 
     resolved_noise(x, y, z) = sum(@. exp(-(x-xₚ)^2/σx^2 -(y-yₚ)^2/σy^2 -(z-zₚ)^2/σz^2))
     set!(model, c=resolved_noise)
+    c = model.tracers.c
+    c.data.parent .-= mean(c)
 
     simulation = Simulation(model; Δt=grid.Δxᶜᵃᵃ^2/κ/20, stop_time=0.1)
 
-    c = model.tracers.c
     χ  = Oceanostics.FlowDiagnostics.TracerVarianceDissipationRate(model, :c)
 
     @compute ∫χdV   = Field(Integral(χ))
@@ -32,9 +44,11 @@ function test_tracer_variance_budget(; N=4, κ=1, rtol=0.01, closure = ScalarDif
 
     ∫c²dV_t⁰ = parent(∫c²dV)[1,1,1]
     function accumulate_χ(sim)
+        increment = sim.Δt * model.auxiliary_fields.∫χdV_prev
+        model.auxiliary_fields = (; model.auxiliary_fields..., ∫∫χdVdt = model.auxiliary_fields.∫∫χdVdt + increment)
+
         compute!(∫χdV)
-        increment = sim.Δt * parent(∫χdV)[1,1,1]
-        model.auxiliary_fields = (; ∫∫χdVdt = model.auxiliary_fields.∫∫χdVdt + increment)
+        model.auxiliary_fields = (; model.auxiliary_fields..., ∫χdV_prev = parent(∫χdV)[1,1,1])
         return nothing
     end
     simulation.callbacks[:integrate_χ] = Callback(accumulate_χ)
@@ -44,10 +58,10 @@ function test_tracer_variance_budget(; N=4, κ=1, rtol=0.01, closure = ScalarDif
     compute!(∫c²dV)
     ∫c²dV_tᶠ = parent(∫c²dV)[1,1,1]
     ∫∫χdVdt_tᶠ = ∫c²dV_t⁰- model.auxiliary_fields.∫∫χdVdt
-    abs_error = (abs(∫∫χdVdt_tᶠ - ∫c²dV_tᶠ)/∫c²dV_tᶠ)
+    abs_error = (abs(∫∫χdVdt_tᶠ - ∫c²dV_tᶠ)/∫c²dV_t⁰)
 
     @info "Error in c² decrease is $abs_error"
-    @test ≈(∫∫χdVdt_tᶠ, ∫c²dV_tᶠ, rtol=rtol)
+    @test abs_error < rtol
 
     return nothing
 end


### PR DESCRIPTION
This PR will improve the calculation of budgets by

- Doing the time-integral with the appropriate value (i.e. value of integral at step `N` depends on the dissipation rate at time step `N-1`, not at time-step `N`)
- Move the variables holding the current integral value outside of `model.auxliary_fields` using `Ref(val)`.