### PR TITLE
Add `TracerVarianceBudgetTerms` module

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.5"
+julia_version = "1.8.3"
 manifest_format = "2.0"
-project_hash = "80f9377d2bf6b725065dd763a3d2d181d7fa22c0"
+project_hash = "e84f58b61a49a3a262373aa4df919682d19670b2"
 
 [[deps.AbstractFFTs]]
 deps = ["ChainRulesCore", "LinearAlgebra"]
@@ -94,7 +94,7 @@ version = "4.6.1"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.1+0"
+version = "0.5.2+0"
 
 [[deps.Crayons]]
 git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,20 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.3"
+julia_version = "1.8.5"
 manifest_format = "2.0"
-project_hash = "f5a2de967a260bf554301b56dfcb02ad06ee5743"
-
-[[deps.AMGX]]
-deps = ["AMGX_jll", "CEnum", "CUDA", "JSON", "Libdl", "SparseArrays"]
-git-tree-sha1 = "5f2e38391ea8788c69e3dc2aa297b4bef98c2ac8"
-uuid = "c963dde9-0319-47f5-bf0c-b07d3c80ffa6"
-version = "0.1.4"
-
-[[deps.AMGX_jll]]
-deps = ["Artifacts", "CUDA_Runtime_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg", "TOML"]
-git-tree-sha1 = "9a9e64c4d2acee7b89286985eaa7489ac3e97328"
-uuid = "656d14af-56e4-5275-8e68-4e861d7b5043"
-version = "2.3.0+1"
+project_hash = "80f9377d2bf6b725065dd763a3d2d181d7fa22c0"
 
 [[deps.AbstractFFTs]]
 deps = ["ChainRulesCore", "LinearAlgebra"]
@@ -28,21 +16,15 @@ git-tree-sha1 = "cc37d689f599e8df4f464b2fa3870ff7db7492ef"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 version = "3.6.1"
 
