### PR TITLE
Adds `KineticEnergyForcingTerm`

### DIFF
--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -3,7 +3,7 @@ using DocStringExtensions
 
 #+++ TKEBudgetTerms exports
 export TurbulentKineticEnergy, KineticEnergy
-export KineticEnergyTendency, KineticEnergyDiffusiveTerm
+export KineticEnergyTendency, KineticEnergyDiffusiveTerm, KineticEnergyForcingTerm
 export IsotropicKineticEnergyDissipationRate, KineticEnergyDissipationRate
 export XPressureRedistribution, YPressureRedistribution, ZPressureRedistribution
 export XShearProductionRate, YShearProductionRate, ZShearProductionRate

--- a/src/TKEBudgetTerms.jl
+++ b/src/TKEBudgetTerms.jl
@@ -2,7 +2,7 @@ module TKEBudgetTerms
 using DocStringExtensions
 
 export TurbulentKineticEnergy, KineticEnergy
-export KineticEnergyTendency, KineticEnergyDiffusiveTerm
+export KineticEnergyTendency, KineticEnergyDiffusiveTerm, KineticEnergyForcingTerm
 export IsotropicKineticEnergyDissipationRate, KineticEnergyDissipationRate
 export XPressureRedistribution, YPressureRedistribution, ZPressureRedistribution
 export XShearProductionRate, YShearProductionRate, ZShearProductionRate
@@ -25,8 +25,8 @@ using Oceanostics: validate_location, validate_dissipative_closure
 # Some useful operators
 @inline ψ²(i, j, k, grid, ψ) = @inbounds ψ[i, j, k]^2
 
-@inline ψ′²(i, j, k, grid, ψ, Ψ) = @inbounds (ψ[i, j, k] - Ψ[i, j, k])^2
-@inline ψ′²(i, j, k, grid, ψ, Ψ::Number) = @inbounds (ψ[i, j, k] - Ψ)^2
+@inline ψ′²(i, j, k, grid, ψ, ψ̄) = @inbounds (ψ[i, j, k] - ψ̄[i, j, k])^2
+@inline ψ′²(i, j, k, grid, ψ, ψ̄::Number) = @inbounds (ψ[i, j, k] - ψ̄)^2
 
 @inline fψ²(i, j, k, grid, f, ψ) = f(i, j, k, grid, ψ)^2
 
@@ -260,7 +260,7 @@ end
 """
     $(SIGNATURES)
 
-Return a `KernelFunctionOperation` that computes the diffusive term the KE prognostic equation:
+Return a `KernelFunctionOperation` that computes the diffusive term of the KE prognostic equation:
 
 ```
     DIFF = uᵢ∂ⱼτᵢⱼ
@@ -282,6 +282,44 @@ function KineticEnergyDiffusiveTerm(model; location = (Center, Center, Center))
                     fields(model),
                     model.buoyancy)
     return KernelFunctionOperation{Center, Center, Center}(uᵢ∂ⱼ_τᵢⱼᶜᶜᶜ, model.grid, dependencies...)
+end
+#---
+
+#--- Kinetic energy forcing term
+@inline function uᵢFᵤᵢᶜᶜᶜ(i, j, k, grid, forcings,
+                                         clock,
+                                         model_fields)
+
+    u∂ⱼ_τ₁ⱼ = ℑxᶜᵃᵃ(i, j, k, grid, ψf, model_fields.u, forcings.u, clock, model_fields)
+    v∂ⱼ_τ₂ⱼ = ℑyᵃᶜᵃ(i, j, k, grid, ψf, model_fields.v, forcings.v, clock, model_fields)
+    w∂ⱼ_τ₃ⱼ = ℑzᵃᵃᶜ(i, j, k, grid, ψf, model_fields.w, forcings.w, clock, model_fields)
+
+    return u∂ⱼ_τ₁ⱼ+ v∂ⱼ_τ₂ⱼ + w∂ⱼ_τ₃ⱼ
+end
+
+"""
+    $(SIGNATURES)
+
+Return a `KernelFunctionOperation` that computes the forcing term of the KE prognostic equation:
+
+```
+    FORC = uᵢFᵤᵢ
+```
+
+where `uᵢ` are the velocity components and `Fᵤᵢ` is the forcing term(s) in the `uᵢ`
+prognostic equation (i.e. the forcing for `uᵢ`).
+"""
+function KineticEnergyForcingTerm(model; location = (Center, Center, Center))
+    validate_location(location, "KineticEnergyForcingTerm")
+    model_fields = fields(model)
+
+    if model isa HydrostaticFreeSurfaceModel
+        model_fields = (; model_fields..., w=ZeroField())
+    end
+    dependencies = (model.forcing,
+                    model.clock,
+                    fields(model))
+    return KernelFunctionOperation{Center, Center, Center}(uᵢFᵤᵢᶜᶜᶜ, model.grid, dependencies...)
 end
 #---
 

--- a/src/TKEBudgetTerms.jl
+++ b/src/TKEBudgetTerms.jl
@@ -309,7 +309,7 @@ Return a `KernelFunctionOperation` that computes the forcing term of the KE prog
 where `uᵢ` are the velocity components and `Fᵤᵢ` is the forcing term(s) in the `uᵢ`
 prognostic equation (i.e. the forcing for `uᵢ`).
 """
