### PR TITLE
Add `PotentialEnergy` methods for `BuoyancyTracer` and `SeawaterBuoyancy{<:LinearEquationOfState}`

### DIFF
--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -33,8 +33,6 @@ export ProgressMessengers
 #+++ Utils for validation
 # Right now, all kernels must be located at ccc
 using Oceananigans.TurbulenceClosures: AbstractScalarDiffusivity, ThreeDimensionalFormulation
-using Oceananigans.BuoyancyModels: Buoyancy, BuoyancyTracer, SeawaterBuoyancy, LinearEquationOfState
-using SeawaterPolynomials: BoussinesqEquationOfState
 using Oceananigans.Grids: Center, Face
 
 validate_location(location, type, valid_location=(Center, Center, Center)) =
@@ -44,13 +42,6 @@ validate_location(location, type, valid_location=(Center, Center, Center)) =
 validate_dissipative_closure(closure) = error("Cannot calculate dissipation rate for $closure")
 validate_dissipative_closure(::AbstractScalarDiffusivity{<:Any, ThreeDimensionalFormulation}) = nothing
 validate_dissipative_closure(closure_tuple::Tuple) = Tuple(validate_dissipative_closure(c) for c in closure_tuple)
-
-validate_buoyancy(buoyancy::Nothing) = throw(ArgumentError("Cannot calculate gravitational potential energy without a buoyancy model."))
-validate_buoyancy(buoyancy::Buoyancy{<:BuoyancyTracer, g}) where g =
-    throw(ArgumentError("Cannot calculate gravitational potential energy for the buoyancy model $(buoyancy.model)."))
-validate_buoyancy(buoyancy::Buoyancy{<:SeawaterBuoyancy{FT, <:LinearEquationOfState, T, S}, g}) where {FT, T, S, g} =
-    throw(ArgumentError("To calculate gravitational potential energy with a linear equation of state use a linear `BoussinesqEquationOfState`."))
-validate_buoyancy(buoyancy::Buoyancy{<:SeawaterBuoyancy{FT, <:BoussinesqEquationOfState, T, S}, g}) where {FT, T, S, g} = nothing
 
 #---
 

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -17,8 +17,8 @@ using SeawaterPolynomials: BoussinesqEquationOfState
 
 const NoBuoyancyModel = Union{Nothing, ShallowWaterModel}
 const BuoyancyTracerModel = Buoyancy{<:BuoyancyTracer, g} where g
-const BuoyancyLinearEOSModel = Buoyancy{<:SeawaterBuoyancy{FT, <:LinearEquationOfState, T, S}} where {FT, T, S}
-const BuoyancyBoussinesqEOSModel = Buoyancy{<:SeawaterBuoyancy{FT, <:BoussinesqEquationOfState, T, S}} where {FT, T, S}
+const BuoyancyLinearEOSModel = Buoyancy{<:SeawaterBuoyancy{FT, <:LinearEquationOfState, T, S} where {FT, T, S}, g} where {g}
+const BuoyancyBoussinesqEOSModel = Buoyancy{<:SeawaterBuoyancy{FT, <:BoussinesqEquationOfState, T, S} where {FT, T, S}, g} where {g}
 
 validate_gravity_unit_vector(gravity_unit_vector::NegativeZDirection) = nothing
 validate_gravity_unit_vector(gravity_unit_vector) =
