### PR TITLE
Use julia version 1.10 on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - '1.10'
         os:
           - ubuntu-latest
         arch:

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.2"
 manifest_format = "2.0"
-project_hash = "bab8eb8385b835035e413ca5e0b68b0c9c732f34"
+project_hash = "d32a24574e4309866e21921f965e8d3c45a9a19a"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]


### PR DESCRIPTION
I ran into some issues with the tests (see [here](https://github.com/tomchor/Oceanostics.jl/issues/165)) on ci after merging #163. Updating ci to run on julia v1.10 has solved this.

Closes #165 