-function KineticEnergyForcingTerm(model; location = (Center, Center, Center))
+function KineticEnergyForcingTerm(model::NonhydrostaticModel; location = (Center, Center, Center))
     validate_location(location, "KineticEnergyForcingTerm")
     model_fields = fields(model)
 

--- a/src/TKEBudgetTerms.jl
+++ b/src/TKEBudgetTerms.jl
@@ -313,9 +313,6 @@ function KineticEnergyForcingTerm(model::NonhydrostaticModel; location = (Center
     validate_location(location, "KineticEnergyForcingTerm")
     model_fields = fields(model)
 
-    if model isa HydrostaticFreeSurfaceModel
-        model_fields = (; model_fields..., w=ZeroField())
-    end
     dependencies = (model.forcing,
                     model.clock,
                     fields(model))

--- a/src/TKEBudgetTerms.jl
+++ b/src/TKEBudgetTerms.jl
@@ -294,7 +294,7 @@ end
     vFᵛ = ℑyᵃᶜᵃ(i, j, k, grid, ψf, model_fields.v, forcings.v, clock, model_fields)
     wFʷ = ℑzᵃᵃᶜ(i, j, k, grid, ψf, model_fields.w, forcings.w, clock, model_fields)
 
-    return uFᵘ+ vFᵛⱼ + wFʷ
+    return uFᵘ+ vFᵛ + wFʷ
 end
 
 """

--- a/src/TKEBudgetTerms.jl
+++ b/src/TKEBudgetTerms.jl
@@ -290,11 +290,11 @@ end
                                          clock,
                                          model_fields)
 
-    u∂ⱼ_τ₁ⱼ = ℑxᶜᵃᵃ(i, j, k, grid, ψf, model_fields.u, forcings.u, clock, model_fields)
-    v∂ⱼ_τ₂ⱼ = ℑyᵃᶜᵃ(i, j, k, grid, ψf, model_fields.v, forcings.v, clock, model_fields)
-    w∂ⱼ_τ₃ⱼ = ℑzᵃᵃᶜ(i, j, k, grid, ψf, model_fields.w, forcings.w, clock, model_fields)
+    uFᵘ = ℑxᶜᵃᵃ(i, j, k, grid, ψf, model_fields.u, forcings.u, clock, model_fields)
+    vFᵛ = ℑyᵃᶜᵃ(i, j, k, grid, ψf, model_fields.v, forcings.v, clock, model_fields)
+    wFʷ = ℑzᵃᵃᶜ(i, j, k, grid, ψf, model_fields.w, forcings.w, clock, model_fields)
 
-    return u∂ⱼ_τ₁ⱼ+ v∂ⱼ_τ₂ⱼ + w∂ⱼ_τ₃ⱼ
+    return uFᵘ+ vFᵛⱼ + wFʷ
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,7 +224,7 @@ function test_ke_forcing_term(grid; model_type=NonhydrostaticModel)
 
     @compute ε_truth = Field(@at (Center, Center, Center) (-0.1 * model.velocities.u^2 -0.2 * model.velocities.v^2 -0.3 * model.velocities.w^2))
 
-    @test ≈(Array(interior(ε_field, 1, 1, 1)), Array(interior(ε_truth, 1, 1, 1)), rtol=1e-12, atol=eps())
+    @test isapprox(Array(interior(ε_field, 1, 1, 1)), Array(interior(ε_truth, 1, 1, 1)), rtol=1e-12, atol=eps())
 
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,6 +223,7 @@ function test_tracer_diagnostics(model)
     @test χ isa AbstractOperation
     @test χ_field isa Field
 
+    # Some of the models have LES closure, which means they don't have dissipation if u=v=w=0
     set!(model, u=grid_noise, v=grid_noise, w=grid_noise, b=grid_noise)
     @compute ε̄ₚ = Field(Average(TracerVarianceDissipationRate(model, :b)))
     @compute ε̄ₚ₂ = Field(Average(TracerVarianceDiffusiveTerm(model, :b)))


### PR DESCRIPTION
This PR adds `KineticEnergyForcingTerm`, which calculates the contribution of the momentum forcing terms on the kinetic energy evolution. It's especially useful when calculating the dissipation rate due to sponge layers and such.