### PR TITLE
Adds extra methods to some diagnostics for more user control

### DIFF
--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -260,7 +260,7 @@ function ErtelPotentialVorticity(model, u, v, w, b, coriolis; location = (Face, 
 
     if coriolis isa FPlane
         fx = fy = 0
-        fz = model.coriolis.f
+        fz = coriolis.f
     elseif coriolis isa ConstantCartesianCoriolis
         fx = coriolis.fx
         fy = coriolis.fy
@@ -326,47 +326,26 @@ function DirectionalErtelPotentialVorticity(model, direction; location = (Face, 
         b = model.tracers.b
     end
 
-    coriolis = model.coriolis
-    if coriolis != nothing
-        if coriolis isa FPlane
-            fx = fy = 0
-            fz = coriolis.f
-        elseif coriolis isa ConstantCartesianCoriolis
-            fx = coriolis.fx
-            fy = coriolis.fy
-            fz = coriolis.fz
-        else
-        throw(ArgumentError("`DirectionalErtelPotentialVorticity` only implemented for `FPlane` and `ConstantCartesianCoriolis`"))
-        end
-        f_dir = sum([fx, fy, fz] .* direction)
-    else
-        f_dir = 0
-    end
-
-    dir_x, dir_y, dir_z = direction
-    return KernelFunctionOperation{Face, Face, Face}(directional_ertel_potential_vorticity_fff, model.grid,
-                                                     u, v, w, b, (; f_dir, dir_x, dir_y, dir_z))
+    return DirectionalErtelPotentialVorticity(model, direction, u, v, w, b, model.coriolis; location)
 end
 
 
 function DirectionalErtelPotentialVorticity(model, direction, u, v, w, b, coriolis; location = (Face, Face, Face))
     validate_location(location, "DirectionalErtelPotentialVorticity", (Face, Face, Face))
 
-    if coriolis != nothing
-        if coriolis isa FPlane
-            fx = fy = 0
-            fz = coriolis.f
-        elseif coriolis isa ConstantCartesianCoriolis
-            fx = coriolis.fx
-            fy = coriolis.fy
-            fz = coriolis.fz
-        else
-        throw(ArgumentError("`DirectionalErtelPotentialVorticity` only implemented for `FPlane` and `ConstantCartesianCoriolis`"))
-        end
-        f_dir = sum([fx, fy, fz] .* direction)
+    if coriolis isa FPlane
+        fx = fy = 0
+        fz = coriolis.f
+    elseif coriolis isa ConstantCartesianCoriolis
+        fx = coriolis.fx
+        fy = coriolis.fy
+        fz = coriolis.fz
+    elseif coriolis == nothing
+        fx = fy = fz = 0
     else
-        f_dir = 0
+        throw(ArgumentError("ErtelPotentialVorticity is only implemented for FPlane and ConstantCartesianCoriolis"))
     end
+    f_dir = sum([fx, fy, fz] .* direction)
 
     dir_x, dir_y, dir_z = direction
     return KernelFunctionOperation{Face, Face, Face}(directional_ertel_potential_vorticity_fff, model.grid,

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -75,15 +75,7 @@ function RichardsonNumber(model; location = (Center, Center, Face), add_backgrou
         b = model.tracers.b
     end
 
-    if model.buoyancy.gravity_unit_vector isa NegativeZDirection
-        true_vertical_direction = (0, 0, 1)
-    elseif model.buoyancy.gravity_unit_vector isa ZDirection
-        true_vertical_direction = (0, 0, -1)
-    else
-        true_vertical_direction = .-model.buoyancy.gravity_unit_vector
-    end
-    return KernelFunctionOperation{Center, Center, Face}(richardson_number_ccf, model.grid,
-                                                         u, v, w, b, true_vertical_direction)
+    return RichardsonNumber(model, u, v, w, b; location)
 end
 
 
@@ -142,6 +134,16 @@ function RossbyNumber(model; location = (Face, Face, Face), add_background = tru
     else
         u, v, w = model.velocities
     end
+
+    return RossbyNumber(model, u, v, w, model.coriolis; location, 
+                        dWdy_bg, dVdz_bg, dUdz_bg, dWdx_bg, dUdy_bg, dVdx_bg)
+end
+
+function RossbyNumber(model, u, v, w, coriolis; location = (Face, Face, Face),
+                      dWdy_bg=0, dVdz_bg=0,
+                      dUdz_bg=0, dWdx_bg=0,
+                      dUdy_bg=0, dVdx_bg=0)
+    validate_location(location, "RossbyNumber", (Face, Face, Face))
 
     coriolis = model.coriolis
     if coriolis isa FPlane

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -145,10 +145,9 @@ function RossbyNumber(model, u, v, w, coriolis; location = (Face, Face, Face),
                       dUdy_bg=0, dVdx_bg=0)
     validate_location(location, "RossbyNumber", (Face, Face, Face))
 
-    coriolis = model.coriolis
     if coriolis isa FPlane
         fx = fy = 0
-        fz = model.coriolis.f
+        fz = coriolis.f
     elseif coriolis isa ConstantCartesianCoriolis
         fx = coriolis.fx
         fy = coriolis.fy
@@ -249,7 +248,12 @@ function ErtelPotentialVorticity(model; location = (Face, Face, Face), add_backg
         b = model.tracers.b
     end
 
-    coriolis = model.coriolis
+    return ErtelPotentialVorticity(model, u, v, w, b, model.coriolis; location)
+end
+
+function ErtelPotentialVorticity(model, u, v, w, b, coriolis; location = (Face, Face, Face))
+    validate_location(location, "ErtelPotentialVorticity", (Face, Face, Face))
+
     if coriolis isa FPlane
         fx = fy = 0
         fz = model.coriolis.f
@@ -257,8 +261,10 @@ function ErtelPotentialVorticity(model; location = (Face, Face, Face), add_backg
         fx = coriolis.fx
         fy = coriolis.fy
         fz = coriolis.fz
+    elseif coriolis == nothing
+        fx = fy = fz = 0
     else
-        throw(ArgumentError("ErtelPotentialVorticity only implemented for FPlane and ConstantCartesianCoriolis"))
+        throw(ArgumentError("ErtelPotentialVorticity is only implemented for FPlane and ConstantCartesianCoriolis"))
     end
 
     return KernelFunctionOperation{Face, Face, Face}(ertel_potential_vorticity_fff, model.grid,

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -85,6 +85,21 @@ function RichardsonNumber(model; location = (Center, Center, Face), add_backgrou
     return KernelFunctionOperation{Center, Center, Face}(richardson_number_ccf, model.grid,
                                                          u, v, w, b, true_vertical_direction)
 end
+
+
+function RichardsonNumber(model, u, v, w, b; location = (Center, Center, Face))
+    validate_location(location, "RichardsonNumber", (Center, Center, Face))
+
+    if model.buoyancy.gravity_unit_vector isa NegativeZDirection
+        true_vertical_direction = (0, 0, 1)
+    elseif model.buoyancy.gravity_unit_vector isa ZDirection
+        true_vertical_direction = (0, 0, -1)
+    else
+        true_vertical_direction = .-model.buoyancy.gravity_unit_vector
+    end
+    return KernelFunctionOperation{Center, Center, Face}(richardson_number_ccf, model.grid,
+                                                         u, v, w, b, true_vertical_direction)
+end
 #---
 
 #+++ Rossby number

--- a/src/TracerVarianceBudgetTerms.jl
+++ b/src/TracerVarianceBudgetTerms.jl
@@ -3,7 +3,7 @@ using DocStringExtensions
 
 export TracerVarianceDissipationRate, TracerVarianceTendency, TracerVarianceDiffusiveTerm
 
-using Oceanostics: validate_location, validate_dissipative_closure, add_background_fields
+using Oceanostics: validate_location, validate_dissipative_closure
 
 using Oceananigans.Operators
 using Oceananigans.AbstractOperations: KernelFunctionOperation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,6 +102,11 @@ function test_vel_only_diagnostics(model)
     Ro = Field(op)
     @test all(interior(compute!(Ro)) .≈ 0)
 
+    op = RossbyNumber(model, model.velocities..., model.coriolis)
+    @test op isa AbstractOperation
+    Ro = Field(op)
+    @test all(interior(compute!(Ro)) .≈ 0)
+
     op = RossbyNumber(model; dUdy_bg=1, dVdx_bg=1)
     @test op isa AbstractOperation
     Ro = Field(op)
@@ -127,11 +132,22 @@ function test_vel_only_diagnostics(model)
 end
 
 function test_buoyancy_diagnostics(model)
+    u, v, w = model.velocities
+    b = model.tracer.b
+
     Ri = RichardsonNumber(model)
     @test Ri isa AbstractOperation
     @test compute!(Field(Ri)) isa Field
 
+    Ri = RichardsonNumber(model, u, v, w, b)
+    @test Ri isa AbstractOperation
+    @test compute!(Field(Ri)) isa Field
+
     PVe = ErtelPotentialVorticity(model)
+    @test PVe isa AbstractOperation
+    @test compute!(Field(PVe)) isa Field
+
+    PVe = ErtelPotentialVorticity(model, u, v, w, b, model.coriolis)
     @test PVe isa AbstractOperation
     @test compute!(Field(PVe)) isa Field
 
@@ -144,6 +160,10 @@ function test_buoyancy_diagnostics(model)
     @test compute!(Field(PVtw)) isa Field
 
     DEPV = DirectionalErtelPotentialVorticity(model, (0, 0, 1))
+    @test DEPV isa AbstractOperation
+    @test compute!(Field(DEPV)) isa Field
+
+    DEPV = DirectionalErtelPotentialVorticity(model, (0, 0, 1), u, v, w, b, model.coriolis)
     @test DEPV isa AbstractOperation
     @test compute!(Field(DEPV)) isa Field
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,7 +133,7 @@ end
 
 function test_buoyancy_diagnostics(model)
     u, v, w = model.velocities
-    b = model.tracer.b
+    b = model.tracers.b
 
     Ri = RichardsonNumber(model)
     @test Ri isa AbstractOperation


### PR DESCRIPTION
A simple way to allow users to circumvent https://github.com/CliMA/Oceananigans.jl/issues/3140

Closes https://github.com/tomchor/Oceanostics.jl/issues/137

Basically (taking the `RichardsonNumber` as an example) this PR adds an extra function call that returns the desired diagnostic. There's the traditional `model`-only call:

```julia
Ri = RichardsonNumber(model)
```

And now there will be calls where the variables are explicitly passed:

```julia
Ri = RichardsonNumber(model, u, v, w, b)
```

This allows for more control, which allows for simpler abstract trees if the need arises. For example a user can write

```julia
b_bg = (x, y, z, t) -> 1
model = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=:b,
                            background_fields = (; b = BackgroundField(b_bg),))
u, v, w = model.velocities
b = model.tracers.b
B = model.background_fields.tracers.b

using Oceanostics
Ri = RichardsonNumber(model, u, v, w, Field(b+B))
```

which returns a simpler tree than
```julia
Ri = RichardsonNumber(model, add_background=true)
```
but produces same result.