@@ -110,7 +110,7 @@ julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: g′z_ccc (generic function with 1 method)
-└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665, ρ₀=1020.0)")
+└── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665, ρ₀=1020.0)")
 ```
 
 To use a reference density set a constant value for the keyword argument `geopotential_height`
@@ -143,7 +143,7 @@ KernelFunctionOperation at (Center, Center, Center)
                                  geopotential_height = model_geopotential_height(model))
 
     validate_location(location, "PotentialEnergy")
-    validate_gravity_unit_vector(model.buoyancy.gravity_unit_vector)
+    isnothing(model.buoyancy) ? nothing : validate_gravity_unit_vector(model.buoyancy.gravity_unit_vector)
 
     return PotentialEnergy(model, model.buoyancy, geopotential_height)
 end

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -5,31 +5,22 @@ using DocStringExtensions
 export PotentialEnergy
 
 using Oceananigans.AbstractOperations: KernelFunctionOperation
-using Oceananigans: Models.seawater_density
-using Oceananigans: Models.model_geopotential_height
+using Oceananigans.Models: seawater_density
+using Oceananigans.Models: model_geopotential_height
 using Oceananigans.Grids: Center, Face
 using Oceananigans.BuoyancyModels: Buoyancy, BuoyancyTracer, SeawaterBuoyancy, LinearEquationOfState
-using Oceananigans.Models: NonhydrostaticModel, HydrostaticFreeSurfaceModel
-using Oceanostics: validate_location, validate_buoyancy
+using Oceananigans.BuoyancyModels: buoyancy_perturbationᶜᶜᶜ
+using Oceananigans.Models: ShallowWaterModel
+using Oceanostics: validate_location
 using SeawaterPolynomials: BoussinesqEquationOfState
 
-const ModelsWithBoussinesqEOS = Union{NonhydrostaticModel{TS, E, A, G, T,
-                                    <:Buoyancy{<:SeawaterBuoyancy{FT, <:BoussinesqEquationOfState, Temp, Sal}},
-                                    R, SD, U, C, Φ, F, V, S, K, BG, P, BGC, I, AF},
-                                    HydrostaticFreeSurfaceModel{TS, E, A, S, G, T, V,
-                                    <:Buoyancy{<:SeawaterBuoyancy{FT, <:BoussinesqEquationOfState, Temp, Sal}},
-                                    R, F, P, BGC, U, C, Φ, K, AF}} where
-                                    {TS, E, A, G, T, R, SD, U, C, Φ, F, V, S, K, BG, P,
-                                    BGC, I, AF, FT, Temp, Sal}
+const NoBuoyancyModel = Union{Nothing, ShallowWaterModel}
+const BuoyancyTracerModel = Buoyancy{<:BuoyancyTracer, g} where g
+const BuoyancyLinearEOSModel = Buoyancy{<:SeawaterBuoyancy{FT, <:LinearEquationOfState, T, S}} where {FT, T, S}
+const BuoyancyBoussinesqEOSModel = Buoyancy{<:SeawaterBuoyancy{FT, <:BoussinesqEquationOfState, T, S}} where {FT, T, S}
 
-const ModelsWithBuoyancyTracer = Union{NonhydrostaticModel{TS, E, A, G, T,
-                                        <:Buoyancy{<:BuoyancyTracer, g},
-                                        R, SD, U, C, Φ, F, V, S, K, BG, P, BGC, I, AF},
-                                        HydrostaticFreeSurfaceModel{TS, E, A, S, G, T, V,
-                                        <:Buoyancy{<:BuoyancyTracer, g},
-                                        R, F, P, BGC, U, C, Φ, K, AF}} where
-                                        {TS, E, A, G, T, R, SD, U, C, Φ, F, V, S, K, BG, P,
-                                        BGC, I, AF, g}
+linear_eos_buoyancy(model) = linear_eos_buoyancy(model.grid, model.buoyancy.model, model.tracers)
+linear_eos_buoyancy(grid, buoyancy, tracers) = KernelFunctionOperation{Center, Center, Center}(buoyancy_perturbationᶜᶜᶜ, grid, buoyancy, tracers)
 
 """
     $(SIGNATURES)
@@ -38,16 +29,48 @@ Return a `KernelFunctionOperation` to compute the `PotentialEnergy` per unit vol
 ```math
 Eₚ = \\frac{gρz}{ρ₀}
 ```
-at each grid `location` in `model`.
+at each grid `location` in `model`. `PotentialEnergy` is defined for both `BuoyancyTracer`
+and `SeawaterBuoyancy`. See the relevant Oceananigans.jl documentation on
+[buoyancy models](https://clima.github.io/OceananigansDocumentation/dev/model_setup/buoyancy_and_equation_of_state/)
+for more information about available options.
 
-**NOTE:** A `BoussinesqEquationOfState` must be used in the `model` to calculate
-`seawater_density`. See the [relevant documentation](https://clima.github.io/OceananigansDocumentation/dev/model_setup/buoyancy_and_equation_of_state/#Idealized-nonlinear-equations-of-state)
-for how to set `SeawaterBuoyancy` using a `BoussinesqEquationOfState`.
+The optional keyword argument `geopotential_height` is only used
+if ones wishes to calculate `Eₚ` with a potential density referenced to `geopotential_height`,
+rather than in-situ density, when using a `BoussinesqEquationOfState`.
 
 Example
 =======
 
-The default behaviour of `PotentialEnergy` uses the *in-situ density* in the calculation:
+Usage with a `BuoyancyTracer` buoyacny model
+```jldoctest
+julia> using Oceananigans
+
+julia> using Oceanostics.PotentialEnergyEquationTerms: PotentialEnergy
+
+julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded))
+1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+├── Flat x
+├── Flat y
+└── Bounded  z ∈ [-1000.0, 0.0]   regularly spaced with Δz=10.0
+
+julia> model = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=(:b,))
+NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
+├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+├── timestepper: QuasiAdamsBashforth2TimeStepper
+├── tracers: b
+├── closure: Nothing
+├── buoyancy: BuoyancyTracer with ĝ = NegativeZDirection()
+└── coriolis: Nothing
+
+julia> PotentialEnergy(model)
+KernelFunctionOperation at (Center, Center, Center)
+├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+├── kernel_function: bz_ccc (generic function with 1 method)
+└── arguments: ("1×1×100 Field{Center, Center, Center} on RectilinearGrid on CPU", "KernelFunctionOperation at (Center, Center, Center)")
+```
+
+The default behaviour of `PotentialEnergy` uses the *in-situ density* in the calculation
+when the equation of state is a `BoussinesqEquationOfState`:
 ```jldoctest
 julia> using Oceananigans, SeawaterPolynomials.TEOS10
 
