### PR TITLE
Adds Q (from Q-criterion) calculation

### DIFF
--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -334,6 +334,15 @@ end
 """
     $(SIGNATURES)
 
+Calculate the modulus (absolute value) of the strain rate tensor `S`, which is defined as the
+symmetric part of the velocity gradient tensor:
+
+    Sᵢⱼ = ½(∂ⱼuᵢ + ∂ᵢuⱼ)
+
+Its modulus is then defined (using Einstein summation notation) as
+
+    || Sᵢⱼ || = √( Sᵢⱼ Sᵢⱼ)
+
 """
 function StrainRateTensorModulus(model; location = (Center, Center, Center))
     validate_location(location, "StrainRateTensorModulus", (Center, Center, Center))
@@ -358,6 +367,15 @@ end
 """
     $(SIGNATURES)
 
+Calculate the modulus (absolute value) of the vorticity tensor `Ω`, which is defined as the
+antisymmetric part of the velocity gradient tensor:
+
+    Ωᵢⱼ = ½(∂ⱼuᵢ - ∂ᵢuⱼ)
+
+Its modulus is then defined (using Einstein summation notation) as
+
+    || Ωᵢⱼ || = √( Ωᵢⱼ Ωᵢⱼ)
+
 """
 function VorticityTensorModulus(model; location = (Center, Center, Center))
     validate_location(location, "VorticityTensorModulus", (Center, Center, Center))
@@ -375,6 +393,20 @@ end
 """
     $(SIGNATURES)
 
+Calculate the value of the `Q` velocity gradient tensor invariant. This is usually just called `Q`
+and it is generally used for identifying and visualizing vortices in fluid flow.
+
+The definition and nomenclature comes from the equation for the eigenvalues `λ` of the velocity
+gradient tensor `∂ⱼuᵢ`:
+
+    λ³ + P λ² + Q λ + T = 0
+
+from where `Q` is defined as
+
+    Q = ½ ( ΩᵢⱼΩᵢⱼ - SᵢⱼSᵢⱼ)
+
+and where `Sᵢⱼ= ½(∂ⱼuᵢ + ∂ᵢuⱼ)` and `Ωᵢⱼ= ½(∂ⱼuᵢ - ∂ᵢuⱼ)`. More info about it can be found in
+10.1063/1.5124245.
 """
 function QVelocityGradientTensorInvariant(model; location = (Center, Center, Center))
     validate_location(location, "QVelocityGradientTensorInvariant", (Center, Center, Center))

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -317,7 +317,7 @@ end
 #---
 
 #+++ Velocity gradient tensor
-@inline fψ_plus_gφ²(i, j, k, grid, f, ψ, g, φ) = @inbounds (f(i, j, k, grid, ψ) + g(i, j, k, grid, φ))^2
+@inline fψ_plus_gφ²(i, j, k, grid, f, ψ, g, φ) = (f(i, j, k, grid, ψ) + g(i, j, k, grid, φ))^2
 
 function strain_rate_tensor_modulus_ccc(i, j, k, grid, u, v, w)
     Sˣˣ² = ∂xᶜᶜᶜ(i, j, k, grid, u)^2

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -350,7 +350,7 @@ function StrainRateTensorModulus(model; location = (Center, Center, Center))
 end
 
 
