### PR TITLE
Trying out improvements to docs/make.jl

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,8 +3,4 @@ CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
-Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 Rasters = "a3a2b9e3-a471-40c9-b274-f788e487c689"
-
-[compat]
-Oceananigans = "0.80, 0.81, 0.82"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -67,7 +67,7 @@ if CI
                versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
                devbranch = "main",
                push_preview = true,
-               repo_previews = "github.com/tomchor/Oceanostics.jl.git:doc-previews",
+               branch_previews = "doc-previews",
                )
 end
 #---

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,5 @@
+pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..")) # add Oceananigans to environment stack
+
 using Documenter
 using Literate
 using Glob
@@ -65,6 +67,7 @@ if CI
                versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
                devbranch = "main",
                push_preview = true,
+               repo_previews = "doc-previews",
                )
 end
 #---

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -56,7 +56,22 @@ makedocs(sitename = "Oceanostics.jl",
 #---
 
 #+++ Cleanup any output files, e.g., .jld2 or .nc, created by docs. Otherwise they are pushed up in the docs branch in the repo
-for file in vcat(glob("docs/*.jld2"), glob("docs/*.nc"), glob("docs/generated/*.nc"), glob("docs/generated/*.nc"))
+"""
+    recursive_find(directory, pattern)
+
+Return list of filepaths within `directory` that contains the `pattern::Regex`.
+"""
+recursive_find(directory, pattern) =
+    mapreduce(vcat, walkdir(directory)) do (root, dirs, files)
+        joinpath.(root, filter(contains(pattern), files))
+    end
+
+files = []
+for pattern in [r"\.jld2", r"\.nc"]
+    global files = vcat(files, recursive_find(@__DIR__, pattern))
+end
+
+for file in files
     rm(file)
 end
 #---

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -67,7 +67,7 @@ if CI
                versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
                devbranch = "main",
                push_preview = true,
-               repo_previews = "doc-previews",
+               repo_previews = "github.com/tomchor/Oceanostics.jl.git:doc-previews",
                )
 end
 #---

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..")) # add Oceananigans to environment stack
+pushfirst!(LOAD_PATH, joinpath(@__DIR__, "..")) # add Oceanostics environment
 
 using Documenter
 using Literate


### PR DESCRIPTION
This PR tries out a couple of changes in the `docs/make.jl` file:

1. Adds the main project's environment to the docs (this prevents the versions of deps in `Manifest.toml` and `docs/Manifest.toml` from being different, which was happening for Oceananigans)
2. Pushes previews to a different branch, so that hopefully we can still see previews, but cleaning them up will be a matter of deleting the branch