### PR TITLE
Attempt at deploying all versions of the docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -62,6 +62,8 @@ end
 #+++ Deploy thedocs
 if CI
     deploydocs(repo = "github.com/tomchor/Oceanostics.jl.git",
+               versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
+               devbranch = "main",
                push_preview = true,
                )
 end


### PR DESCRIPTION
Per the `deploydocs` docs:

```julia
  versions determines content and order of the resulting version selector in the generated html. The following entries are valid in the versions vector:

    •  "v#": includes links to the latest documentation for each major release cycle (i.e. v2.0, v1.1).

    •  "v#.#": includes links to the latest documentation for each minor release cycle (i.e. v2.0, v1.1, v1.0, v0.1).

    •  "v#.#.#": includes links to all released versions.

    •  "v^": includes a link to the docs for the maximum version (i.e. a link vX.Y pointing to vX.Y.Z for highest X, Y, Z, respectively).

    •  A pair, e.g. "first" => "second", which will put "first" in the selector, and generate a url from which "second" can be accessed. The second argument can be "v^", to point to
       the maximum version docs (as in e.g. "stable" => "v^").
```

The default should be `versions = ["stable" => "v^", "v#.#", devurl => devurl]` but maybe it's not? Anyway it's good to be explicit.

Also the default is `devbranch = nothing`, which isn't guaranteed to return `main`, so let's be explicit about that.

cc @navidcy 