### PR TITLE
Ensure that output files are deleted before pushing to `gh-pages`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -54,7 +54,7 @@ makedocs(sitename = "Oceanostics.jl",
 #---
 
 #+++ Cleanup any output files, e.g., .jld2 or .nc, created by docs. Otherwise they are pushed up in the docs branch in the repo
-for file in vcat(glob("docs/*.jld2"), glob("docs/*.nc"))
+for file in vcat(glob("docs/*.jld2"), glob("docs/*.nc"), glob("docs/generated/*.nc"), glob("docs/generated/*.nc"))
     rm(file)
 end
 #---


### PR DESCRIPTION
At the moment there are some `.nc` files pushed up there and in the course of time this can make the repo grow in size a lot.