@@ -114,11 +137,38 @@ KernelFunctionOperation at (Center, Center, Center)
 └── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665, ρ₀=1020.0)")
 ```
 """
-@inline function PotentialEnergy(model::ModelsWithBoussinesqEOS;
-                                geopotential_height = model_geopotential_height(model),
-                                location = (Center, Center, Center))
+@inline function PotentialEnergy(model; location = (Center, Center, Center),
+                                 geopotential_height = model_geopotential_height(model))
 
     validate_location(location, "PotentialEnergy")
+
+    return PotentialEnergy(model, model.buoyancy, geopotential_height)
+end
+
+@inline PotentialEnergy(model, buoyancy_model::NoBuoyancyModel, geopotential_height) =
+    throw(ArgumentError("Cannot calculate gravitational potential energy without a Buoyancy model."))
+
+@inline function PotentialEnergy(model, buoyancy_model::BuoyancyTracerModel, geopotential_height)
+
+    grid = model.grid
+    b = model.tracers.b
+    Z = model_geopotential_height(model)
+
+    return KernelFunctionOperation{Center, Center, Center}(bz_ccc, grid, b, Z)
+end
+
+@inline function PotentialEnergy(model, buoyancy_model::BuoyancyLinearEOSModel, geopotential_height)
+
+    grid = model.grid
+    b = linear_eos_buoyancy(model)
+    Z = model_geopotential_height(model)
+
+    return KernelFunctionOperation{Center, Center, Center}(bz_ccc, grid, b, Z)
+end
+
+@inline bz_ccc(i, j, k, grid, b, Z) = b[i, j, k] * Z[i, j, k]
+
+@inline function PotentialEnergy(model, buoyancy_model::BuoyancyBoussinesqEOSModel, geopotential_height)
 
     grid = model.grid
     ρ = seawater_density(model; geopotential_height)
@@ -130,19 +180,5 @@ KernelFunctionOperation at (Center, Center, Center)
 end
 
 @inline g′z_ccc(i, j, k, grid, ρ, Z, p) = (p.g / p.ρ₀) * ρ[i, j, k] * Z[i, j, k]
-
-@inline function PotentialEnergy(model::ModelsWithBuoyancyTracer;
-                                location = (Center, Center, Center))
-
-    validate_location(location, "PotentialEnergy")
-
-    grid = model.grid
-    b = model.tracers.b
-    Z = model_geopotential_height(model)
-
-    return KernelFunctionOperation{Center, Center, Center}(bz_ccc, grid, b, Z)
-end
-
-@inline bz_ccc(i, j, k, grid, b, Z) = b[i, j, k] * Z[i, j, k]
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -344,7 +344,7 @@ function test_potential_energy_equation_terms(model; geopotential_height = nothi
 
     if model.buoyancy isa BuoyancyBoussinesqEOSModel
         ρ = isnothing(geopotential_height) ? Field(seawater_density(model)) :
-                                            Field(seawater_density(model; geopotential_height))
+                                             Field(seawater_density(model; geopotential_height))
 
         compute!(ρ)
         Z = Field(model_geopotential_height(model))


### PR DESCRIPTION
Currently `PotentialEnergy` only works if the `BuoyancyModel` has a `BoussinesqEquationOfState`. This PR extends `PotentialEnergy` to have methods for both `BuoyancyTracer` and `SeawaterBuoyancy{<:LinearEquationOfState}`. It does so by dispatching on the `BuoyancyModel`.

To calculate the potential energy per unit volume for `BuoyancyTracer` and `SeawaterBuoyancy{<:LinearEquationOfState}` I have used

$$
E_{p} = bz
$$

where $b$ is buoyancy (I think this is what it should be but let me know if not!). In the case of `BuoyancyTracer` $b$ is exactly the buoyancy tracer and in the case of `SeawaterBuoyancy{<:LinearEquationOfState}` I compute the buoyancy via

https://github.com/tomchor/Oceanostics.jl/blob/68007f19e61f13152e8a6efd9a568eb933d941b2/src/PotentialEnergyEquationTerms.jl#L22-L23

I am not sure if this is the optimal way to do things so please let me know if you know of better ways to do this!

Once the calculation of $E_{p}$ is confirmed I will add some calculation tests to check things are doing what they should similar to what is currently there for when `SeawaterBuoyancy{<:BoussinesqEquationOfState}`

https://github.com/tomchor/Oceanostics.jl/blob/68007f19e61f13152e8a6efd9a568eb933d941b2/test/runtests.jl#L345-L358