### PR TITLE
Add `PotentialEnergy` `KernelFunctionOperation`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ docs/Manifest.toml
 # No netcdf files or videos
 *.nc
 *.mp4
+
+# Mac os stuff
+.DS_STORE

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.2"
+julia_version = "1.10.2"
 manifest_format = "2.0"
-project_hash = "60d4a31d39d98cbbe0bac89cbb91027ae090ab3e"
+project_hash = "bab8eb8385b835035e413ca5e0b68b0c9c732f34"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]
@@ -34,9 +34,9 @@ version = "1.1.1"
 
 [[deps.ArrayInterface]]
 deps = ["Adapt", "LinearAlgebra", "Requires", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "bbec08a37f8722786d87bedf84eae19c020c4efa"
+git-tree-sha1 = "c5aeb516a84459e0318a02507d2261edad97eb75"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "7.7.0"
+version = "7.7.1"
 
     [deps.ArrayInterface.extensions]
     ArrayInterfaceBandedMatricesExt = "BandedMatrices"
@@ -85,9 +85,9 @@ version = "0.5.0"
 
 [[deps.CFTime]]
 deps = ["Dates", "Printf"]
-git-tree-sha1 = "ed2e76c1c3c43fd9d0cb9248674620b29d71f2d1"
+git-tree-sha1 = "5afb5c5ba2688ca43a9ad2e5a91cbb93921ccfa1"
 uuid = "179af706-886a-5703-950a-314cd64e0468"
-version = "0.1.2"
+version = "0.1.3"
 
 [[deps.CUDA]]
 deps = ["AbstractFFTs", "Adapt", "BFloat16s", "CEnum", "CUDA_Driver_jll", "CUDA_Runtime_Discovery", "CUDA_Runtime_jll", "Crayons", "DataFrames", "ExprTools", "GPUArrays", "GPUCompiler", "KernelAbstractions", "LLVM", "LLVMLoopInfo", "LazyArtifacts", "Libdl", "LinearAlgebra", "Logging", "NVTX", "Preferences", "PrettyTables", "Printf", "Random", "Random123", "RandomNumbers", "Reexport", "Requires", "SparseArrays", "Statistics", "UnsafeAtomicsLLVM"]
@@ -141,9 +141,9 @@ version = "0.2.5"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "75bd5b6fc5089df449b5d35fa501c846c9b6549b"
+git-tree-sha1 = "c955881e3c981181362ae4088b35995446298b80"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.12.0"
+version = "4.14.0"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -152,13 +152,13 @@ weakdeps = ["Dates", "LinearAlgebra"]
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.5+0"
+version = "1.1.0+0"
 
 [[deps.ConstructionBase]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "c53fc348ca4d40d7b371e71fd52251839080cbc9"
+git-tree-sha1 = "260fd2400ed2dab602a7c15cf10c1933c59930a2"
 uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
-version = "1.5.4"
+version = "1.5.5"
 
     [deps.ConstructionBase.extensions]
     ConstructionBaseIntervalSetsExt = "IntervalSets"
@@ -175,9 +175,9 @@ version = "4.1.1"
 
 [[deps.CubedSphere]]
 deps = ["Elliptic", "FFTW", "Printf", "ProgressBars", "SpecialFunctions", "TaylorSeries", "Test"]
-git-tree-sha1 = "253193dfb0384646936c5ff3230b27a20d91261e"
+git-tree-sha1 = "10134667d7d3569b191a65801514271b8a93b292"
 uuid = "7445602f-e544-4518-8976-18f8e8ae6cdb"
-version = "0.2.4"
+version = "0.2.5"
 
 [[deps.DataAPI]]
 git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
@@ -192,9 +192,9 @@ version = "1.6.1"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "ac67408d9ddf207de5cfa9a97e114352430f01ed"
+git-tree-sha1 = "0f4b5d62a88d8f59003e43c25a8a90de9eb76317"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.16"
+version = "0.18.18"
 
 [[deps.DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -264,9 +264,9 @@ version = "3.3.10+0"
 
 [[deps.FileIO]]
 deps = ["Pkg", "Requires", "UUIDs"]
-git-tree-sha1 = "c5c28c245101bd59154f649e19b038d15901b5dc"
+git-tree-sha1 = "82d8afa92ecf4b52d78d869f038ebfb881267322"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.16.2"
+version = "1.16.3"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -355,9 +355,9 @@ version = "0.2.2"
 
 [[deps.IterativeSolvers]]
 deps = ["LinearAlgebra", "Printf", "Random", "RecipesBase", "SparseArrays"]
-git-tree-sha1 = "b435d190ef8369cf4d79cc9dd5fba88ba0165307"
+git-tree-sha1 = "59545b0a2b27208b0650df0a46b8e3019f85055b"
 uuid = "42fd0dbc-a981-5370-80f2-aaf504508153"
-version = "0.9.3"
+version = "0.9.4"
 
 [[deps.IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
@@ -366,9 +366,9 @@ version = "1.0.0"
 
 [[deps.JLD2]]
 deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "Pkg", "PrecompileTools", "Printf", "Reexport", "Requires", "TranscodingStreams", "UUIDs"]
-git-tree-sha1 = "7c0008f0b7622c6c0ee5c65cbc667b69f8a65672"
+git-tree-sha1 = "5ea6acdd53a51d897672edb694e3cc2912f3f8a7"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.45"
+version = "0.4.46"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
@@ -396,9 +396,9 @@ version = "0.2.1+0"
 
 [[deps.KernelAbstractions]]
 deps = ["Adapt", "Atomix", "InteractiveUtils", "LinearAlgebra", "MacroTools", "PrecompileTools", "Requires", "SparseArrays", "StaticArrays", "UUIDs", "UnsafeAtomics", "UnsafeAtomicsLLVM"]
-git-tree-sha1 = "4e0cb2f5aad44dcfdc91088e85dee4ecb22c791c"
+git-tree-sha1 = "ed7167240f40e62d97c1f5f7735dea6de3cc5c49"
 uuid = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-version = "0.9.16"
+version = "0.9.18"
 
     [deps.KernelAbstractions.extensions]
     EnzymeExt = "EnzymeCore"
@@ -408,9 +408,9 @@ version = "0.9.16"
 
 [[deps.LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Preferences", "Printf", "Requires", "Unicode"]
-git-tree-sha1 = "cb4619f7353fc62a1a22ffa3d7ed9791cfb47ad8"
+git-tree-sha1 = "ab01dde107f21aa76144d0771dccc08f152ccac7"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "6.4.2"
+version = "6.6.2"
 weakdeps = ["BFloat16s"]
 
     [deps.LLVM.extensions]
@@ -418,9 +418,9 @@ weakdeps = ["BFloat16s"]
 
 [[deps.LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
-git-tree-sha1 = "98eaee04d96d973e79c25d49167668c5c8fb50e2"
+git-tree-sha1 = "88b916503aac4fb7f701bb625cd84ca5dd1677bc"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.27+1"
+version = "0.0.29+0"
 
 [[deps.LLVMLoopInfo]]
 git-tree-sha1 = "2e5c102cfc41f48ae4740c7eca7743cc7e7b75ea"
@@ -454,21 +454,26 @@ uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-version = "0.6.3"
+version = "0.6.4"
 
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "7.84.0+0"
+version = "8.4.0+0"
 
 [[deps.LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.10.2+0"
+version = "1.11.0+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -485,9 +490,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "7d6dd4e9212aebaeed356de34ccf262a3cd415aa"
+git-tree-sha1 = "18144f3e9cbe9b15b070288eef858f71b291ce37"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.26"
+version = "0.3.27"
 
     [deps.LogExpFunctions.extensions]
     LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -523,10 +528,10 @@ version = "0.20.16"
     CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [[deps.MPICH_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
-git-tree-sha1 = "2ee75365ca243c1a39d467e35ffd3d4d32eef11e"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "656036b9ed6f942d35e536e249600bc31d0f9df8"
 uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
-version = "4.1.2+1"
+version = "4.2.0+0"
 
 [[deps.MPIPreferences]]
 deps = ["Libdl", "Preferences"]
@@ -535,10 +540,10 @@ uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 version = "0.1.10"
 
 [[deps.MPItrampoline_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
-git-tree-sha1 = "8eeb3c73bbc0ca203d0dc8dad4008350bbe5797b"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "77c3bd69fdb024d75af38713e883d0f249ce19c2"
 uuid = "f1f71cc9-e9ae-5b93-9b94-4fe0e1ad3748"
-version = "5.3.1+1"
+version = "5.3.2+0"
 
 [[deps.MacroTools]]
 deps = ["Markdown", "Random"]
@@ -553,13 +558,13 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+0"
+version = "2.28.2+1"
 
 [[deps.MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "b01beb91d20b0d1312a9471a36017b5b339d26de"
+git-tree-sha1 = "f12a29c4400ba812841c6ace3f4efbb6dbb3ba01"
 uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
-version = "10.1.4+1"
+version = "10.1.4+2"
 
 [[deps.Missings]]
 deps = ["DataAPI"]
@@ -572,7 +577,7 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.10.11"
+version = "2023.1.10"
 
 [[deps.NCDatasets]]
 deps = ["CFTime", "CommonDataModel", "DataStructures", "Dates", "DiskArrays", "NetCDF_jll", "NetworkOptions", "Printf"]
@@ -626,18 +631,18 @@ weakdeps = ["Adapt"]
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.21+4"
+version = "0.3.23+4"
 
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
-version = "0.8.1+0"
+version = "0.8.1+2"
 
 [[deps.OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "PMIx_jll", "TOML", "Zlib_jll", "libevent_jll", "prrte_jll"]
-git-tree-sha1 = "1d1421618bab0e820bdc7ae1a2b46ce576981273"
+git-tree-sha1 = "f46caf663e069027a06942d00dced37f1eb3d8ad"
 uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
-version = "5.0.1+0"
+version = "5.0.2+0"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -697,7 +702,7 @@ version = "0.15.1"
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.9.2"
+version = "1.10.0"
 
 [[deps.PkgVersion]]
 deps = ["Pkg"]
@@ -713,15 +718,15 @@ version = "1.4.3"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.2.0"
+version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.1"
+version = "1.4.3"
 
 [[deps.PrettyTables]]
 deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "Reexport", "StringManipulation", "Tables"]
@@ -750,14 +755,14 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.Random123]]
 deps = ["Random", "RandomNumbers"]
-git-tree-sha1 = "c860e84651f58ce240dd79e5d9e055d55234c35a"
+git-tree-sha1 = "4743b43e5a9c4a2ede372de7061eed81795b12e7"
 uuid = "74087812-796a-5b5d-8853-05524746bad3"
-version = "1.6.2"
+version = "1.7.0"
 
 [[deps.RandomNumbers]]
 deps = ["Random", "Requires"]
@@ -790,9 +795,13 @@ version = "1.3.0"
 
 [[deps.Rotations]]
 deps = ["LinearAlgebra", "Quaternions", "Random", "StaticArrays"]
-git-tree-sha1 = "1867f44fb5fbeb6ef544ea2b1a8e22882058d30b"
+git-tree-sha1 = "2a0a5d8569f481ff8840e3b7c84bbf188db6a3fe"
 uuid = "6038ab10-8711-5258-84ad-4b1120ba62dc"
-version = "1.6.2"
+version = "1.7.0"
+weakdeps = ["RecipesBase"]
+
+    [deps.Rotations.extensions]
+    RotationsRecipesBaseExt = "RecipesBase"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -830,6 +839,7 @@ version = "1.2.1"
 [[deps.SparseArrays]]
 deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.10.0"
 
 [[deps.SpecialFunctions]]
 deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
@@ -845,9 +855,9 @@ version = "2.3.1"
 
 [[deps.Static]]
 deps = ["IfElse"]
-git-tree-sha1 = "f295e0a1da4ca425659c57441bcb59abb035a4bc"
+git-tree-sha1 = "d2fdac9ff3906e27f7a618d47b676941baa6c80c"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "0.8.8"
+version = "0.8.10"
 
 [[deps.StaticArrayInterface]]
 deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "Requires", "SparseArrays", "Static", "SuiteSparse"]
@@ -862,9 +872,9 @@ weakdeps = ["OffsetArrays", "StaticArrays"]
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
-git-tree-sha1 = "7b0e9c14c624e435076d19aea1e5cbdec2b9ca37"
+git-tree-sha1 = "bf074c045d3d5ffd956fa0a461da38a44685d6b2"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.2"
+version = "1.9.3"
 
     [deps.StaticArrays.extensions]
     StaticArraysChainRulesCoreExt = "ChainRulesCore"
@@ -887,7 +897,7 @@ version = "0.3.0"
 [[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-version = "1.9.0"
+version = "1.10.0"
 
 [[deps.StatsAPI]]
 deps = ["LinearAlgebra"]
@@ -918,10 +928,17 @@ uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
 version = "0.3.4"
 
 [[deps.StructArrays]]
-deps = ["Adapt", "ConstructionBase", "DataAPI", "GPUArraysCore", "StaticArraysCore", "Tables"]
-git-tree-sha1 = "1b0b1205a56dc288b71b1961d48e351520702e24"
+deps = ["ConstructionBase", "DataAPI", "Tables"]
+git-tree-sha1 = "f4dc295e983502292c4c3f951dbb4e985e35b3be"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.17"
+version = "0.6.18"
+weakdeps = ["Adapt", "GPUArraysCore", "SparseArrays", "StaticArrays"]
+
+    [deps.StructArrays.extensions]
+    StructArraysAdaptExt = "Adapt"
+    StructArraysGPUArraysCoreExt = "GPUArraysCore"
+    StructArraysSparseArraysExt = "SparseArrays"
+    StructArraysStaticArraysExt = "StaticArrays"
 
 [[deps.StructTypes]]
 deps = ["Dates", "UUIDs"]
@@ -934,9 +951,9 @@ deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
 uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[deps.SuiteSparse_jll]]
-deps = ["Artifacts", "Libdl", "Pkg", "libblastrampoline_jll"]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
 uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
-version = "5.10.1+6"
+version = "7.2.1+1"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -962,9 +979,9 @@ version = "1.10.0"
 
 [[deps.TaylorSeries]]
 deps = ["LinearAlgebra", "Markdown", "Requires", "SparseArrays"]
-git-tree-sha1 = "9138fdc8ee4e3b8839eca696a76d15e16c9c7af0"
+git-tree-sha1 = "1c7170668366821b0c4c4fe03ee78f8d6cf36e2c"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
-version = "0.15.4"
+version = "0.16.0"
 
     [deps.TaylorSeries.extensions]
     TaylorSeriesIAExt = "IntervalArithmetic"
@@ -983,18 +1000,18 @@ uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 version = "0.5.23"
 
 [[deps.TranscodingStreams]]
-git-tree-sha1 = "54194d92959d8ebaa8e26227dbe3cdefcdcd594f"
+git-tree-sha1 = "a09c933bebed12501890d8e92946bbab6a1690f1"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.10.3"
+version = "0.10.5"
 weakdeps = ["Random", "Test"]
 
     [deps.TranscodingStreams.extensions]
     TestExt = ["Test", "Random"]
 
 [[deps.TupleTools]]
-git-tree-sha1 = "155515ed4c4236db30049ac1495e2969cc06be9d"
+git-tree-sha1 = "41d61b1c545b06279871ef1a4b5fcb2cac2191cd"
 uuid = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
-version = "1.4.3"
+version = "1.5.0"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -1021,14 +1038,14 @@ version = "1.3.0"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
-git-tree-sha1 = "801cbe47eae69adc50f36c3caec4758d2650741b"
+git-tree-sha1 = "07e470dabc5a6a4254ffebc29a1b3fc01464e105"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.12.2+0"
+version = "2.12.5+0"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+0"
+version = "1.2.13+1"
 
 [[deps.Zstd_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1038,14 +1055,14 @@ version = "1.5.5+0"
 
 [[deps.libaec_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "eddd19a8dea6b139ea97bdc8a0e2667d4b661720"
+git-tree-sha1 = "46bf7be2917b59b761247be3f317ddf75e50e997"
 uuid = "477f73a3-ac25-53e9-8cc3-50b2fa2566f0"
-version = "1.0.6+1"
+version = "1.1.2+0"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.8.0+0"
+version = "5.8.0+1"
 
 [[deps.libevent_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll"]
@@ -1056,12 +1073,12 @@ version = "2.1.13+1"
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.48.0+0"
+version = "1.52.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+0"
+version = "17.4.0+2"
 
 [[deps.prrte_jll]]
 deps = ["Artifacts", "Hwloc_jll", "JLLWrappers", "Libdl", "PMIx_jll", "libevent_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,12 @@ version = "0.14.0"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 
 [compat]
 DocStringExtensions = "0.9"
-Oceananigans = "0.85, 0.86, 0.87, 0.88, 0.89, 0.90"
+Oceananigans = "0.89, 0.90"
+SeawaterPolynomials = "0.3"
 julia = "1.9"
 
 [extras]

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -30,3 +30,10 @@ Private = false
 Modules = [Oceanostics.FlowDiagnostics]
 Private = false
 ```
+
+## Oceanostics.DensityEquationTerms
+
+```@autodocs
+Modules = [Oceanostics.DensityEquationTerms]
+Private = false
+```

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -31,9 +31,9 @@ Modules = [Oceanostics.FlowDiagnostics]
 Private = false
 ```
 
-## Oceanostics.DensityEquationTerms
+## Oceanostics.PotentialEnergyEquationTerms
 
 ```@autodocs
-Modules = [Oceanostics.DensityEquationTerms]
+Modules = [Oceanostics.PotentialEnergyEquationTerms]
 Private = false
 ```

--- a/src/DensityEquationTerms.jl
+++ b/src/DensityEquationTerms.jl
@@ -1,0 +1,120 @@
+module DensityEquationTerms
+
+using DocStringExtensions
+
+export GravitationalPotentialEnergy
+
+using Oceananigans.AbstractOperations: KernelFunctionOperation
+using Oceananigans: Models.seawater_density
+using Oceananigans: Models.model_geopotential_height
+using Oceananigans.Grids: Center, Face
+using Oceanostics: validate_location, validate_buoyancy
+
+
+"""
+    $(SIGNATURES)
+
+Return a `KernelFunctionOperation` to compute the`GravitationalPotentialEnergy`, `Eₚ = gρz`,
+at each grid `location` in `model`.
+**NOTE:** A `BoussinesqEquationOfState` must be used in the `model` to calculate
+`seawater_density`. See the [relevant documentation](https://clima.github.io/OceananigansDocumentation/dev/model_setup/buoyancy_and_equation_of_state/#Idealized-nonlinear-equations-of-state)
+for how to set `SeawaterBuoyancy` using a `BoussinesqEquationOfState`.
+
+Example
+=======
+
+By passing only the `model` to the function, the in-situ density is used in the calculation:
+```jldoctest
+julia> using Oceananigans, SeawaterPolynomials.TEOS10
+
+julia> using Oceanostics.DensityEquationTerms: GravitationalPotentialEnergy
+
+julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded))
+1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+├── Flat x
+├── Flat y
+└── Bounded  z ∈ [-1000.0, 0.0]   regularly spaced with Δz=10.0
+
+julia> tracers = (:T, :S)
+(:T, :S)
+
+julia> eos = TEOS10EquationOfState()
+BoussinesqEquationOfState{Float64}:
+    ├── seawater_polynomial: TEOS10SeawaterPolynomial{Float64}
+    └── reference_density: 1020.0
+
+julia> buoyancy = SeawaterBuoyancy(equation_of_state=eos)
+SeawaterBuoyancy{Float64}:
+├── gravitational_acceleration: 9.80665
+└── equation_of_state: BoussinesqEquationOfState{Float64}
+
+julia> model = NonhydrostaticModel(; grid, buoyancy, tracers)
+NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
+├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+├── timestepper: QuasiAdamsBashforth2TimeStepper
+├── tracers: (T, S)
+├── closure: Nothing
+├── buoyancy: SeawaterBuoyancy with g=9.80665 and BoussinesqEquationOfState{Float64} with ĝ = NegativeZDirection()
+└── coriolis: Nothing
+
+julia> GravitationalPotentialEnergy(model)
+KernelFunctionOperation at (Center, Center, Center)
+├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+├── kernel_function: gravitational_potential_energy_ccc (generic function with 1 method)
+└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "Tuple{Float64}")
+```
+
+To use a reference density pass the argument `reference_geopotential_height` to
+`GravitationalPotentialEnergy`:
+```jldoctest
+julia> using Oceananigans, SeawaterPolynomials.TEOS10
+
+julia> using Oceanostics.DensityEquationTerms: GravitationalPotentialEnergy
+
+julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded));
+
+julia> tracers = (:T, :S);
+
+julia> eos = TEOS10EquationOfState();
+
+julia> buoyancy = SeawaterBuoyancy(equation_of_state=eos);
+
+julia> model = NonhydrostaticModel(; grid, buoyancy, tracers);
+
+julia> reference_geopotential_height = 0; # density variable will be σ₀
+
+julia> GravitationalPotentialEnergy(model, reference_geopotential_height)
+KernelFunctionOperation at (Center, Center, Center)
+├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+├── kernel_function: gravitational_potential_energy_ccc (generic function with 1 method)
+└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "Tuple{Float64}")
+```
+"""
+@inline function GravitationalPotentialEnergy(model; location = (Center, Center, Center))
+
+    validate_location(location, "GravitationalPotentialEnergy")
+    validate_buoyancy(model.buoyancy)
+
+    grid = model.grid
+    ρ = seawater_density(model) # in-situ model density
+    Z = model_geopotential_height(model)
+    g = tuple(model.buoyancy.model.gravitational_acceleration)
+
+    return KernelFunctionOperation{Center, Center, Center}(gravitational_potential_energy_ccc, grid, ρ, Z, g)
+end
+@inline function GravitationalPotentialEnergy(model, reference_geopotential_height; location = (Center, Center, Center))
+
+    validate_location(location, "GravitationalPotentialEnergy")
+    validate_buoyancy(model.buoyancy)
+
+    grid = model.grid
+    σ = seawater_density(model, geopotential_height = reference_geopotential_height) # potential density reference to `reference_geopotential_height`
+    Z = model_geopotential_height(model)
+    g = tuple(model.buoyancy.model.gravitational_acceleration)
+
+    return KernelFunctionOperation{Center, Center, Center}(gravitational_potential_energy_ccc, grid, σ, Z, g)
+end
+
+@inline gravitational_potential_energy_ccc(i, j, k, grid, density, Z, g) = g[1] * density[i, j, k] * Z[i, j, k]
+
+end # module

--- a/src/DensityEquationTerms.jl
+++ b/src/DensityEquationTerms.jl
@@ -67,9 +67,9 @@ KernelFunctionOperation at (Center, Center, Center)
 To use a reference density pass the argument `reference_geopotential_height` to
 `GravitationalPotentialEnergy`:
 ```jldoctest
-julia> using Oceananigans, SeawaterPolynomials.TEOS10
+julia> using Oceananigans, SeawaterPolynomials.TEOS10;
 
-julia> using Oceanostics.DensityEquationTerms: GravitationalPotentialEnergy
+julia> using Oceanostics.DensityEquationTerms: GravitationalPotentialEnergy;
 
 julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded));
 

--- a/src/DensityEquationTerms.jl
+++ b/src/DensityEquationTerms.jl
@@ -2,7 +2,7 @@ module DensityEquationTerms
 
 using DocStringExtensions
 
-export GravitationalPotentialEnergy
+export PotentialEnergy
 
 using Oceananigans.AbstractOperations: KernelFunctionOperation
 using Oceananigans: Models.seawater_density
@@ -14,7 +14,7 @@ using Oceanostics: validate_location, validate_buoyancy
 """
     $(SIGNATURES)
 
-Return a `KernelFunctionOperation` to compute the`GravitationalPotentialEnergy`, `Eₚ = gρz`,
+Return a `KernelFunctionOperation` to compute the`PotentialEnergy`, `Eₚ = gρz`,
 at each grid `location` in `model`.
 **NOTE:** A `BoussinesqEquationOfState` must be used in the `model` to calculate
 `seawater_density`. See the [relevant documentation](https://clima.github.io/OceananigansDocumentation/dev/model_setup/buoyancy_and_equation_of_state/#Idealized-nonlinear-equations-of-state)
@@ -27,7 +27,7 @@ By passing only the `model` to the function, the in-situ density is used in the 
 ```jldoctest
 julia> using Oceananigans, SeawaterPolynomials.TEOS10
 
-julia> using Oceanostics.DensityEquationTerms: GravitationalPotentialEnergy
+julia> using Oceanostics.DensityEquationTerms: PotentialEnergy
 
 julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded))
 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
@@ -57,19 +57,19 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 ├── buoyancy: SeawaterBuoyancy with g=9.80665 and BoussinesqEquationOfState{Float64} with ĝ = NegativeZDirection()
 └── coriolis: Nothing
 
-julia> GravitationalPotentialEnergy(model)
+julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── kernel_function: gravitational_potential_energy_ccc (generic function with 1 method)
+├── kernel_function: gρz_ccc (generic function with 1 method)
 └── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "Tuple{Float64}")
 ```
 
 To use a reference density pass the argument `reference_geopotential_height` to
-`GravitationalPotentialEnergy`:
+`PotentialEnergy`:
 ```jldoctest
 julia> using Oceananigans, SeawaterPolynomials.TEOS10;
 
-julia> using Oceanostics.DensityEquationTerms: GravitationalPotentialEnergy;
+julia> using Oceanostics.DensityEquationTerms: PotentialEnergy;
 
 julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded));
 
@@ -83,38 +83,38 @@ julia> model = NonhydrostaticModel(; grid, buoyancy, tracers);
 
 julia> reference_geopotential_height = 0; # density variable will be σ₀
 
-julia> GravitationalPotentialEnergy(model, reference_geopotential_height)
+julia> PotentialEnergy(model, reference_geopotential_height)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── kernel_function: gravitational_potential_energy_ccc (generic function with 1 method)
+├── kernel_function: gρz_ccc (generic function with 1 method)
 └── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "Tuple{Float64}")
 ```
 """
-@inline function GravitationalPotentialEnergy(model; location = (Center, Center, Center))
+@inline function PotentialEnergy(model; location = (Center, Center, Center))
 
-    validate_location(location, "GravitationalPotentialEnergy")
+    validate_location(location, "PotentialEnergy")
     validate_buoyancy(model.buoyancy)
 
     grid = model.grid
     ρ = seawater_density(model) # in-situ model density
     Z = model_geopotential_height(model)
-    g = tuple(model.buoyancy.model.gravitational_acceleration)
+    parameters = (g = model.buoyancy.model.gravitational_acceleration,)
 
-    return KernelFunctionOperation{Center, Center, Center}(gravitational_potential_energy_ccc, grid, ρ, Z, g)
+    return KernelFunctionOperation{Center, Center, Center}(gρz_ccc, grid, ρ, Z, parameters)
 end
-@inline function GravitationalPotentialEnergy(model, reference_geopotential_height; location = (Center, Center, Center))
+@inline function PotentialEnergy(model, reference_geopotential_height; location = (Center, Center, Center))
 
-    validate_location(location, "GravitationalPotentialEnergy")
+    validate_location(location, "PotentialEnergy")
     validate_buoyancy(model.buoyancy)
 
     grid = model.grid
     σ = seawater_density(model, geopotential_height = reference_geopotential_height) # potential density reference to `reference_geopotential_height`
     Z = model_geopotential_height(model)
-    g = tuple(model.buoyancy.model.gravitational_acceleration)
+    parameters = (g = model.buoyancy.model.gravitational_acceleration,)
 
-    return KernelFunctionOperation{Center, Center, Center}(gravitational_potential_energy_ccc, grid, σ, Z, g)
+    return KernelFunctionOperation{Center, Center, Center}(gρz_ccc, grid, σ, Z, parameters)
 end
 
-@inline gravitational_potential_energy_ccc(i, j, k, grid, density, Z, g) = g[1] * density[i, j, k] * Z[i, j, k]
+@inline gρz_ccc(i, j, k, grid, density, Z, p) = p.g * density[i, j, k] * Z[i, j, k]
 
 end # module

--- a/src/DensityEquationTerms.jl
+++ b/src/DensityEquationTerms.jl
@@ -61,7 +61,7 @@ julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: gρz_ccc (generic function with 1 method)
-└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "Tuple{Float64}")
+└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665,)")
 ```
 
 To use a reference density pass the argument `reference_geopotential_height` to
@@ -87,7 +87,7 @@ julia> PotentialEnergy(model, reference_geopotential_height)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: gρz_ccc (generic function with 1 method)
-└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "Tuple{Float64}")
+└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665,)")
 ```
 """
 @inline function PotentialEnergy(model; location = (Center, Center, Center))

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -22,6 +22,10 @@ export DirectionalErtelPotentialVorticity
 export StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
 #---
 
+#+++ DensityEquationTerms exports
+export GravitationalPotentialEnergy
+#---
+
 #+++ ProgressMessengers
 export ProgressMessengers
 #---
@@ -29,6 +33,8 @@ export ProgressMessengers
 #+++ Utils for validation
 # Right now, all kernels must be located at ccc
 using Oceananigans.TurbulenceClosures: AbstractScalarDiffusivity, ThreeDimensionalFormulation
+using Oceananigans.BuoyancyModels: Buoyancy, BuoyancyTracer, SeawaterBuoyancy, LinearEquationOfState
+using SeawaterPolynomials: BoussinesqEquationOfState
 using Oceananigans.Grids: Center, Face
 
 validate_location(location, type, valid_location=(Center, Center, Center)) =
@@ -38,6 +44,14 @@ validate_location(location, type, valid_location=(Center, Center, Center)) =
 validate_dissipative_closure(closure) = error("Cannot calculate dissipation rate for $closure")
 validate_dissipative_closure(::AbstractScalarDiffusivity{<:Any, ThreeDimensionalFormulation}) = nothing
 validate_dissipative_closure(closure_tuple::Tuple) = Tuple(validate_dissipative_closure(c) for c in closure_tuple)
+
+validate_buoyancy(buoyancy::Nothing) = throw(ArgumentError("Cannot calculate gravitational potential energy without a buoyancy model."))
+validate_buoyancy(buoyancy::Buoyancy{<:BuoyancyTracer, g}) where g =
+    throw(ArgumentError("Cannot calculate gravitational potential energy for the buoyancy model $(buoyancy.model)."))
+validate_buoyancy(buoyancy::Buoyancy{<:SeawaterBuoyancy{FT, <:LinearEquationOfState, T, S}, g}) where {FT, T, S, g} =
+    throw(ArgumentError("To calculate gravitational potential energy with a linear equation of state use a linear `BoussinesqEquationOfState`."))
+validate_buoyancy(buoyancy::Buoyancy{<:SeawaterBuoyancy{FT, <:BoussinesqEquationOfState, T, S}, g}) where {FT, T, S, g} = nothing
+
 #---
 
 #+++ Utils for background fields
@@ -51,15 +65,15 @@ function add_background_fields(model)
 
     velocities = model.velocities
     # Adds background velocities to their perturbations only if background velocity isn't ZeroField
-    full_velocities = NamedTuple{keys(velocities)}((model.background_fields.velocities[key] isa ZeroField) ? 
-                                                   val : 
-                                                   val + model.background_fields.velocities[key] 
+    full_velocities = NamedTuple{keys(velocities)}((model.background_fields.velocities[key] isa ZeroField) ?
+                                                   val :
+                                                   val + model.background_fields.velocities[key]
                                                    for (key,val) in zip(keys(velocities), velocities))
     tracers = model.tracers
     # Adds background tracer fields to their perturbations only if background tracer field isn't ZeroField
-    full_tracers = NamedTuple{keys(tracers)}((model.background_fields.tracers[key] isa ZeroField) ? 
-                                              val : 
-                                              val + model.background_fields.tracers[key] 
+    full_tracers = NamedTuple{keys(tracers)}((model.background_fields.tracers[key] isa ZeroField) ?
+                                              val :
+                                              val + model.background_fields.tracers[key]
                                               for (key,val) in zip(keys(tracers), tracers))
 
     return merge(full_velocities, full_tracers)
@@ -76,15 +90,17 @@ using Oceananigans.TurbulenceClosures: νᶜᶜᶜ
 @inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple{}, K::Tuple{}, clock) = zero(grid)
 
 # Unroll the loop over a tuple
-@inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple, K::Tuple, clock) = νᶜᶜᶜ(i, j, k, grid, closure_tuple[1],     K[1],     clock) + 
+@inline _νᶜᶜᶜ(i, j, k, grid, closure_tuple::Tuple, K::Tuple, clock) = νᶜᶜᶜ(i, j, k, grid, closure_tuple[1],     K[1],     clock) +
                                                                      _νᶜᶜᶜ(i, j, k, grid, closure_tuple[2:end], K[2:end], clock)
 #---
 
 include("TKEBudgetTerms.jl")
 include("TracerVarianceBudgetTerms.jl")
 include("FlowDiagnostics.jl")
+include("DensityEquationTerms.jl")
 include("ProgressMessengers/ProgressMessengers.jl")
 
 using .TKEBudgetTerms, .TracerVarianceBudgetTerms, .FlowDiagnostics, .ProgressMessengers
+using .DensityEquationTerms
 
 end # module

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -23,7 +23,7 @@ export StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTens
 #---
 
 #+++ DensityEquationTerms exports
-export GravitationalPotentialEnergy
+export PotentialEnergy
 #---
 
 #+++ ProgressMessengers

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -22,7 +22,7 @@ export DirectionalErtelPotentialVorticity
 export StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
 #---
 
-#+++ DensityEquationTerms exports
+#+++ PotentialEnergyEquationTerms exports
 export PotentialEnergy
 #---
 
@@ -97,10 +97,10 @@ using Oceananigans.TurbulenceClosures: νᶜᶜᶜ
 include("TKEBudgetTerms.jl")
 include("TracerVarianceBudgetTerms.jl")
 include("FlowDiagnostics.jl")
-include("DensityEquationTerms.jl")
+include("PotentialEnergyEquationTerms.jl")
 include("ProgressMessengers/ProgressMessengers.jl")
 
 using .TKEBudgetTerms, .TracerVarianceBudgetTerms, .FlowDiagnostics, .ProgressMessengers
-using .DensityEquationTerms
+using .PotentialEnergyEquationTerms
 
 end # module

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -64,7 +64,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── kernel_function: gρz_ccc (generic function with 1 method)
+├── kernel_function: g′z_ccc (generic function with 1 method)
 └── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665, ρ₀=1020.0)")
 ```
 
@@ -90,7 +90,7 @@ julia> geopotential_height = 0; # density variable will be σ₀
 julia> PotentialEnergy(model; geopotential_height)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── kernel_function: gρz_ccc (generic function with 1 method)
+├── kernel_function: g′z_ccc (generic function with 1 method)
 └── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665, ρ₀=1020.0)")
 ```
 """
@@ -105,9 +105,9 @@ KernelFunctionOperation at (Center, Center, Center)
     parameters = (g = model.buoyancy.model.gravitational_acceleration,
                   ρ₀ = model.buoyancy.model.equation_of_state.reference_density)
 
-    return KernelFunctionOperation{Center, Center, Center}(gρz_ccc, grid, ρ, Z, parameters)
+    return KernelFunctionOperation{Center, Center, Center}(g′z_ccc, grid, ρ, Z, parameters)
 end
 
-@inline gρz_ccc(i, j, k, grid, ρ, Z, p) = (p.g / p.ρ₀) * ρ[i, j, k] * Z[i, j, k]
+@inline g′z_ccc(i, j, k, grid, ρ, Z, p) = (p.g / p.ρ₀) * ρ[i, j, k] * Z[i, j, k]
 
 end # module

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -65,7 +65,7 @@ julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: gρz_ccc (generic function with 1 method)
-└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665,)")
+└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665, ρ₀=1020.0)")
 ```
 
 To use a reference density set a constant value for the keyword argument `geopotential_height`
@@ -91,7 +91,7 @@ julia> PotentialEnergy(model; geopotential_height)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: gρz_ccc (generic function with 1 method)
-└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665,)")
+└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665, ρ₀=1020.0)")
 ```
 """
 @inline function PotentialEnergy(model; geopotential_height = model_geopotential_height(model), location = (Center, Center, Center))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -360,100 +360,100 @@ end
 #---
 
 #+++ Known-value function tests
-# function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), α=1)
-#     model = model_type(; grid, closure)
-#     u₀(x, y, z) = +α*x
-#     v₀(x, y, z) = -α*y
-#     set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
+function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), α=1)
+    model = model_type(; grid, closure)
+    u₀(x, y, z) = +α*x
+    v₀(x, y, z) = -α*y
+    set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
 
-#     u, v, w = model.velocities
+    u, v, w = model.velocities
 
-#     @compute ε = Field(KineticEnergyDissipationRate(model))
-#     @compute S = Field(StrainRateTensorModulus(model))
-#     @compute Ω = Field(VorticityTensorModulus(model))
-#     @compute q = Field(QVelocityGradientTensorInvariant(model))
+    @compute ε = Field(KineticEnergyDissipationRate(model))
+    @compute S = Field(StrainRateTensorModulus(model))
+    @compute Ω = Field(VorticityTensorModulus(model))
+    @compute q = Field(QVelocityGradientTensorInvariant(model))
 
-#     idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
+    idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
 
-#     if model.closure isa Tuple
-#         @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
-#     else
-#         ν_field = viscosity(model.closure, model.diffusivity_fields)
-#     end
+    if model.closure isa Tuple
+        @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
+    else
+        ν_field = viscosity(model.closure, model.diffusivity_fields)
+    end
 
-#     CUDA.@allowscalar begin
-#         ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
+    CUDA.@allowscalar begin
+        ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
 
-#         @test getindex(S, idxs...) ≈ √2*α
-#         @test getindex(Ω, idxs...) ≈ 0
-#         @test getindex(q, idxs...) ≈ (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2 ≈ -α^2
-#         @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2
-#     end
+        @test getindex(S, idxs...) ≈ √2*α
+        @test getindex(Ω, idxs...) ≈ 0
+        @test getindex(q, idxs...) ≈ (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2 ≈ -α^2
+        @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2
+    end
 
-#     return nothing
-# end
+    return nothing
+end
 
-# function test_solid_body_rotation_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), ζ=1)
-#     model = model_type(; grid, closure)
-#     u₀(x, y, z) = +ζ*y / 2
-#     v₀(x, y, z) = -ζ*x / 2
-#     set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
+function test_solid_body_rotation_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), ζ=1)
+    model = model_type(; grid, closure)
+    u₀(x, y, z) = +ζ*y / 2
+    v₀(x, y, z) = -ζ*x / 2
+    set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
 
-#     u, v, w = model.velocities
+    u, v, w = model.velocities
 
-#     @compute ε = Field(KineticEnergyDissipationRate(model))
-#     @compute S = Field(StrainRateTensorModulus(model))
-#     @compute Ω = Field(VorticityTensorModulus(model))
-#     @compute q = Field(QVelocityGradientTensorInvariant(model))
+    @compute ε = Field(KineticEnergyDissipationRate(model))
+    @compute S = Field(StrainRateTensorModulus(model))
+    @compute Ω = Field(VorticityTensorModulus(model))
+    @compute q = Field(QVelocityGradientTensorInvariant(model))
 
-#     idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
+    idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
 
-#     if model.closure isa Tuple
-#         @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
-#     else
-#         ν_field = viscosity(model.closure, model.diffusivity_fields)
-#     end
+    if model.closure isa Tuple
+        @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
+    else
+        ν_field = viscosity(model.closure, model.diffusivity_fields)
+    end
 
-#     CUDA.@allowscalar begin
-#         ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
+    CUDA.@allowscalar begin
+        ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
 
-#         @test getindex(S, idxs...) ≈ 0
-#         @test getindex(Ω, idxs...) ≈ ζ/√2
-#         @test getindex(q, idxs...) ≈ (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2 ≈ ζ^2/4
-#         @test getindex(ε, idxs...) ≈ 0
-#     end
-# end
+        @test getindex(S, idxs...) ≈ 0
+        @test getindex(Ω, idxs...) ≈ ζ/√2
+        @test getindex(q, idxs...) ≈ (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2 ≈ ζ^2/4
+        @test getindex(ε, idxs...) ≈ 0
+    end
+end
 
-# function test_uniform_shear_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), σ=1)
-#     model = model_type(; grid, closure)
-#     u₀(x, y, z) = +σ * y
-#     set!(model, u=u₀, v=0, w=0, enforce_incompressibility=false)
+function test_uniform_shear_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), σ=1)
+    model = model_type(; grid, closure)
+    u₀(x, y, z) = +σ * y
+    set!(model, u=u₀, v=0, w=0, enforce_incompressibility=false)
 
-#     u, v, w = model.velocities
+    u, v, w = model.velocities
 
-#     @compute ε = Field(KineticEnergyDissipationRate(model))
-#     @compute S = Field(StrainRateTensorModulus(model))
-#     @compute Ω = Field(VorticityTensorModulus(model))
-#     @compute q = Field(QVelocityGradientTensorInvariant(model))
+    @compute ε = Field(KineticEnergyDissipationRate(model))
+    @compute S = Field(StrainRateTensorModulus(model))
+    @compute Ω = Field(VorticityTensorModulus(model))
+    @compute q = Field(QVelocityGradientTensorInvariant(model))
 
-#     idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
+    idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
 
-#     if model.closure isa Tuple
-#         @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
-#     else
-#         ν_field = viscosity(model.closure, model.diffusivity_fields)
-#     end
+    if model.closure isa Tuple
+        @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
+    else
+        ν_field = viscosity(model.closure, model.diffusivity_fields)
+    end
 
-#     CUDA.@allowscalar begin
-#         ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
+    CUDA.@allowscalar begin
+        ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
 
-#         @test getindex(S, idxs...) ≈ σ/√2
-#         @test getindex(Ω, idxs...) ≈ σ/√2
-#         @test ≈(getindex(q, idxs...), (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2, atol=eps())
-#         @test ≈(getindex(q, idxs...), 0, atol=eps())
-#         @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2
-#     end
-# end
+        @test getindex(S, idxs...) ≈ σ/√2
+        @test getindex(Ω, idxs...) ≈ σ/√2
+        @test ≈(getindex(q, idxs...), (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2, atol=eps())
+        @test ≈(getindex(q, idxs...), 0, atol=eps())
+        @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2
+    end
+end
 #---
 
 model_kwargs = (buoyancy = Buoyancy(model=BuoyancyTracer()),
@@ -475,50 +475,50 @@ model_types = (NonhydrostaticModel, HydrostaticFreeSurfaceModel)
 @testset "Oceanostics" begin
     for grid in grids
         for model_type in model_types
-            # for closure in closures
-            #     @info "Testing $model_type on grid and with closure" grid closure
-            #     model = model_type(; grid, closure, model_kwargs...)
+            for closure in closures
+                @info "Testing $model_type on grid and with closure" grid closure
+                model = model_type(; grid, closure, model_kwargs...)
 
-            #     @info "Testing velocity-only diagnostics"
-            #     test_vel_only_diagnostics(model)
+                @info "Testing velocity-only diagnostics"
+                test_vel_only_diagnostics(model)
 
-            #     @info "Testing buoyancy diagnostics"
-            #     test_buoyancy_diagnostics(model)
+                @info "Testing buoyancy diagnostics"
+                test_buoyancy_diagnostics(model)
 
-            #     if model isa NonhydrostaticModel
-            #         @info "Testing pressure terms"
-            #         test_pressure_term(model)
+                if model isa NonhydrostaticModel
+                    @info "Testing pressure terms"
+                    test_pressure_term(model)
 
-            #         @info "Testing buoyancy production term"
-            #         test_buoyancy_production_term(grid; model_type)
-            #     end
+                    @info "Testing buoyancy production term"
+                    test_buoyancy_production_term(grid; model_type)
+                end
 
-            #     @info "Testing energy dissipation rate terms"
-            #     test_ke_dissipation_rate_terms(grid; model_type, closure)
+                @info "Testing energy dissipation rate terms"
+                test_ke_dissipation_rate_terms(grid; model_type, closure)
 
 
-            #     if model_type == NonhydrostaticModel
-            #         @info "Testing energy dissipation rate terms"
-            #         test_momentum_advection_term(grid; model_type)
+                if model_type == NonhydrostaticModel
+                    @info "Testing energy dissipation rate terms"
+                    test_momentum_advection_term(grid; model_type)
 
-            #         @info "Testing forcing terms"
-            #         test_ke_forcing_term(grid; model_type)
+                    @info "Testing forcing terms"
+                    test_ke_forcing_term(grid; model_type)
 
-            #         @info "Testing uniform strain flow"
-            #         test_uniform_strain_flow(grid; model_type, closure, α=3)
+                    @info "Testing uniform strain flow"
+                    test_uniform_strain_flow(grid; model_type, closure, α=3)
 
-            #         @info "Testing solid body rotation flow"
-            #         test_solid_body_rotation_flow(grid; model_type, closure, ζ=3)
+                    @info "Testing solid body rotation flow"
+                    test_solid_body_rotation_flow(grid; model_type, closure, ζ=3)
 
-            #         @info "Testing uniform shear flow"
-            #         test_uniform_shear_flow(grid; model_type, closure, σ=3)
-            #     end
+                    @info "Testing uniform shear flow"
+                    test_uniform_shear_flow(grid; model_type, closure, σ=3)
+                end
 
-            #     @info "Testing tracer variance terms"
-            #     model = model_type(; grid, closure, model_kwargs...)
-            #     test_tracer_diagnostics(model)
+                @info "Testing tracer variance terms"
+                model = model_type(; grid, closure, model_kwargs...)
+                test_tracer_diagnostics(model)
 
-            # end
+            end
             @info "Testing error throws for invalid buoyancy models"
             for buoyancy in invalid_buoyancy_models
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test
-#using CUDA
+using CUDA
 
 using Oceananigans
 using Oceananigans.AbstractOperations: AbstractOperation
@@ -11,7 +11,7 @@ using SeawaterPolynomials: RoquetEquationOfState
 using Oceanostics
 using Oceanostics: TKEBudgetTerms, TracerVarianceBudgetTerms, FlowDiagnostics, PressureRedistributionTerm, BuoyancyProductionTerm, AdvectionTerm
 using Oceanostics.TKEBudgetTerms: AdvectionTerm
-using Oceanostics: GravitationalPotentialEnergy
+using Oceanostics: PotentialEnergy
 using Oceanostics.ProgressMessengers
 
 include("test_budgets.jl")
@@ -326,15 +326,15 @@ end
 
 function test_density_equation_terms_errors(model)
 
-    @test_throws ArgumentError GravitationalPotentialEnergy(model)
-    @test_throws ArgumentError GravitationalPotentialEnergy(model, 0)
+    @test_throws ArgumentError PotentialEnergy(model)
+    @test_throws ArgumentError PotentialEnergy(model, 0)
 
     return nothing
 end
 
 function test_density_equation_terms(model)
 
-    Eₚ = GravitationalPotentialEnergy(model)
+    Eₚ = PotentialEnergy(model)
     Eₚ_field = Field(Eₚ)
     @test Eₚ isa AbstractOperation
     @test Eₚ_field isa Field
@@ -354,7 +354,7 @@ function test_density_equation_terms(model)
 end
 function test_density_equation_terms(model, reference_geopotential_height)
 
-    Eₚ = GravitationalPotentialEnergy(model, reference_geopotential_height)
+    Eₚ = PotentialEnergy(model, reference_geopotential_height)
     Eₚ_field = Field(Eₚ)
     @test Eₚ isa AbstractOperation
     @test Eₚ_field isa Field

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using Oceananigans.AbstractOperations: AbstractOperation
 using Oceananigans.Fields: @compute
 using Oceananigans.TurbulenceClosures: ThreeDimensionalFormulation
 using Oceananigans.Models: seawater_density, model_geopotential_height
-using SeawaterPolynomials: RoquetEquationOfState
+using SeawaterPolynomials: RoquetEquationOfState, TEOS10EquationOfState
 
 using Oceanostics
 using Oceanostics: TKEBudgetTerms, TracerVarianceBudgetTerms, FlowDiagnostics, PressureRedistributionTerm, BuoyancyProductionTerm, AdvectionTerm
@@ -327,7 +327,7 @@ end
 function test_density_equation_terms_errors(model)
 
     @test_throws ArgumentError PotentialEnergy(model)
-    @test_throws ArgumentError PotentialEnergy(model, 0)
+    @test_throws ArgumentError PotentialEnergy(model, geopotential_height = 0)
 
     return nothing
 end
@@ -335,7 +335,7 @@ end
 function test_density_equation_terms(model; geopotential_height = nothing)
 
     Eₚ = isnothing(geopotential_height) ? PotentialEnergy(model) :
-                                          PotentialEnergy(model, geopotential_height)
+                                          PotentialEnergy(model; geopotential_height)
 
     Eₚ_field = Field(Eₚ)
     @test Eₚ isa AbstractOperation
@@ -348,9 +348,10 @@ function test_density_equation_terms(model; geopotential_height = nothing)
     compute!(ρ)
     Z = Field(model_geopotential_height(model))
     compute!(Z)
+    ρ₀ = model.buoyancy.model.equation_of_state.reference_density
     g = model.buoyancy.model.gravitational_acceleration
 
-    true_value = g .* ρ.data .* Z.data
+    true_value = (g / ρ₀) .* ρ.data .* Z.data
 
     @test isequal(Eₚ_field.data, true_value)
 
@@ -359,100 +360,100 @@ end
 #---
 
 #+++ Known-value function tests
-function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), α=1)
-    model = model_type(; grid, closure)
-    u₀(x, y, z) = +α*x
-    v₀(x, y, z) = -α*y
-    set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
+# function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), α=1)
+#     model = model_type(; grid, closure)
+#     u₀(x, y, z) = +α*x
+#     v₀(x, y, z) = -α*y
+#     set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
 
-    u, v, w = model.velocities
+#     u, v, w = model.velocities
 
-    @compute ε = Field(KineticEnergyDissipationRate(model))
-    @compute S = Field(StrainRateTensorModulus(model))
-    @compute Ω = Field(VorticityTensorModulus(model))
-    @compute q = Field(QVelocityGradientTensorInvariant(model))
+#     @compute ε = Field(KineticEnergyDissipationRate(model))
+#     @compute S = Field(StrainRateTensorModulus(model))
+#     @compute Ω = Field(VorticityTensorModulus(model))
+#     @compute q = Field(QVelocityGradientTensorInvariant(model))
 
-    idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
+#     idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
 
-    if model.closure isa Tuple
-        @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
-    else
-        ν_field = viscosity(model.closure, model.diffusivity_fields)
-    end
+#     if model.closure isa Tuple
+#         @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
+#     else
+#         ν_field = viscosity(model.closure, model.diffusivity_fields)
+#     end
 
-    CUDA.@allowscalar begin
-        ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
+#     CUDA.@allowscalar begin
+#         ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
 
-        @test getindex(S, idxs...) ≈ √2*α
-        @test getindex(Ω, idxs...) ≈ 0
-        @test getindex(q, idxs...) ≈ (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2 ≈ -α^2
-        @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2
-    end
+#         @test getindex(S, idxs...) ≈ √2*α
+#         @test getindex(Ω, idxs...) ≈ 0
+#         @test getindex(q, idxs...) ≈ (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2 ≈ -α^2
+#         @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2
+#     end
 
-    return nothing
-end
+#     return nothing
+# end
 
-function test_solid_body_rotation_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), ζ=1)
-    model = model_type(; grid, closure)
-    u₀(x, y, z) = +ζ*y / 2
-    v₀(x, y, z) = -ζ*x / 2
-    set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
+# function test_solid_body_rotation_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), ζ=1)
+#     model = model_type(; grid, closure)
+#     u₀(x, y, z) = +ζ*y / 2
+#     v₀(x, y, z) = -ζ*x / 2
+#     set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
 
-    u, v, w = model.velocities
+#     u, v, w = model.velocities
 
-    @compute ε = Field(KineticEnergyDissipationRate(model))
-    @compute S = Field(StrainRateTensorModulus(model))
-    @compute Ω = Field(VorticityTensorModulus(model))
-    @compute q = Field(QVelocityGradientTensorInvariant(model))
+#     @compute ε = Field(KineticEnergyDissipationRate(model))
+#     @compute S = Field(StrainRateTensorModulus(model))
+#     @compute Ω = Field(VorticityTensorModulus(model))
+#     @compute q = Field(QVelocityGradientTensorInvariant(model))
 
-    idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
+#     idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
 
-    if model.closure isa Tuple
-        @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
-    else
-        ν_field = viscosity(model.closure, model.diffusivity_fields)
-    end
+#     if model.closure isa Tuple
+#         @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
+#     else
+#         ν_field = viscosity(model.closure, model.diffusivity_fields)
+#     end
 
-    CUDA.@allowscalar begin
-        ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
+#     CUDA.@allowscalar begin
+#         ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
 
-        @test getindex(S, idxs...) ≈ 0
-        @test getindex(Ω, idxs...) ≈ ζ/√2
-        @test getindex(q, idxs...) ≈ (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2 ≈ ζ^2/4
-        @test getindex(ε, idxs...) ≈ 0
-    end
-end
+#         @test getindex(S, idxs...) ≈ 0
+#         @test getindex(Ω, idxs...) ≈ ζ/√2
+#         @test getindex(q, idxs...) ≈ (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2 ≈ ζ^2/4
+#         @test getindex(ε, idxs...) ≈ 0
+#     end
+# end
 
-function test_uniform_shear_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), σ=1)
-    model = model_type(; grid, closure)
-    u₀(x, y, z) = +σ * y
-    set!(model, u=u₀, v=0, w=0, enforce_incompressibility=false)
+# function test_uniform_shear_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), σ=1)
+#     model = model_type(; grid, closure)
+#     u₀(x, y, z) = +σ * y
+#     set!(model, u=u₀, v=0, w=0, enforce_incompressibility=false)
 
-    u, v, w = model.velocities
+#     u, v, w = model.velocities
 
-    @compute ε = Field(KineticEnergyDissipationRate(model))
-    @compute S = Field(StrainRateTensorModulus(model))
-    @compute Ω = Field(VorticityTensorModulus(model))
-    @compute q = Field(QVelocityGradientTensorInvariant(model))
+#     @compute ε = Field(KineticEnergyDissipationRate(model))
+#     @compute S = Field(StrainRateTensorModulus(model))
+#     @compute Ω = Field(VorticityTensorModulus(model))
+#     @compute q = Field(QVelocityGradientTensorInvariant(model))
 
-    idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
+#     idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
 
-    if model.closure isa Tuple
-        @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
-    else
-        ν_field = viscosity(model.closure, model.diffusivity_fields)
-    end
+#     if model.closure isa Tuple
+#         @compute ν_field = Field(sum(viscosity(model.closure, model.diffusivity_fields)))
+#     else
+#         ν_field = viscosity(model.closure, model.diffusivity_fields)
+#     end
 
-    CUDA.@allowscalar begin
-        ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
+#     CUDA.@allowscalar begin
+#         ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
 
-        @test getindex(S, idxs...) ≈ σ/√2
-        @test getindex(Ω, idxs...) ≈ σ/√2
-        @test ≈(getindex(q, idxs...), (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2, atol=eps())
-        @test ≈(getindex(q, idxs...), 0, atol=eps())
-        @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2
-    end
-end
+#         @test getindex(S, idxs...) ≈ σ/√2
+#         @test getindex(Ω, idxs...) ≈ σ/√2
+#         @test ≈(getindex(q, idxs...), (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2, atol=eps())
+#         @test ≈(getindex(q, idxs...), 0, atol=eps())
+#         @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2
+#     end
+# end
 #---
 
 model_kwargs = (buoyancy = Buoyancy(model=BuoyancyTracer()),
@@ -474,50 +475,50 @@ model_types = (NonhydrostaticModel, HydrostaticFreeSurfaceModel)
 @testset "Oceanostics" begin
     for grid in grids
         for model_type in model_types
-            for closure in closures
-                @info "Testing $model_type on grid and with closure" grid closure
-                model = model_type(; grid, closure, model_kwargs...)
+            # for closure in closures
+            #     @info "Testing $model_type on grid and with closure" grid closure
+            #     model = model_type(; grid, closure, model_kwargs...)
 
-                @info "Testing velocity-only diagnostics"
-                test_vel_only_diagnostics(model)
+            #     @info "Testing velocity-only diagnostics"
+            #     test_vel_only_diagnostics(model)
 
-                @info "Testing buoyancy diagnostics"
-                test_buoyancy_diagnostics(model)
+            #     @info "Testing buoyancy diagnostics"
+            #     test_buoyancy_diagnostics(model)
 
-                if model isa NonhydrostaticModel
-                    @info "Testing pressure terms"
-                    test_pressure_term(model)
+            #     if model isa NonhydrostaticModel
+            #         @info "Testing pressure terms"
+            #         test_pressure_term(model)
 
-                    @info "Testing buoyancy production term"
-                    test_buoyancy_production_term(grid; model_type)
-                end
+            #         @info "Testing buoyancy production term"
+            #         test_buoyancy_production_term(grid; model_type)
+            #     end
 
-                @info "Testing energy dissipation rate terms"
-                test_ke_dissipation_rate_terms(grid; model_type, closure)
+            #     @info "Testing energy dissipation rate terms"
+            #     test_ke_dissipation_rate_terms(grid; model_type, closure)
 
 
-                if model_type == NonhydrostaticModel
-                    @info "Testing energy dissipation rate terms"
-                    test_momentum_advection_term(grid; model_type)
+            #     if model_type == NonhydrostaticModel
+            #         @info "Testing energy dissipation rate terms"
+            #         test_momentum_advection_term(grid; model_type)
 
-                    @info "Testing forcing terms"
-                    test_ke_forcing_term(grid; model_type)
+            #         @info "Testing forcing terms"
+            #         test_ke_forcing_term(grid; model_type)
 
-                    @info "Testing uniform strain flow"
-                    test_uniform_strain_flow(grid; model_type, closure, α=3)
+            #         @info "Testing uniform strain flow"
+            #         test_uniform_strain_flow(grid; model_type, closure, α=3)
 
-                    @info "Testing solid body rotation flow"
-                    test_solid_body_rotation_flow(grid; model_type, closure, ζ=3)
+            #         @info "Testing solid body rotation flow"
+            #         test_solid_body_rotation_flow(grid; model_type, closure, ζ=3)
 
-                    @info "Testing uniform shear flow"
-                    test_uniform_shear_flow(grid; model_type, closure, σ=3)
-                end
+            #         @info "Testing uniform shear flow"
+            #         test_uniform_shear_flow(grid; model_type, closure, σ=3)
+            #     end
 
-                @info "Testing tracer variance terms"
-                model = model_type(; grid, closure, model_kwargs...)
-                test_tracer_diagnostics(model)
+            #     @info "Testing tracer variance terms"
+            #     model = model_type(; grid, closure, model_kwargs...)
+            #     test_tracer_diagnostics(model)
 
-            end
+            # end
             @info "Testing error throws for invalid buoyancy models"
             for buoyancy in invalid_buoyancy_models
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ include("test_budgets.jl")
 
 #+++ Default grids and functions
 arch = has_cuda_gpu() ? arch = GPU() : CPU()
-arch = CPU()
+
 N = 6
 regular_grid = RectilinearGrid(arch, size=(N, N, N), extent=(1, 1, 1))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,21 +1,24 @@
 using Test
-using CUDA
+#using CUDA
 
 using Oceananigans
 using Oceananigans.AbstractOperations: AbstractOperation
 using Oceananigans.Fields: @compute
 using Oceananigans.TurbulenceClosures: ThreeDimensionalFormulation
+using Oceananigans.Models: seawater_density, model_geopotential_height
+using SeawaterPolynomials: RoquetEquationOfState
 
 using Oceanostics
 using Oceanostics: TKEBudgetTerms, TracerVarianceBudgetTerms, FlowDiagnostics, PressureRedistributionTerm, BuoyancyProductionTerm, AdvectionTerm
 using Oceanostics.TKEBudgetTerms: AdvectionTerm
+using Oceanostics: GravitationalPotentialEnergy
 using Oceanostics.ProgressMessengers
 
 include("test_budgets.jl")
 
 #+++ Default grids and functions
 arch = has_cuda_gpu() ? arch = GPU() : CPU()
-
+arch = CPU()
 N = 6
 regular_grid = RectilinearGrid(arch, size=(N, N, N), extent=(1, 1, 1))
 
@@ -320,6 +323,55 @@ function test_tracer_diagnostics(model)
 
     return nothing
 end
+
+function test_density_equation_terms_errors(model)
+
+    @test_throws ArgumentError GravitationalPotentialEnergy(model)
+    @test_throws ArgumentError GravitationalPotentialEnergy(model, 0)
+
+    return nothing
+end
+
+function test_density_equation_terms(model)
+
+    Eₚ = GravitationalPotentialEnergy(model)
+    Eₚ_field = Field(Eₚ)
+    @test Eₚ isa AbstractOperation
+    @test Eₚ_field isa Field
+    compute!(Eₚ_field)
+
+    ρ = Field(seawater_density(model))
+    compute!(ρ)
+    Z = Field(model_geopotential_height(model))
+    compute!(Z)
+    g = model.buoyancy.model.gravitational_acceleration
+
+    true_value =  g .* ρ.data .* Z.data
+
+    @test isequal(Eₚ_field.data, true_value)
+
+    return nothing
+end
+function test_density_equation_terms(model, reference_geopotential_height)
+
+    Eₚ = GravitationalPotentialEnergy(model, reference_geopotential_height)
+    Eₚ_field = Field(Eₚ)
+    @test Eₚ isa AbstractOperation
+    @test Eₚ_field isa Field
+    compute!(Eₚ_field)
+
+    ρ = Field(seawater_density(model, geopotential_height = reference_geopotential_height))
+    compute!(ρ)
+    Z = Field(model_geopotential_height(model))
+    compute!(Z)
+    g = model.buoyancy.model.gravitational_acceleration
+
+    true_value =  @. g * ρ.data * Z.data
+
+    @test isequal(Eₚ_field.data, true_value)
+
+    return nothing
+end
 #---
 
 #+++ Known-value function tests
@@ -419,13 +471,17 @@ function test_uniform_shear_flow(grid; model_type=NonhydrostaticModel, closure=S
 end
 #---
 
-model_kwargs = (buoyancy = Buoyancy(model=BuoyancyTracer()), 
+model_kwargs = (buoyancy = Buoyancy(model=BuoyancyTracer()),
                 coriolis = FPlane(1e-4),
                 tracers = :b)
 
 closures = (ScalarDiffusivity(ν=1e-6, κ=1e-7),
             SmagorinskyLilly(),
             (ScalarDiffusivity(ν=1e-6, κ=1e-7), AnisotropicMinimumDissipation()),)
+
+invalid_buoyancy_models = (nothing, BuoyancyTracer(), SeawaterBuoyancy())
+valid_buoyancy_models = (SeawaterBuoyancy(equation_of_state=TEOS10EquationOfState()),
+                         SeawaterBuoyancy(equation_of_state=RoquetEquationOfState(:Linear)))
 
 grids = (regular_grid, stretched_grid)
 
@@ -455,7 +511,7 @@ model_types = (NonhydrostaticModel, HydrostaticFreeSurfaceModel)
                 @info "Testing energy dissipation rate terms"
                 test_ke_dissipation_rate_terms(grid; model_type, closure)
 
-       
+
                 if model_type == NonhydrostaticModel
                     @info "Testing energy dissipation rate terms"
                     test_momentum_advection_term(grid; model_type)
@@ -478,13 +534,30 @@ model_types = (NonhydrostaticModel, HydrostaticFreeSurfaceModel)
                 test_tracer_diagnostics(model)
 
             end
+            @info "Testing error throws for invalid buoyancy models"
+            for buoyancy in invalid_buoyancy_models
+
+                tracers = buoyancy isa BuoyancyTracer ? :b : (:S, :T)
+                model = model_type(; grid, buoyancy, tracers)
+                test_density_equation_terms_errors(model)
+
+            end
+            @info "Testing valid buoyancy models"
+            for buoyancy in valid_buoyancy_models
+
+                model = model_type(; grid, buoyancy, tracers = (:S, :T))
+                set!(model, S = 34.7, T = 0.5)
+                test_density_equation_terms(model)
+                test_density_equation_terms(model, 0)
+
+            end
         end
 
         @info "Testing input validation for dissipation rates"
         invalid_closures = [HorizontalScalarDiffusivity(ν=1e-6, κ=1e-7),
                             VerticalScalarDiffusivity(ν=1e-6, κ=1e-7),
                             (ScalarDiffusivity(ν=1e-6, κ=1e-7), HorizontalScalarDiffusivity(ν=1e-6, κ=1e-7))]
-        
+
         for closure in invalid_closures
             model = NonhydrostaticModel(grid = regular_grid; model_kwargs..., closure)
             @test_throws ErrorException IsotropicKineticEnergyDissipationRate(model; U=0, V=0, W=0)
@@ -496,7 +569,7 @@ model_types = (NonhydrostaticModel, HydrostaticFreeSurfaceModel)
     for closure in closures
         LES = is_LES(closure)
         model = NonhydrostaticModel(grid = regular_grid;
-                                    buoyancy = Buoyancy(model=BuoyancyTracer()), 
+                                    buoyancy = Buoyancy(model=BuoyancyTracer()),
                                     coriolis = FPlane(1e-4),
                                     tracers = :b,
                                     closure = closure)


### PR DESCRIPTION
This PR adds the `KernelFunctionOperation` `PotentialEnergy`, defined as the potential energy per unit volume $E_{p} = \frac{g\rho z}{\rho_{0}}$, in a new script called `src/PotentialEnergyEquationTerms.jl`. `PotentialEnergy` can use either in-situ density or a user defined potential density for the calculation. To ensure `seawater_density` from Oceananigans.jl exists I updated the compat entry. As well, I needed to add [SeawaterPolynomials.jl](https://github.com/CliMA/SeawaterPolynomials.jl) as a dependency for the project. This has updated the `Manifest.toml` --- hope that is ok!

I added some validating functions similar to those already in use in the package and there are tests that check both the error throwing and a basic calculation to check things are running smoothly.

Closes #163 

Though this PR does not completely close #163 the background potential energy is something I will leave to another PR and refer back to the comments in #163 or open up a new issues where this can be kept track of.