-[[deps.AlgebraicMultigrid]]
-deps = ["CommonSolve", "LinearAlgebra", "Printf", "Reexport", "SparseArrays"]
-git-tree-sha1 = "796eedcb42226861a51d92d28ee82d4985ee860b"
-uuid = "2169fc97-5a83-5252-b627-83903c6c433c"
-version = "0.5.1"
-
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 version = "1.1.1"
 
 [[deps.ArrayInterface]]
 deps = ["Adapt", "LinearAlgebra", "Requires", "SnoopPrecompile", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "a89acc90c551067cd84119ff018619a1a76c6277"
+git-tree-sha1 = "38911c7737e123b28182d89027f4216cfc8a9da7"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "7.2.1"
+version = "7.4.3"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -85,18 +67,6 @@ git-tree-sha1 = "1680366a69e9c95744ef23a239e6cfe61cf2e1ca"
 uuid = "72cfdca4-0801-4ab0-bf6a-d52aa10adc57"
 version = "0.4.7"
 
-[[deps.CUDA_Driver_jll]]
-deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
-git-tree-sha1 = "a1efe2bfb96c10906dede10f1580aca0ae6d092f"
-uuid = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-version = "0.4.0+2"
-
-[[deps.CUDA_Runtime_jll]]
-deps = ["Artifacts", "CUDA_Driver_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
-git-tree-sha1 = "96e06a24c89a9945c57278fd09fb717f71476d87"
-uuid = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
-version = "0.4.0+2"
-
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
 git-tree-sha1 = "c6d890a52d2c4d55d326439580c3b8d0875a77d9"
@@ -109,10 +79,11 @@ git-tree-sha1 = "485193efd2176b88e6622a39a246f8c5b600e74e"
 uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 version = "0.1.6"
 
-[[deps.CommonSolve]]
-git-tree-sha1 = "9441451ee712d1aec22edad62db1a9af3dc8d852"
-uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
-version = "0.2.3"
+[[deps.CommonDataModel]]
+deps = ["CFTime", "DataStructures", "Dates", "Preferences", "Printf"]
+git-tree-sha1 = "246cf98b1422f984dd3abc11834c64e83d7bf832"
+uuid = "1fbeeb36-5f17-413c-809b-666fb144f157"
+version = "0.2.1"
 
 [[deps.Compat]]
 deps = ["Dates", "LinearAlgebra", "UUIDs"]
@@ -123,7 +94,7 @@ version = "4.6.1"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.5.2+0"
+version = "1.0.1+0"
 
 [[deps.Crayons]]
 git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
@@ -155,12 +126,6 @@ version = "1.0.0"
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
-
-[[deps.DiffRules]]
-deps = ["IrrationalConstants", "LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
-git-tree-sha1 = "a4ad7ef19d2cdc2eff57abbbe68032b1cd0bd8f8"
-uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.13.0"
 
 [[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -210,9 +175,9 @@ uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.GPUArrays]]
 deps = ["Adapt", "GPUArraysCore", "LLVM", "LinearAlgebra", "Printf", "Random", "Reexport", "Serialization", "Statistics"]
-git-tree-sha1 = "a28f752ffab0ccd6660fc7af5ad1c9ad176f45f7"
+git-tree-sha1 = "9ade6983c3dbbd492cf5729f865fe030d1541463"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
-version = "8.6.3"
+version = "8.6.6"
 
 [[deps.GPUArraysCore]]
 deps = ["Adapt"]
@@ -227,9 +192,9 @@ uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.17.3"
 
 [[deps.Glob]]
-git-tree-sha1 = "4df9f7e06108728ebf00a0a11edee4b29a482bb2"
+git-tree-sha1 = "97285bbd5230dd766e9ef6749b80fc617126d496"
 uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
-version = "1.3.0"
+version = "1.3.1"
 
 [[deps.HDF5_jll]]
 deps = ["Artifacts", "JLLWrappers", "LibCURL_jll", "Libdl", "OpenSSL_jll", "Pkg", "Zlib_jll"]
@@ -292,12 +257,6 @@ git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.4.1"
 
-[[deps.JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
-uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.3"
-
 [[deps.JSON3]]
 deps = ["Dates", "Mmap", "Parsers", "SnoopPrecompile", "StructTypes", "UUIDs"]
 git-tree-sha1 = "84b10656a41ef564c39d2d477d7236966d2b5683"
@@ -312,15 +271,15 @@ version = "0.8.6"
 
 [[deps.LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "df115c31f5c163697eede495918d8e85045c8f04"
+git-tree-sha1 = "f044a2796a9e18e0531b9b3072b0019a61f264bc"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "4.16.0"
+version = "4.17.1"
 
 [[deps.LLVMExtra_jll]]
-deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg", "TOML"]
-git-tree-sha1 = "7718cf44439c676bc0ec66a87099f41015a522d6"
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
+git-tree-sha1 = "070e4b5b65827f82c16ae0916376cb47377aa1b5"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.16+2"
+version = "0.0.18+0"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -392,10 +351,10 @@ uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 version = "0.1.7"
 
 [[deps.MPItrampoline_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "Pkg", "TOML"]
-git-tree-sha1 = "b3f9e42685b4ad614eca0b44bd863cd41b1c86ea"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "ad88f863a5a16b3e26d14446afd3cd746266281b"
 uuid = "f1f71cc9-e9ae-5b93-9b94-4fe0e1ad3748"
-version = "5.0.2+1"
+version = "5.2.1+3"
 
 [[deps.MacroTools]]
 deps = ["Markdown", "Random"]
@@ -414,9 +373,9 @@ version = "2.28.0+0"
 
 [[deps.MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "a16aa086d335ed7e0170c5265247db29172af2f9"
+git-tree-sha1 = "a8027af3d1743b3bfae34e54872359fdebb31422"
 uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
-version = "10.1.3+2"
+version = "10.1.3+4"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -426,16 +385,10 @@ uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 version = "2022.2.1"
 
 [[deps.NCDatasets]]
-deps = ["CFTime", "DataStructures", "Dates", "NetCDF_jll", "NetworkOptions", "Printf"]
-git-tree-sha1 = "fe130b7201b7fd908d950076dbfc0671270894c5"
+deps = ["CFTime", "CommonDataModel", "DataStructures", "Dates", "NetCDF_jll", "NetworkOptions", "Printf"]
+git-tree-sha1 = "afd015e81e60cfbdba04ef59bcdc80e18bd613cd"
 uuid = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
-version = "0.12.13"
-
-[[deps.NaNMath]]
-deps = ["OpenLibm_jll"]
-git-tree-sha1 = "0877504529a3e5c3343c6f8b4c0381e57e4387e4"
-uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "1.0.2"
+version = "0.12.14"
 
 [[deps.NetCDF_jll]]
 deps = ["Artifacts", "HDF5_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Pkg", "XML2_jll", "Zlib_jll"]
@@ -448,10 +401,10 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
 [[deps.Oceananigans]]
-deps = ["AMGX", "Adapt", "AlgebraicMultigrid", "CUDA", "CUDAKernels", "Crayons", "CubedSphere", "Dates", "DocStringExtensions", "FFTW", "Glob", "IncompleteLU", "InteractiveUtils", "IterativeSolvers", "JLD2", "KernelAbstractions", "LinearAlgebra", "Logging", "MPI", "NCDatasets", "OffsetArrays", "OrderedCollections", "PencilArrays", "PencilFFTs", "Pkg", "Printf", "Random", "Rotations", "SeawaterPolynomials", "SparseArrays", "Statistics", "StructArrays", "Tullio"]
-git-tree-sha1 = "967e1c47abfb4457e57182a2b645432ab4c8e01c"
+deps = ["Adapt", "CUDA", "CUDAKernels", "Crayons", "CubedSphere", "Dates", "DocStringExtensions", "FFTW", "Glob", "IncompleteLU", "InteractiveUtils", "IterativeSolvers", "JLD2", "KernelAbstractions", "LinearAlgebra", "Logging", "MPI", "NCDatasets", "OffsetArrays", "OrderedCollections", "PencilArrays", "PencilFFTs", "Pkg", "Printf", "Random", "Rotations", "SeawaterPolynomials", "SparseArrays", "Statistics", "StructArrays"]
+git-tree-sha1 = "56a5b364df16907051c1ad261d52ab59f144d213"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.80.0"
+version = "0.81.0"
 
 [[deps.OffsetArrays]]
 deps = ["Adapt"]
@@ -488,9 +441,9 @@ uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 version = "0.5.5+0"
 
 [[deps.OrderedCollections]]
-git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+git-tree-sha1 = "d321bf2de576bf25ec4d3e4360faca399afca282"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.4.1"
+version = "1.6.0"
 
 [[deps.Parsers]]
 deps = ["Dates", "SnoopPrecompile"]
@@ -506,9 +459,9 @@ version = "0.17.10"
 
 [[deps.PencilFFTs]]
 deps = ["AbstractFFTs", "FFTW", "LinearAlgebra", "MPI", "PencilArrays", "Reexport", "TimerOutputs"]
-git-tree-sha1 = "032161020f4b6d341281d84a89f5240d42ad48c3"
+git-tree-sha1 = "602dc6232e4c2747035dd39a0e6569fccb9e9337"
 uuid = "4a48f351-57a6-4416-9ec4-c37015456aae"
-version = "0.14.2"
+version = "0.14.3"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -527,9 +480,9 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[deps.ProgressBars]]
 deps = ["Printf"]
-git-tree-sha1 = "806ebc92e1b4b4f72192369a28dfcaf688566b2b"
+git-tree-sha1 = "9d84c8646109eb8bc7a006d59b157c64d5155c81"
 uuid = "49802e3a-d2f1-5c88-81d8-b72133a6f568"
-version = "1.4.1"
+version = "1.5.0"
 
 [[deps.Quaternions]]
 deps = ["LinearAlgebra", "Random", "RealDot"]
@@ -591,9 +544,9 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
 
 [[deps.SeawaterPolynomials]]
-git-tree-sha1 = "20e6926c620cedee2b7551b61169dd118b4e34f2"
+git-tree-sha1 = "958ba75b90c7c8a117d041d33184134201cf8c0f"
 uuid = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
-version = "0.3.1"
+version = "0.3.2"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -619,9 +572,9 @@ version = "2.2.0"
 
 [[deps.Static]]
 deps = ["IfElse"]
-git-tree-sha1 = "d0435ba43ab5ad1cbb5f0d286ca4ba67029ed3ee"
+git-tree-sha1 = "08be5ee09a7632c32695d954a602df96a877bf0d"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "0.8.4"
+version = "0.8.6"
 
 [[deps.StaticArrayInterface]]
 deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "Requires", "SnoopPrecompile", "SparseArrays", "Static", "SuiteSparse"]
@@ -631,9 +584,9 @@ version = "1.3.0"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
-git-tree-sha1 = "2d7d9e1ddadc8407ffd460e24218e37ef52dd9a3"
+git-tree-sha1 = "b8d897fe7fa688e93aef573711cb207c08c9e11e"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.16"
+version = "1.5.19"
 
 [[deps.StaticArraysCore]]
 git-tree-sha1 = "6b7ba252635a5eff6a0b0664a41ee140a1c9e72a"
@@ -657,9 +610,9 @@ version = "1.2.3"
 
 [[deps.StructArrays]]
 deps = ["Adapt", "DataAPI", "GPUArraysCore", "StaticArraysCore", "Tables"]
-git-tree-sha1 = "b03a3b745aa49b566f128977a7dd1be8711c5e71"
+git-tree-sha1 = "521a0e828e98bb69042fec1809c1b5a680eb7389"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.14"
+version = "0.6.15"
 
 [[deps.StructTypes]]
 deps = ["Dates", "UUIDs"]
@@ -684,9 +637,9 @@ version = "1.0.1"
 
 [[deps.Tables]]
 deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "OrderedCollections", "TableTraits", "Test"]
-git-tree-sha1 = "c79322d36826aa2f4fd8ecfa96ddb47b174ac78d"
+git-tree-sha1 = "1544b926975372da01227b382066ab70e574a3ec"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.10.0"
+version = "1.10.1"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
@@ -711,15 +664,9 @@ version = "0.5.22"
 
 [[deps.TranscodingStreams]]
 deps = ["Random", "Test"]
-git-tree-sha1 = "94f38103c984f89cf77c402f2a68dbd870f8165f"
+git-tree-sha1 = "0b829474fed270a4b0ab07117dce9b9a2fa7581a"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.9.11"
-
-[[deps.Tullio]]
-deps = ["ChainRulesCore", "DiffRules", "LinearAlgebra", "Requires"]
-git-tree-sha1 = "7871a39eac745697ee512a87eeff06a048a7905b"
-uuid = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
-version = "0.3.5"
+version = "0.9.12"
 
 [[deps.TupleTools]]
 git-tree-sha1 = "3c712976c47707ff893cf6ba4354aa14db1d8938"
@@ -740,9 +687,9 @@ version = "0.2.1"
 
 [[deps.UnsafeAtomicsLLVM]]
 deps = ["LLVM", "UnsafeAtomics"]
-git-tree-sha1 = "33af9d2031d0dc09e2be9a0d4beefec4466def8e"
+git-tree-sha1 = "ead6292c02aab389cb29fe64cc9375765ab1e219"
 uuid = "d80eeb9a-aca5-4d75-85e5-170c8b632249"
-version = "0.1.0"
+version = "0.1.1"
 
 [[deps.VersionParsing]]
 git-tree-sha1 = "58d6e80b4ee071f5efd07fda82cb9fbe17200868"

--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,7 @@ Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-DocStringExtensions = "0.9"
-Oceananigans = "0.80.0"
+Oceananigans = "0.80, 0.81"
 julia = "^1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
 authors = ["tomchor <tomaschor@gmail.com>"]
-version = "0.10.3"
+version = "0.11.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -1,19 +1,24 @@
 module Oceanostics
 using DocStringExtensions
 
-#++++ TKEBudgetTerms exports
+#+++ TKEBudgetTerms exports
 export TurbulentKineticEnergy, KineticEnergy
 export IsotropicViscousDissipationRate, IsotropicPseudoViscousDissipationRate
 export XPressureRedistribution, YPressureRedistribution, ZPressureRedistribution
 export XShearProductionRate, YShearProductionRate, ZShearProductionRate
-#----
+#---
 
-#++++ FlowDiagnostics exports
+#+++ TracerVarianceBudgetTerms exports
+export TracerVarianceTendency
+export TracerVarianceDiffusiveTerm
+export TracerVarianceDissipationRate
+#---
+
+#+++ FlowDiagnostics exports
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity
 export IsotropicBuoyancyMixingRate
-export TracerVarianceDissipationRate
-#----
+#---
 
 #+++ Utils for validation
 # Right now, all kernels must be located at ccc
@@ -29,9 +34,33 @@ validate_dissipative_closure(::AbstractScalarDiffusivity{<:Any, ThreeDimensional
 validate_dissipative_closure(closure_tuple::Tuple) = Tuple(validate_dissipative_closure(c) for c in closure_tuple)
 #---
 
-#####
-##### A few utils for closure tuples:
-#####
+#+++ Utils for background fields
+using Oceananigans.Fields: ZeroField
+"""
+    $(SIGNATURES)
+
+Add background fields (velocities and tracers only) to their perturbations.
+"""
+function add_background_fields(model)
+
+    velocities = model.velocities
+    # Adds background velocities to their perturbations only if background velocity isn't ZeroField
+    full_velocities = NamedTuple{keys(velocities)}((model.background_fields.velocities[key] isa ZeroField) ? 
+                                                   val : 
+                                                   val + model.background_fields.velocities[key] 
+                                                   for (key,val) in zip(keys(velocities), velocities))
+    tracers = model.tracers
+    # Adds background tracer fields to their perturbations only if background tracer field isn't ZeroField
+    full_tracers = NamedTuple{keys(tracers)}((model.background_fields.tracers[key] isa ZeroField) ? 
+                                              val : 
+                                              val + model.background_fields.tracers[key] 
+                                              for (key,val) in zip(keys(tracers), tracers))
+
+    return merge(full_velocities, full_tracers)
+end
+#---
+
+#+++ A few utils for closure tuples:
 using Oceananigans.TurbulenceClosures: νᶜᶜᶜ, calc_nonlinear_κᶜᶜᶜ
 
 # Fallbacks that capture "single closure" case
@@ -50,11 +79,13 @@ using Oceananigans.TurbulenceClosures: νᶜᶜᶜ, calc_nonlinear_κᶜᶜᶜ
 @inline _calc_nonlinear_κᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple, args...) =
     calc_nonlinear_κᶜᶜᶜ(i, j, k, grid, closure_tuple[1], args...) +
     _calc_nonlinear_κᶜᶜᶜ(i, j, k, grid, closure_tuple[2:end], args...)
+#---
 
 include("TKEBudgetTerms.jl")
+include("TracerVarianceBudgetTerms.jl")
 include("FlowDiagnostics.jl")
 include("progress_messengers.jl")
 
-using .TKEBudgetTerms
+using .TKEBudgetTerms, .TracerVarianceBudgetTerms, .FlowDiagnostics
 
 end # module

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -17,7 +17,7 @@ export TracerVarianceDissipationRate
 #+++ FlowDiagnostics exports
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity
-export IsotropicBuoyancyMixingRate
+export DirectionalErtelPotentialVorticity
 #---
 
 #+++ Utils for validation

--- a/src/TKEBudgetTerms.jl
+++ b/src/TKEBudgetTerms.jl
@@ -6,12 +6,10 @@ export IsotropicViscousDissipationRate, IsotropicPseudoViscousDissipationRate
 export XPressureRedistribution, YPressureRedistribution, ZPressureRedistribution
 export XShearProductionRate, YShearProductionRate, ZShearProductionRate
 
-using Oceananigans
 using Oceananigans.Operators
 using Oceananigans.AbstractOperations
 using Oceananigans.AbstractOperations: KernelFunctionOperation
 using Oceananigans.Grids: Center, Face
-using Oceananigans.Fields: ZeroField
 
 using Oceanostics: _νᶜᶜᶜ
 using Oceanostics: validate_location, validate_dissipative_closure

--- a/src/TracerVarianceBudgetTerms.jl
+++ b/src/TracerVarianceBudgetTerms.jl
@@ -95,7 +95,7 @@ end
 Return a `KernelFunctionOperation` that computes the diffusive term of the tracer variance
 prognostic equation using Oceananigans' diffusive tracer flux divergence kernel:
 
-    DIFF = c ∂ⱼFⱼ
+    DIFF = 2 c ∂ⱼFⱼ
 
 where `c` is the tracer, and `Fⱼ` is the tracer's diffusive flux in the `j`-th direction.
 

--- a/src/TracerVarianceBudgetTerms.jl
+++ b/src/TracerVarianceBudgetTerms.jl
@@ -1,0 +1,183 @@
+module TracerVarianceBudgetTerms
+using DocStringExtensions
+
+export TracerVarianceDissipationRate, TracerVarianceTendency, TracerVarianceDiffusiveTerm
+
+using Oceanostics: validate_location, validate_dissipative_closure, add_background_fields
+
+using Oceananigans.Operators
+using Oceananigans.AbstractOperations: KernelFunctionOperation
+using Oceananigans.Grids: Center, Face
+using Oceananigans: fields
+using Oceananigans.Models.NonhydrostaticModels: tracer_tendency
+using Oceananigans.TurbulenceClosures: ∇_dot_qᶜ
+
+import Oceananigans.TurbulenceClosures: diffusive_flux_x, diffusive_flux_y, diffusive_flux_z
+
+
+
+#+++ Tracer vriance tendency
+@inline function c∂ₜcᶜᶜᶜ(i, j, k, grid, val_tracer_index::Val{tracer_index},
+                                        val_tracer_name,
+                                        advection,
+                                        closure,
+                                        c_immersed_bc,
+                                        buoyancy,
+                                        biogeochemistry,
+                                        background_fields,
+                                        velocities,
+                                        tracers, args...) where tracer_index
+
+    return 2 * tracers[tracer_index][i, j, k] * tracer_tendency(i, j, k, grid, 
+                                                                val_tracer_index, 
+                                                                val_tracer_name,
+                                                                advection,
+                                                                closure,
+                                                                c_immersed_bc,
+                                                                buoyancy,
+                                                                biogeochemistry,
+                                                                background_fields,
+                                                                velocities,
+                                                                tracers,
+                                                                args...)
+end
+
+function TracerVarianceTendency(model, tracer_name; location = (Center, Center, Center))
+    validate_location(location, "TracerVarianceTendency")
+    tracer_index = findfirst(n -> n === tracer_name, propertynames(model.tracers))
+
+    dependencies = (Val(tracer_index),
+                    Val(tracer_name),
+                    model.advection,
+                    model.closure,
+                    model.tracers[tracer_name].boundary_conditions.immersed,
+                    model.buoyancy,
+                    model.biogeochemistry,
+                    model.background_fields,
+                    model.velocities,
+                    model.tracers,
+                    model.auxiliary_fields,
+                    model.diffusivity_fields,
+                    model.forcing[tracer_name],
+                    model.clock)
+
+    return KernelFunctionOperation{Center, Center, Center}(c∂ₜcᶜᶜᶜ, model.grid, dependencies...)
+end
+#---
+
+#+++ Tracer variance diffusive term
+@inline function c∇_dot_qᶜ(i, j, k, grid, closure,
+                                          diffusivities,
+                                          val_tracer_index,
+                                          tracer,
+                                          args...)
+    return 2 * tracer[i,j,k] * ∇_dot_qᶜ(i, j, k, grid, closure, diffusivities, val_tracer_index, tracer, args...)
+end
+
+"""
+    $(SIGNATURES)
+
+Return a `KernelFunctionOperation` that computes the diffusive term of the tracer variance
+prognostic equation using Oceananigans' diffusive tracer flux divergence kernel:
+
+    DIFF = c ∂ⱼFⱼ
+
+where `c` is the tracer, and `Fⱼ` is the tracer's diffusive flux.
+
+```julia
+```
+"""
+function TracerVarianceDiffusiveTerm(model, tracer_name; location = (Center, Center, Center))
+    validate_location(location, "TracerVarianceDiffusiveTerm")
+    tracer_index = findfirst(n -> n === tracer_name, propertynames(model.tracers))
+
+    dependencies = (model.closure,
+                    model.diffusivity_fields,
+                    Val(tracer_index),
+                    model.tracers[tracer_name],
+                    model.clock,
+                    fields(model),
+                    model.buoyancy)
+    return KernelFunctionOperation{Center, Center, Center}(c∇_dot_qᶜ, model.grid, dependencies...)
+end
+#---
+
+
+#+++ Tracer variance dissipation rate
+for diff_flux in (:diffusive_flux_x, :diffusive_flux_y, :diffusive_flux_z)
+    # Unroll the loop over a tuple
+    @eval @inline $diff_flux(i, j, k, grid, closure_tuple::Tuple, diffusivity_fields, args...) = 
+        $diff_flux(i, j, k, grid, closure_tuple[1], diffusivity_fields[1], args...) + 
+        $diff_flux(i, j, k, grid, closure_tuple[2:end], diffusivity_fields[2:end], args...)
+
+    # End of the line
+    @eval @inline $diff_flux(i, j, k, grid, closure_tuple::Tuple{}, args...) = zero(grid)
+end
+
+# Variance dissipation at fcc
+@inline χxᶠᶜᶜ(i, j, k, grid, closure, diffusivity_fields, id, c, args...) =
+    - Axᶠᶜᶜ(i, j, k, grid) * δxᶠᵃᵃ(i, j, k, grid, c) * diffusive_flux_x(i, j, k, grid, closure, diffusivity_fields, id, c, args...)
+
+# Variance dissipation at cfc
+@inline χyᶜᶠᶜ(i, j, k, grid, closure, diffusivity_fields, id, c, args...) =
+    - Ayᶜᶠᶜ(i, j, k, grid) * δyᵃᶠᵃ(i, j, k, grid, c) * diffusive_flux_y(i, j, k, grid, closure, diffusivity_fields, id, c, args...)
+
+# Variance dissipation at ccf
+@inline χzᶜᶜᶠ(i, j, k, grid, closure, diffusivity_fields, id, c, args...) =
+    - Azᶜᶜᶠ(i, j, k, grid) * δzᵃᵃᶠ(i, j, k, grid, c) * diffusive_flux_z(i, j, k, grid, closure, diffusivity_fields, id, c, args...)
+
+@inline function tracer_variance_dissipation_rate_ccc(i, j, k, grid, args...)
+return 2 * (ℑxᶜᵃᵃ(i, j, k, grid, χxᶠᶜᶜ, args...) + # F, C, C  → C, C, C
+            ℑyᵃᶜᵃ(i, j, k, grid, χyᶜᶠᶜ, args...) + # C, F, C  → C, C, C
+            ℑzᵃᵃᶜ(i, j, k, grid, χzᶜᶜᶠ, args...)   # C, C, F  → C, C, C
+            ) / Vᶜᶜᶜ(i, j, k, grid) # This division by volume, coupled with the call to δ above, ensures a derivative operation
+end
+
+"""
+    $(SIGNATURES)
+
+Return a `KernelFunctionOperation` that computes the isotropic variance dissipation rate
+for `tracer_name` in `model.tracers`. The isotropic variance dissipation rate is defined as 
+
+    χ = 2 ∇c ⋅ F⃗
+
+where `F⃗` is the diffusive flux of `c` and `∇` is the gradient operator. `χ` is implemented in its
+conservative formulation based on the equation above. 
+
+Note that often `χ` is written as `χ = 2κ (∇c ⋅ ∇c)`, which is the special case for Fickian diffusion
+(`κ` is the tracer diffusivity).
+
+Here `tracer_name` is needed even when passing `tracer` in order to get the appropriate `tracer_index`.
+When passing `tracer`, this function should be used as
+
+```julia
+grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1))
+model = NonhydrostaticModel(grid=grid, tracers=:b, closure=SmagorinskyLilly())
+
+b̄ = Field(Average(model.tracers.b, dims=(1,2)))
+b′ = model.tracers.b - b̄
+
+χb = TracerVarianceDissipationRate(model, :b, tracer=b′)
+```
+"""
+function TracerVarianceDissipationRate(model, tracer_name; tracer = nothing, location = (Center, Center, Center))
+    validate_location(location, "TracerVarianceDissipationRate")
+    tracer_index = findfirst(n -> n === tracer_name, propertynames(model.tracers))
+
+    parameters = (; model.closure, model.clock, model.buoyancy,
+                  id = Val(tracer_index))
+
+    tracer = tracer == nothing ? model.tracers[tracer_name] : tracer
+    return KernelFunctionOperation{Center, Center, Center}(tracer_variance_dissipation_rate_ccc, model.grid,
+                                                           model.closure,
+                                                           model.diffusivity_fields,
+                                                           Val(tracer_index),
+                                                           tracer, 
+                                                           model.clock,
+                                                           fields(model),
+                                                           model.buoyancy)
+end
+#---
+
+end # module
+

--- a/src/TracerVarianceBudgetTerms.jl
+++ b/src/TracerVarianceBudgetTerms.jl
@@ -8,7 +8,7 @@ using Oceanostics: validate_location, validate_dissipative_closure, add_backgrou
 using Oceananigans.Operators
 using Oceananigans.AbstractOperations: KernelFunctionOperation
 using Oceananigans.Grids: Center, Face
-using Oceananigans: fields
+using Oceananigans: NonhydrostaticModel, fields
 using Oceananigans.Models.NonhydrostaticModels: tracer_tendency
 using Oceananigans.TurbulenceClosures: ∇_dot_qᶜ
 
@@ -42,7 +42,7 @@ import Oceananigans.TurbulenceClosures: diffusive_flux_x, diffusive_flux_y, diff
                                                                 args...)
 end
 
-function TracerVarianceTendency(model, tracer_name; location = (Center, Center, Center))
+function TracerVarianceTendency(model::NonhydrostaticModel, tracer_name; location = (Center, Center, Center))
     validate_location(location, "TracerVarianceTendency")
     tracer_index = findfirst(n -> n === tracer_name, propertynames(model.tracers))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using Oceananigans.AbstractOperations: AbstractOperation
 using Oceananigans.Fields: @compute
 using Oceananigans.TurbulenceClosures: ThreeDimensionalFormulation
 
+using Oceanostics
 using Oceanostics: TKEBudgetTerms, TracerVarianceBudgetTerms, FlowDiagnostics
 using Oceanostics: SimpleProgressMessenger, SingleLineProgressMessenger, make_message
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,18 +186,20 @@ function test_tracer_diagnostics(model)
     @test χ isa AbstractOperation
     @test χ_field isa Field
 
-    χ = TracerVarianceTendency(model, :b)
-    χ_field = compute!(Field(χ))
-    @test χ isa AbstractOperation
-    @test χ_field isa Field
-
     set!(model, u=grid_noise, v=grid_noise, w=grid_noise, b=grid_noise)
     @compute ε̄ₚ = Field(Average(TracerVarianceDissipationRate(model, :b)))
     @compute ε̄ₚ₂ = Field(Average(TracerVarianceDiffusiveTerm(model, :b)))
-    @compute ∂ₜc² = Field(Average(TracerVarianceTendency(model, :b)))
-
     @test ≈(interior(ε̄ₚ)[1,1,1], interior(ε̄ₚ₂)[1,1,1], rtol=1e-12, atol=eps())
-    @test ≈(interior(ε̄ₚ)[1,1,1], -interior(∂ₜc²)[1,1,1], rtol=1e-10, atol=eps())
+
+    if model isa NonhydrostaticModel
+        χ = TracerVarianceTendency(model, :b)
+        χ_field = compute!(Field(χ))
+        @test χ isa AbstractOperation
+        @test χ_field isa Field
+
+        @compute ∂ₜc² = Field(Average(TracerVarianceTendency(model, :b)))
+        @test ≈(interior(ε̄ₚ)[1,1,1], -interior(∂ₜc²)[1,1,1], rtol=1e-10, atol=eps())
+    end
 
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -283,16 +283,8 @@ closures = (ScalarDiffusivity(ν=1e-6, κ=1e-7),
         test_progress_messenger(model, TimedProgressMessenger(; LES=LES))
     end
 
+    rtol = 0.02; N = 64
+    @info "Testing tracer variance budget on and a regular grid with N=$N and tolerance $rtol"
+    test_tracer_variance_budget(N=N, rtol=rtol, regular_grid=true)
 
-#    closures = [ScalarDiffusivity(ν=1, κ=1),
-#                (HorizontalScalarDiffusivity(κ=2), VerticalScalarDiffusivity(κ=1/2)),
-#                (ScalarDiffusivity(ν=1, κ=1), SmagorinskyLilly()),
-#                ]
-#    for closure in closures
-#        @info "Testing tracer variance budget with closure $closure and a regular grid"
-#        test_tracer_variance_budget(N=64, rtol=0.01, closure=closure, regular_grid=true)
-#
-#        @info "Testing tracer variance budget with closure $closure and an irregular grid"
-#        test_tracer_variance_budget(N=64, rtol=0.01, closure=closure, regular_grid=false)
-#    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,10 +211,7 @@ model_kwargs = (buoyancy = Buoyancy(model=BuoyancyTracer()),
 
 closures = (ScalarDiffusivity(ν=1e-6, κ=1e-7),
             SmagorinskyLilly(),
-            AnisotropicMinimumDissipation(),
-            (HorizontalScalarDiffusivity(ν=1e-4, κ=1e-4), VerticalScalarDiffusivity(ν=1e-6, κ=1e-6)),
-            (ScalarDiffusivity(ν=1e-6, κ=1e-7), SmagorinskyLilly()),
-            )
+            (ScalarDiffusivity(ν=1e-6, κ=1e-7), AnisotropicMinimumDissipation()))
 
 @testset "Oceanostics" begin
     for grid in (regular_grid, stretched_grid)
@@ -238,7 +235,7 @@ closures = (ScalarDiffusivity(ν=1e-6, κ=1e-7),
                     @info "Testing energy dissipation rate terms with closure" closure
                     test_ke_dissipation_rate_terms(model)
                 end
-        
+       
                 @info "Testing tracer variance terms wth closure" closure
                 test_tracer_diagnostics(model)
             end
@@ -250,18 +247,17 @@ closures = (ScalarDiffusivity(ν=1e-6, κ=1e-7),
                             (ScalarDiffusivity(ν=1e-6, κ=1e-7), HorizontalScalarDiffusivity(ν=1e-6, κ=1e-7))]
         
         for closure in invalid_closures
-            model = NonhydrostaticModel(; grid, model_kwargs..., closure)
+            model = NonhydrostaticModel(grid = regular_grid; model_kwargs..., closure)
             @test_throws ErrorException IsotropicViscousDissipationRate(model; U=0, V=0, W=0)
             @test_throws ErrorException IsotropicPseudoViscousDissipationRate(model; U=0, V=0, W=0)
         end
 
     end
 
-        
-    
+
     for closure in closures
         LES = is_LES(closure)
-        model = NonhydrostaticModel(; grid,
+        model = NonhydrostaticModel(grid = regular_grid;
                                     buoyancy = Buoyancy(model=BuoyancyTracer()), 
                                     coriolis = FPlane(1e-4),
                                     tracers = :b,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,7 +189,7 @@ function test_tracer_diagnostics(model)
     set!(model, u=grid_noise, v=grid_noise, w=grid_noise, b=grid_noise)
     @compute ε̄ₚ = Field(Average(TracerVarianceDissipationRate(model, :b)))
     @compute ε̄ₚ₂ = Field(Average(TracerVarianceDiffusiveTerm(model, :b)))
-    @test ≈(interior(ε̄ₚ)[1,1,1], interior(ε̄ₚ₂)[1,1,1], rtol=1e-12, atol=eps())
+    @test ≈(Array(interior(ε̄ₚ, 1, 1, 1)), Array(interior(ε̄ₚ₂, 1, 1, 1)), rtol=1e-12, atol=eps())
 
     if model isa NonhydrostaticModel
         χ = TracerVarianceTendency(model, :b)
@@ -198,7 +198,7 @@ function test_tracer_diagnostics(model)
         @test χ_field isa Field
 
         @compute ∂ₜc² = Field(Average(TracerVarianceTendency(model, :b)))
-        @test ≈(interior(ε̄ₚ)[1,1,1], -interior(∂ₜc²)[1,1,1], rtol=1e-10, atol=eps())
+        @test ≈(Array(interior(ε̄ₚ, 1, 1, 1)), -Array(interior(∂ₜc², 1, 1, 1)), rtol=1e-10, atol=eps())
     end
 
     return nothing

--- a/test/test_budgets.jl
+++ b/test/test_budgets.jl
@@ -19,29 +19,42 @@ function periodic_locations(N_locations, flip_z=true)
     return x₀, y₀, z₀
 end
 
-function test_tracer_variance_budget(; N=16, rtol=0.01, closure = ScalarDiffusivity(κ=κ))
+function test_tracer_variance_budget(; N=16, rtol=0.01, closure = ScalarDiffusivity(κ=κ), regular_grid=true)
 
-    grid = RectilinearGrid(topology=(Periodic, Flat, Periodic), size=(N,N), extent=(1,1))
+    if regular_grid
+        grid = RectilinearGrid(topology=(Periodic, Flat, Periodic), size=(N,N), extent=(1,1))
+    else
+        S = 2
+        zᵃᵃᶠ(k) = (tanh(S * (2 * (k - 1) / N - 1)) / tanh(S) - 1) / 2 # [-1.0, 0.0]
+        grid = RectilinearGrid(topology=(Periodic, Flat, Bounded), size=(N,N), x=(0,1), z=zᵃᵃᶠ)
+    end
     model = NonhydrostaticModel(grid=grid, tracers=:c, closure=closure)
 
     # A kind of convoluted way to create x-periodic, resolved initial noise
     σx = 4grid.Δxᶜᵃᵃ # x length scale of the noise
     σy = 4grid.Δyᵃᶜᵃ # x length scale of the noise
-    σz = 4grid.Δzᵃᵃᶜ # z length scale of the noise
+    σz = 4mean(zspacings(grid, Center(), Center(), Center())) # z length scale of the noise
 
     N_gaussians = 20 # How many Gaussians do we want sprinkled throughout the domain?
     Random.seed!(772)
     xₚ, yₚ, zₚ = periodic_locations(N_gaussians)
 
     resolved_noise(x, y, z) = sum(@. exp(-(x-xₚ)^2/σx^2 -(y-yₚ)^2/σy^2 -(z-zₚ)^2/σz^2))
-    set!(model, c=resolved_noise)
+    set!(model, u=resolved_noise, c=resolved_noise)
+
+    u, v, w = model.velocities
     c = model.tracers.c
+
     c.data.parent .-= mean(c)
+    u.data.parent .-= mean(u)
 
     κ = diffusivity(model.closure, model.diffusivity_fields, Val(:c))
     @compute κ = κ isa Tuple ? Field(sum(κ)) : κ
-    Δt = min_Δx(grid)^2/maximum(κ)/20
+    Δt = min(minimum_zspacing(grid)^2/maximum(κ)/10, minimum_zspacing(grid)/maximum(u) / 10)
     simulation = Simulation(model; Δt=Δt, stop_time=0.1)
+
+    wizard = TimeStepWizard(cfl=0.1, diffusive_cfl=0.1)
+    simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(4))
 
     χ  = Oceanostics.FlowDiagnostics.TracerVarianceDissipationRate(model, :c)
 


### PR DESCRIPTION
This does two things:

1. Adds `TracerVarianceBudgetTerms` module (along with `TracerVarianceTendency` and `TracerVarianceDiffusiveTerm`)
2. Simplifies organization of tests, while making them broader

Point 1 creates a module dedicated for tracer variance budgets and uses Oceananigans kernels directly to calculate the terms. I'll add more terms slowly one by one, but using Oceananigans kernels should make this process easy and (since there are no interpolations to get tracer variance in `(Center, Center, Center)`, we can guarantee that the terms are conserve tracer variance up to machine precision. 

In fact, one advantage is that this gives a robust point of comparison for our tracer variance dissipation rate, whose average is now tested against `TracerVarianceTendency` and `TracerVarianceDiffusiveTerm` up to machine precision to ensure that it's formulation is conservative.

Point 2 makes the testing code much simpler, and now we're also going to test everything for every combination between several closures, model types, and grid types. Something like this:

```julia
@testset "Oceanostics" begin
    for grid in (regular_grid, stretched_grid)
        for model_type in (NonhydrostaticModel, HydrostaticFreeSurfaceModel)
            for closure in closures
                #Test things
...
```

This is likely overkill, but it does make the code much more readable and the code case for now is small enough that tests still run pretty fast. (Something like 20 minutes on my laptop, not counting the budget tests, which have to evolve a simulation.)