-@inline fψ_minus_gφ²(i, j, k, grid, f, ψ, g, φ) = @inbounds (f(i, j, k, grid, ψ) - g(i, j, k, grid, φ))^2
+@inline fψ_minus_gφ²(i, j, k, grid, f, ψ, g, φ) = (f(i, j, k, grid, ψ) - g(i, j, k, grid, φ))^2
 
 function vorticity_tensor_modulus_ccc(i, j, k, grid, u, v, w)
     Ωˣʸ² = ℑxyᶜᶜᵃ(i, j, k, grid, fψ_minus_gφ², ∂yᶠᶠᶜ, u, ∂xᶠᶠᶜ, v) / 4

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -315,4 +315,41 @@ function DirectionalErtelPotentialVorticity(model, direction; location = (Face, 
 end
 #---
 
+#+++ Velocity gradient tensor
+@inline fψ_plus_gφ²(i, j, k, grid, f, ψ, g, φ) = @inbounds (f(i, j, k, grid, ψ) + g(i, j, k, grid, φ))^2
+
+function strain_rate_tensor_modulus_ccc(i, j, k, grid, u, v, w)
+    Sˣˣ² = ∂xᶜᶜᶜ(i, j, k, grid, u)^2
+    Sʸʸ² = ∂yᶜᶜᶜ(i, j, k, grid, v)^2
+    Sᶻᶻ² = ∂zᶜᶜᶜ(i, j, k, grid, w)^2
+
+    Sˣʸ² = ℑxyᶜᶜᵃ(i, j, k, grid, fψ_plus_gφ², ∂yᶠᶠᶜ, u, ∂xᶠᶠᶜ, v) / 4
+    Sˣᶻ² = ℑxzᶜᵃᶜ(i, j, k, grid, fψ_plus_gφ², ∂zᶠᶜᶠ, u, ∂xᶠᶜᶠ, w) / 4
+    Sʸᶻ² = ℑyzᵃᶜᶜ(i, j, k, grid, fψ_plus_gφ², ∂zᶜᶠᶠ, v, ∂yᶜᶠᶠ, w) / 4
+
+    return √(Sˣˣ² + Sʸʸ² + Sᶻᶻ² + 2 * (Sˣʸ² + Sˣᶻ² + Sʸᶻ²))
+end
+
+@inline fψ_minus_gφ²(i, j, k, grid, f, ψ, g, φ) = @inbounds (f(i, j, k, grid, ψ) - g(i, j, k, grid, φ))^2
+
+function vorticity_tensor_modulus_ccc(i, j, k, grid, u, v, w)
+    Ωˣʸ² = ℑxyᶜᶜᵃ(i, j, k, grid, fψ_minus_gφ², ∂yᶠᶠᶜ, u, ∂xᶠᶠᶜ, v) / 4
+    Ωˣᶻ² = ℑxzᶜᵃᶜ(i, j, k, grid, fψ_minus_gφ², ∂zᶠᶜᶠ, u, ∂xᶠᶜᶠ, w) / 4
+    Ωʸᶻ² = ℑyzᵃᶜᶜ(i, j, k, grid, fψ_minus_gφ², ∂zᶜᶠᶠ, v, ∂yᶜᶠᶠ, w) / 4
+
+    Ωʸˣ² = ℑxyᶜᶜᵃ(i, j, k, grid, fψ_minus_gφ², ∂xᶠᶠᶜ, v, ∂yᶠᶠᶜ, u) / 4
+    Ωᶻˣ² = ℑxzᶜᵃᶜ(i, j, k, grid, fψ_minus_gφ², ∂xᶠᶜᶠ, w, ∂zᶠᶜᶠ, u) / 4
+    Ωᶻʸ² = ℑyzᵃᶜᶜ(i, j, k, grid, fψ_minus_gφ², ∂yᶜᶠᶠ, w, ∂zᶜᶠᶠ, v) / 4
+
+    return √(Ωˣʸ² + Ωˣᶻ² + Ωʸᶻ² + Ωʸˣ² + Ωᶻˣ² + Ωᶻʸ²)
+end
+
+# From 10.1063/1.5124245
+@inline function Q_ccc(i, j, k, grid, u, v, w)
+    S² = strain_rate_tensor_modulus_ccc(i, j, k, grid, u, v, w)^2
+    Ω² = vorticity_tensor_modulus_ccc(i, j, k, grid, u, v, w)^2
+    return (Ω² - S²) / 2
+end
+#---
+
 end # module

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -19,6 +19,7 @@ export TracerVarianceDissipationRate
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity
 export DirectionalErtelPotentialVorticity
+export StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
 #---
 
 #+++ Utils for validation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,7 +118,7 @@ function test_vel_only_diagnostics(model)
     @test all(interior(compute!(Ω)) .≈ 0)
 
     op = QVelocityGradientTensorInvariant(model)
-    @test op == Oceanostics.Q(model)
+    CUDA.@allowscalar @test op == Oceanostics.Q(model)
     @test op isa AbstractOperation
     q = Field(op)
     @test all(interior(compute!(q)) .≈ 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -241,7 +241,7 @@ function test_tracer_diagnostics(model)
 end
 #---
 
-#+++ Known-vaue function tests
+#+++ Known-value function tests
 function test_uniform_strain_flow(model; α=1)
     u₀(x, y, z) = +α*x
     v₀(x, y, z) = -α*y
@@ -253,7 +253,7 @@ function test_uniform_strain_flow(model; α=1)
     @compute S = Field(StrainRateTensorModulus(model))
     @compute Ω = Field(VorticityTensorModulus(model))
 
-    idxs = (grid.Nx÷2, grid.Ny÷2, 1) # Let's get somewhere far from boundaries
+    idxs = (model.grid.Nx÷2, model.grid.Ny÷2, 1) # Let's get somewhere far from boundaries
 
     if model.closure isa Tuple
         @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,7 +167,7 @@ function test_pressure_terms(model)
 end
 
 function test_ke_dissipation_rate_terms(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1))
-    model = model_type(; grid, closure, tracers=:b)
+    model = model_type(; grid, closure, buoyancy=BuoyancyTracer(), tracers=:b)
 
     if !(model.closure isa Tuple) || all(isa.(model.closure, ScalarDiffusivity{ThreeDimensionalFormulation}))
         ε_iso = IsotropicKineticEnergyDissipationRate(model; U=0, V=0, W=0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -245,7 +245,7 @@ end
 function test_uniform_strain_flow(model; α=1)
     u₀(x, y, z) = +α*x
     v₀(x, y, z) = -α*y
-    set!(model, u=u₀, v=v₀, enforce_incompressibility=false)
+    set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
 
     u, v, w = model.velocities
 
@@ -275,7 +275,7 @@ end
 function test_solid_body_rotation_flow(model; ζ=1)
     u₀(x, y, z) = +ζ*y / 2
     v₀(x, y, z) = -ζ*x / 2
-    set!(model, u=u₀, v=v₀, enforce_incompressibility=false)
+    set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
 
     u, v, w = model.velocities
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -253,9 +253,15 @@ function test_uniform_strain_flow(model; α=1)
     @compute S = Field(StrainRateTensorModulus(model))
     @compute Ω = Field(VorticityTensorModulus(model))
 
-    idxs = (4, 4, 1)
-    ν = viscosity(model.closure, model.diffusivity_fields)
-    ν = ν isa Number ? ν : getindex(ν, idxs...)
+    idxs = (grid.Nx÷2, grid.Ny÷2, 1) # Let's get somewhere far from boundaries
+
+    if model.closure isa Tuple
+        @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
+    else
+        ν_field = viscosity(model.closure, model.diffusivity_fields)
+    end
+    ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
+
     @test getindex(S, idxs...) ≈ √2*α
     @test getindex(Ω, idxs...) ≈ 0
     @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -272,7 +272,7 @@ function test_uniform_strain_flow(model; α=1)
     return nothing
 end
 
-function test_solid_body_rotation_flow(model, ζ=1)
+function test_solid_body_rotation_flow(model; ζ=1)
     u₀(x, y, z) = +ζ*y / 2
     v₀(x, y, z) = -ζ*x / 2
     set!(model, u=u₀, v=v₀, enforce_incompressibility=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,10 +118,10 @@ function test_vel_only_diagnostics(model)
     @test all(interior(compute!(Ω)) .≈ 0)
 
     op = QVelocityGradientTensorInvariant(model)
-    @test op == Q(model)
+    @test op == Oceanostics.Q(model)
     @test op isa AbstractOperation
-    Q = Field(op)
-    @test all(interior(compute!(Q)) .≈ 0)
+    q = Field(op)
+    @test all(interior(compute!(q)) .≈ 0)
 
     return nothing
 end


### PR DESCRIPTION
This PR adds the calculation of the "Q" velocity gradient tensor invariant. This is useful for the identification and visualization of vortices in fluid dynamics (a comparative study of similar methods can be found [here](https://www.tandfonline.com/doi/pdf/10.1080/19942060.2020.1816496#:~:text=The%20Q%20criterion%20defines%20Q,strain%20in%20the%20vortices%20areas.&text=Lambda%2D2%20criterion%20(Jeong%20%26,%2B%202%20with%20%CF%832%20%3C%200).).)

The definition and nomenclature comes from the equation for the eigenvalues of the velocity gradient tensor $\nabla \vec u$:

```math
\lambda^3+P \lambda^2+Q \lambda+T=0
```

$Q$ is then defined as

```math
Q=\frac{1}{2}\left(\|\bf\Omega\|^2-\|\bf S\|^2\right)
```

where $\bf S$ is the strain rate tensor and $\bf \Omega$ is the vorticity tensor (i.e. the symmetric and antisymmetric parts of the velocity gradient tensor, respectively).

This PR adds `KernelFunctionOperations` for `StrainRateTensorModulus` ($|| \bf S ||$), `VorticityTensorModulus` ($|| \bf \Omega ||$),  and `Q`.

PS: I don't love this nomenclature since it gives basically zero information on what it's called, but I haven't ever seen it being called something else. If anyone knows of a better name for this, lmk.