### PR TITLE
Fix bug in `KineticEnergyTendencyTerm`

### DIFF
--- a/src/TKEBudgetTerms.jl
+++ b/src/TKEBudgetTerms.jl
@@ -176,7 +176,9 @@ end
                                           coriolis,
                                           stokes_drift,
                                           closure,
-                                          immersed_bc,
+                                          u_immersed_bc,
+                                          v_immersed_bc,
+                                          w_immersed_bc,
                                           buoyancy,
                                           background_fields,
                                           velocities,
@@ -186,7 +188,7 @@ end
                                           forcing,
                                           pHY′,
                                           clock)
-        u∂ₜu = ℑxᶜᵃᵃ(i, j, k, grid, ψf, velocities.u, u_velocity_tendency, advection, coriolis, stokes_drift, closure, immersed_bc, buoyancy, background_fields,
+        u∂ₜu = ℑxᶜᵃᵃ(i, j, k, grid, ψf, velocities.u, u_velocity_tendency, advection, coriolis, stokes_drift, closure, u_immersed_bc, buoyancy, background_fields,
                                                                            velocities,
                                                                            tracers,
                                                                            auxiliary_fields,
@@ -195,7 +197,7 @@ end
                                                                            pHY′,
                                                                            clock)
 
-        v∂ₜv = ℑyᵃᶜᵃ(i, j, k, grid, ψf, velocities.v, v_velocity_tendency, advection, coriolis, stokes_drift, closure, immersed_bc, buoyancy, background_fields,
+        v∂ₜv = ℑyᵃᶜᵃ(i, j, k, grid, ψf, velocities.v, v_velocity_tendency, advection, coriolis, stokes_drift, closure, v_immersed_bc, buoyancy, background_fields,
                                                                            velocities,
                                                                            tracers,
                                                                            auxiliary_fields,
@@ -204,7 +206,7 @@ end
                                                                            pHY′,
                                                                            clock)
 
-        w∂ₜw = ℑzᵃᵃᶜ(i, j, k, grid, ψf, velocities.w, w_velocity_tendency, advection, coriolis, stokes_drift, closure, immersed_bc, buoyancy, background_fields,
+        w∂ₜw = ℑzᵃᵃᶜ(i, j, k, grid, ψf, velocities.w, w_velocity_tendency, advection, coriolis, stokes_drift, closure, w_immersed_bc, buoyancy, background_fields,
                                                                            velocities,
                                                                            tracers,
                                                                            auxiliary_fields,
@@ -229,7 +231,9 @@ function KineticEnergyTendency(model::NonhydrostaticModel; location = (Center, C
                     model.coriolis,
                     model.stokes_drift,
                     model.closure,
-                    model.velocities.u.boundary_conditions.immersed,
+                    u_immersed_bc = model.velocities.u.boundary_conditions.immersed,
+                    v_immersed_bc = model.velocities.v.boundary_conditions.immersed,
+                    w_immersed_bc = model.velocities.w.boundary_conditions.immersed,
                     model.buoyancy,
                     model.background_fields,
                     model.velocities,


### PR DESCRIPTION
The only  `immersed_bc` passed to the model was the `u` component, thus calculation wasn't being done appropriately for cases where that's important.