### PR TITLE
Add background potential energy computation

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.2"
+julia_version = "1.10.3"
 manifest_format = "2.0"
 project_hash = "e19f51c46fc9161a1a3899ab99209f39adde0868"
 
@@ -141,9 +141,9 @@ version = "0.11.5"
 
 [[deps.Colors]]
 deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
-git-tree-sha1 = "fc08e5930ee9a4e03f84bfb5211cb54e7769758a"
+git-tree-sha1 = "362a287c3aa50601b0bc359053d5c2468f0e7ce0"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
-version = "0.12.10"
+version = "0.12.11"
 
 [[deps.CommonDataModel]]
 deps = ["CFTime", "DataStructures", "Dates", "Preferences", "Printf", "Statistics"]
@@ -164,7 +164,7 @@ weakdeps = ["Dates", "LinearAlgebra"]
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.1.0+0"
+version = "1.1.1+0"
 
 [[deps.ConstructionBase]]
 deps = ["LinearAlgebra"]
@@ -285,9 +285,9 @@ uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.FixedPointNumbers]]
 deps = ["Statistics"]
-git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
+git-tree-sha1 = "05882d6995ae5c12bb5f36dd2ed3f61c98cbb172"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-version = "0.8.4"
+version = "0.8.5"
 
 [[deps.Future]]
 deps = ["Random"]
@@ -389,9 +389,9 @@ version = "1.0.0"
 
 [[deps.JLD2]]
 deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "Pkg", "PrecompileTools", "Printf", "Reexport", "Requires", "TranscodingStreams", "UUIDs"]
-git-tree-sha1 = "5ea6acdd53a51d897672edb694e3cc2912f3f8a7"
+git-tree-sha1 = "dca9ff5abdf5fab4456876bc93f80c59a37b81df"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.46"
+version = "0.4.47"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
@@ -419,9 +419,9 @@ version = "0.2.1+0"
 
 [[deps.KernelAbstractions]]
 deps = ["Adapt", "Atomix", "InteractiveUtils", "LinearAlgebra", "MacroTools", "PrecompileTools", "Requires", "SparseArrays", "StaticArrays", "UUIDs", "UnsafeAtomics", "UnsafeAtomicsLLVM"]
-git-tree-sha1 = "ed7167240f40e62d97c1f5f7735dea6de3cc5c49"
+git-tree-sha1 = "db02395e4c374030c53dc28f3c1d33dec35f7272"
 uuid = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-version = "0.9.18"
+version = "0.9.19"
 
     [deps.KernelAbstractions.extensions]
     EnzymeExt = "EnzymeCore"
@@ -861,9 +861,9 @@ version = "0.3.4"
 
 [[deps.SentinelArrays]]
 deps = ["Dates", "Random"]
-git-tree-sha1 = "0e7508ff27ba32f26cd459474ca2ede1bc10991f"
+git-tree-sha1 = "363c4e82b66be7b9f7c7c7da7478fdae07de44b9"
 uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
-version = "1.4.1"
+version = "1.4.2"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -884,9 +884,9 @@ version = "1.10.0"
 
 [[deps.SpecialFunctions]]
 deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "e2cfc4012a19088254b3950b85c3c1d8882d864d"
+git-tree-sha1 = "2f5d4697f21388cbe1ff299430dd169ef97d7e14"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.3.1"
+version = "2.4.0"
 
     [deps.SpecialFunctions.extensions]
     SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -282,7 +282,7 @@ end
     parameters = (g = model.buoyancy.model.gravitational_acceleration,
                   ρ₀ = model.buoyancy.model.equation_of_state.reference_density)
 
-    return KernelFunctionOperation{Center, Center, Center}(g′z✶_ccc, grid, sorted_density, z✶, parameters)
+    return KernelFunctionOperation{Center, Center, Center}(minus_bz✶_ccc, grid, sorted_density, z✶, parameters)
 end
 
 @inline minus_bz✶_ccc(i, j, k, grid, sorted_ρ::Field, z✶::Field, p::NamedTuple) = (p.g / p.ρ₀) * sorted_ρ[i, j, k] * z✶[i, j, k]

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -50,21 +50,9 @@ julia> using Oceananigans
 
 julia> using Oceanostics.PotentialEnergyEquationTerms: PotentialEnergy
 
-julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded))
-1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── Flat x
-├── Flat y
-└── Bounded  z ∈ [-1000.0, 0.0]   regularly spaced with Δz=10.0
+julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded));
 
-julia> model = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=(:b,))
-NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── timestepper: QuasiAdamsBashforth2TimeStepper
-├── advection scheme: Centered reconstruction order 2
-├── tracers: b
-├── closure: Nothing
-├── buoyancy: BuoyancyTracer with ĝ = NegativeZDirection()
-└── coriolis: Nothing
+julia> model = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=(:b,));
 
 julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
@@ -80,34 +68,15 @@ julia> using Oceananigans, SeawaterPolynomials.TEOS10
 
 julia> using Oceanostics.PotentialEnergyEquationTerms: PotentialEnergy
 
-julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded))
-1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── Flat x
-├── Flat y
-└── Bounded  z ∈ [-1000.0, 0.0]   regularly spaced with Δz=10.0
+julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded));
 
-julia> tracers = (:T, :S)
-(:T, :S)
+julia> tracers = (:T, :S);
 
-julia> eos = TEOS10EquationOfState()
-BoussinesqEquationOfState{Float64}:
-    ├── seawater_polynomial: TEOS10SeawaterPolynomial{Float64}
-    └── reference_density: 1020.0
+julia> eos = TEOS10EquationOfState();
 
-julia> buoyancy = SeawaterBuoyancy(equation_of_state=eos)
-SeawaterBuoyancy{Float64}:
-├── gravitational_acceleration: 9.80665
-└── equation_of_state: BoussinesqEquationOfState{Float64}
+julia> buoyancy = SeawaterBuoyancy(equation_of_state=eos);
 
-julia> model = NonhydrostaticModel(; grid, buoyancy, tracers)
-NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── timestepper: QuasiAdamsBashforth2TimeStepper
-├── advection scheme: Centered reconstruction order 2
-├── tracers: (T, S)
-├── closure: Nothing
-├── buoyancy: SeawaterBuoyancy with g=9.80665 and BoussinesqEquationOfState{Float64} with ĝ = NegativeZDirection()
-└── coriolis: Nothing
+julia> model = NonhydrostaticModel(; grid, buoyancy, tracers);
 
 julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
@@ -257,20 +226,9 @@ julia> using Oceananigans
 
 julia> using Oceanostics.PotentialEnergyEquationTerms: BackgroundPotentialEnergy
 
-julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded))
-1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── Flat x
-├── Flat y
-└── Bounded  z ∈ [-1000.0, 0.0]   regularly spaced with Δz=10.0
+julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded));
 
-julia> model = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=(:b,))
-NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── timestepper: QuasiAdamsBashforth2TimeStepper
-├── tracers: b
-├── closure: Nothing
-├── buoyancy: BuoyancyTracer with ĝ = NegativeZDirection()
-└── coriolis: Nothing
+julia> model = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=(:b,));
 
 julia> bpe = BackgroundPotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -12,7 +12,7 @@ using Oceananigans.Grids: NegativeZDirection
 using Oceananigans.BuoyancyModels: Buoyancy, BuoyancyTracer, SeawaterBuoyancy, LinearEquationOfState
 using Oceananigans.BuoyancyModels: buoyancy_perturbationᶜᶜᶜ, Zᶜᶜᶜ
 using Oceananigans.Models: ShallowWaterModel
-using Oceananigans.Fields: Field
+using Oceananigans.Fields: Field, compute!
 using Oceanostics: validate_location
 using SeawaterPolynomials: BoussinesqEquationOfState
 

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -2,7 +2,7 @@ module PotentialEnergyEquationTerms
 
 using DocStringExtensions
 
-export PotentialEnergy, BackgroundPotentialEnergy
+export PotentialEnergy, BackgroundPotentialEnergy, OneDReferenceField
 
 using Oceananigans.AbstractOperations: KernelFunctionOperation, volume, Az, GridMetricOperation
 using Oceananigans.Models: seawater_density

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -7,7 +7,7 @@ export PotentialEnergy, BackgroundPotentialEnergy, OneDReferenceField
 using Oceananigans.AbstractOperations: KernelFunctionOperation, volume, Az, GridMetricOperation
 using Oceananigans.Models: seawater_density
 using Oceananigans.Models: model_geopotential_height
-using Oceananigans.ImmersedBoundaryGrid: ImmersedBoundaryGrid
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 using Oceananigans.Grids
 using Oceananigans.Grids: Center, NegativeZDirection, interior, CenterField
 using Oceananigans.BuoyancyModels: Buoyancy, BuoyancyTracer, SeawaterBuoyancy, LinearEquationOfState

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -195,6 +195,7 @@ end
 
 """
     $(SIGNATURES)
+
 Return a `kernelFunctionOperation` to compute the `BackgroundPotentialEnergy` per unit
 volume,
 ```math

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -202,6 +202,7 @@ the smallest values are at the _bottom_ of the grid.
 
     return KernelFunctionOperation{Center, Center, Center}(sorted_field, grid, sf)
 end
+
 """
     function sort_field_revesre(f)
 Same method as [`sort_field`](@ref) but the 1D array is sorted in _descending_ order.

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -239,7 +239,7 @@ Examples
 ```jldoctest
 julia> using Oceananigans
 
-julia> using Oceanostics.PotentialEnergyEquationTerms: PotentialEnergy
+julia> using Oceanostics.PotentialEnergyEquationTerms: BackgroundPotentialEnergy
 
 julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded))
 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
@@ -260,7 +260,7 @@ julia> bpe = BackgroundPotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: bz_ccc (generic function with 2 methods)
-└── arguments: ("1×1×100 Array{Float64, 3}",)
+└── arguments: ("KernelFunctionOperation at (Center, Center, Center)",)
 ```
 """
 @inline function BackgroundPotentialEnergy(model; location = (Center, Center, Center),

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -3,6 +3,7 @@ module PotentialEnergyEquationTerms
 using DocStringExtensions
 
 export PotentialEnergy
+export sort_field, sorted_field
 
 using Oceananigans.AbstractOperations: KernelFunctionOperation
 using Oceananigans.Models: seawater_density
@@ -12,6 +13,7 @@ using Oceananigans.Grids: NegativeZDirection
 using Oceananigans.BuoyancyModels: Buoyancy, BuoyancyTracer, SeawaterBuoyancy, LinearEquationOfState
 using Oceananigans.BuoyancyModels: buoyancy_perturbationᶜᶜᶜ, Zᶜᶜᶜ
 using Oceananigans.Models: ShallowWaterModel
+using Oceananigans.Fields: Field
 using Oceanostics: validate_location
 using SeawaterPolynomials: BoussinesqEquationOfState
 
@@ -184,4 +186,23 @@ end
 
 @inline g′z_ccc(i, j, k, grid, ρ, p) = (p.g / p.ρ₀) * ρ[i, j, k] * Zᶜᶜᶜ(i, j, k, grid)
 
+## Background Potential Energy drafts
+
+resorted_field(i, j, k, grid, sf) = sf[i, j, k]
+function sorted_field(f::Field)
+    grid = f.grid
+    sorted_f = reshape(sort(reshape(f, :)), size(f))
+    return KernelFunctionOperation{Center, Center, Center}(resorted_field, grid, sorted_f)
+end
+
+function background_potential_energy(model)
+
+    return nothing
+end
+
+## Background potential energy would look like
+# Eb = gρ✶z/ρ₀ where ρ✶ is the sorted density field
+# or Eb = gρz✶/ρ₀ where z✶ = z[sortperm(ρ)]
+# so could have g/ρ₀ * ρ✶[i, j, k] * zᶜᶜᶜ(i, j, k, grid)
+# how to minimise the computation here? ie can I just return one kernel function operation?
 end # module

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -217,7 +217,7 @@ end
 Return a `KernelFunctionOperation` to compute the `BackgroundPotentialEnergy`
 per unit volume,
 ```math
-E_{b} = \\frac{gρz✶}{ρ₀} = -bz.
+E_{b} = \\frac{gρz✶}{ρ₀} = -bz✶.
 ```
 The `BackgroundPotentialEnergy` is the potential energy computed by adiabatically resorting
 the buoyancy or density field into a reference state of minimal potential energy.

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -176,8 +176,9 @@ VolumeField(grid, loc=(Center, Center, Center)) = MetricField(loc, grid, volume)
     function OneDReferenceField(f::Field)
 Return a `OneDReferenceField` of the data in `f` and the corresponding `z✶` coordinate.
 The gridded data is first reshaped into a 1D `Array` then sorted. Returned is a new `Field`
-of this sorted data as well as the `z✶` `Field` that are both on a grid that has the same vertical extent
-as the original field (`f.grid.Lz`) but with the resolution of the whole domain (`Nx * Ny * Nz`).
+of this sorted data as well as the `z✶` `Field` that are both on a one-dimensional grid that
+has the same vertical extent as the original field (`f.grid.Lz`) but with the same _total_
+number of points of the original domain (`Nx * Ny * Nz`).
 The `z✶` `Field` is defined as
 ```math
 \\frac{1}{A}\\int_{f\\mathrm{min}}^{f\\mathrm{max}} \\mathrm{d}V.

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -193,26 +193,11 @@ array throughout the grid such that the _largest_ values are at the top of the g
 the smallest values are at the _bottom_ of the grid.
 """
 @inline sort_field(f) = reshape(sort(reshape(f, :)), size(f))
-
-@inline function sort_field(f::Field)
-    grid = f.grid
-    sorted_field = sort_field(f)
-    return KernelFunctionOperation{Center, Center, Center}(resorted_field, grid, sorted_field)
-end
 """
     function sort_field_revesre(f)
 Same method as [`sort_field`](@ref) but the 1D array is sorted in _descending_ order.
 """
 @inline sort_field_reverse(f) = reshape(sort(reshape(f, :), rev = true), size(f))
-
-@inline function sort_field_reverse(f::Field)
-    grid = f.grid
-    sorted_field = sort_field_reverse(f)
-    return KernelFunctionOperation{Center, Center, Center}(resorted_field, grid, sorted_field)
-end
-
-# For testing and validating `sort`ed fields.
-@inline resorted_field(i, j, k, grid, sf) = sf[i, j, k]
 
 """
     $(SIGNATURES)

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -269,7 +269,7 @@ linear_eos_buoyancy(grid, buoyancy, tracers) = KernelFunctionOperation{Center, C
     b = linear_eos_buoyancy(grid, buoyancy, tracers)
     b = Field(b)
     compute!(b)
-    b✶ = reshape(sort(reshape(b, :), rev = true))
+    b✶ = reshape(sort(reshape(b, :)), size(grid))
 
     return KernelFunctionOperation{Center, Center, Center}(bz_ccc, grid, b✶)
 end

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -180,9 +180,10 @@ has the same vertical extent as the original field (`f.grid.Lz`) but with the sa
 number of points of the original domain (`Nx * Ny * Nz`).
 The `z✶` `Field` is defined as
 ```math
-\\frac{1}{A}\\int_{f\\mathrm{min}}^{f\\mathrm{max}} \\mathrm{d}V.
+-\\frac{1}{A}\\int_{f\\mathrm{min}}^{f\\mathrm{max}} \\mathrm{d}V.
 ```
-and is computed by cumulatively summing the 1D `Array` of grid volumes `ΔV`.
+and is computed by cumulatively summing the 1D `Array` of grid volumes `ΔV`. The negative sign
+ensures that `z✶` is increasing over the same range and same direction as `f.grid`.
 **Note:** `OneDReferenceField` is currently only appropriate for grids that have uniform
 horizontal area.
 """
@@ -195,7 +196,7 @@ function OneDReferenceField(f::Field; rev = false)
 
     p = sortperm(field_data; rev)
     sorted_field_data = field_data[p]
-    z✶ = cumsum(v[p]) / area # divide by area at surface
+    z✶ = -cumsum(v[p]) / area # divide by area at surface
 
     grid_arch = f.grid.architecture
     grid_size = prod(size(f.grid))
@@ -216,7 +217,7 @@ end
 Return a `KernelFunctionOperation` to compute the `BackgroundPotentialEnergy`
 per unit volume,
 ```math
-E_{b} = \\frac{gρz✶}{ρ₀}.
+E_{b} = \\frac{gρz✶}{ρ₀} = -bz.
 ```
 The `BackgroundPotentialEnergy` is the potential energy computed by adiabatically resorting
 the buoyancy or density field into a reference state of minimal potential energy.

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -171,15 +171,17 @@ VolumeField(grid, loc=(Center, Center, Center)) = MetricField(loc, grid, volume)
 
 """
     function OneDReferenceField(f::Field)
-Return a `OneDReferenceField` of the gridded data from the `Field` `f` and the `z✶` for the `Field`.
-The gridded data is first reshaped into a 1D `Array` then sorted. Returned is a new `Field` of this sorted data
-on a z✶ `grid`. The z✶ `grid` is defined as
+Return a `OneDReferenceField` of the data in `f` and the corresponding `z✶` coordinate.
+The gridded data is first reshaped into a 1D `Array` then sorted. Returned is a new `Field`
+of this sorted data as well as the `z✶` `Field` that are both on a grid that has the same vertical extent
+as the original field (`f.grid.Lz`) but with the resolution of the whole domain (`Nx * Ny * Nz`).
+The `z✶` `Field` is defined as
 ```math
 \\frac{1}{A}\\int_{f\\mathrm{min}}^{f\\mathrm{max}} \\mathrm{d}V.
 ```
 and is computed by cumulatively summing the 1D `Array` of grid volumes `ΔV`.
-**Note:** the `OneDReferenceField` is only appropriate for grids that have uniform horizontal
-area.
+**Note:** `OneDReferenceField` is currently only appropriate for grids that have uniform
+horizontal area.
 """
 function OneDReferenceField(f::Field; rev = false)
 

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -189,7 +189,7 @@ end
 @inline resorted_field(i, j, k, grid, sf) = sf[i, j, k]
 @inline function sort_field(f::Field)
     grid = f.grid
-    sorted_field = reshape(sort(reshape(f, :)), size(f))
+    sorted_field = reshape(sort(reshape(f, :), rev = true), size(f))
     return KernelFunctionOperation{Center, Center, Center}(resorted_field, grid, sorted_field)
 end
 
@@ -249,7 +249,7 @@ end
 @inline function BackgroundPotentialEnergy(model, buoyancy_model::BuoyancyTracerModel, geopotential_height)
 
     grid = model.grid
-    b✶ = reshape(sort(reshape(model.tracers.b, :)), size(grid))
+    b✶ = reshape(sort(reshape(model.tracers.b, :), rev = true), size(grid))
 
     return KernelFunctionOperation{Center, Center, Center}(bz_ccc, grid, b✶)
 end
@@ -264,7 +264,7 @@ linear_eos_buoyancy(grid, buoyancy, tracers) = KernelFunctionOperation{Center, C
     b = linear_eos_buoyancy(grid, buoyancy, tracers)
     b = Field(b)
     compute!(b)
-    b✶ = reshape(sort(reshape(b, :)), size(grid))
+    b✶ = reshape(sort(reshape(b, :), rev = true), size(grid))
 
     return KernelFunctionOperation{Center, Center, Center}(bz_ccc, grid, b✶)
 end
@@ -274,7 +274,7 @@ end
     grid = model.grid
     ρ = Field(seawater_density(model; geopotential_height))
     compute!(ρ)
-    ρ✶ = reshape(sort(reshape(ρ, :)), size(grid))
+    ρ✶ = reshape(sort(reshape(ρ, :), rev = true), size(grid))
     parameters = (g = model.buoyancy.model.gravitational_acceleration,
                   ρ₀ = model.buoyancy.model.equation_of_state.reference_density)
 

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -164,10 +164,8 @@ end
 ## Grid metrics from https://github.com/tomchor/Oceanostics.jl/issues/163#issuecomment-2012623824
 
 function MetricField(loc, grid, metric)
-
     metric_operation = GridMetricOperation(loc, metric, grid)
     metric_field = Field(metric_operation)
-
     return compute!(metric_field)
 end
 

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -214,48 +214,26 @@ julia> using Oceananigans
 
 julia> using Oceanostics.PotentialEnergyEquationTerms: PotentialEnergy
 
-julia> grid = RectilinearGrid(size=5, z=(-5, 0), topology=(Flat, Flat, Bounded))
-1×1×5 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded))
+1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── Flat x
 ├── Flat y
-└── Bounded  z ∈ [-5.0, 0.0]      regularly spaced with Δz=1.0
+└── Bounded  z ∈ [-1000.0, 0.0]   regularly spaced with Δz=10.0
 
 julia> model = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=(:b,))
 NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
-├── grid: 1×1×5 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── timestepper: QuasiAdamsBashforth2TimeStepper
 ├── tracers: b
 ├── closure: Nothing
 ├── buoyancy: BuoyancyTracer with ĝ = NegativeZDirection()
 └── coriolis: Nothing
 
-julia> set!(model, b = randn(size(model.grid)));
-
-julia> interior(model.tracers.b, 1, 1, :)
-5-element view(::Array{Float64, 3}, 1, 1, 4:8) with eltype Float64:
-  1.6132888274716937
- -0.7877032120116347
- -0.9357749288520266
-  1.310757334669075
-  0.09514543268446216
-
 julia> bpe = BackgroundPotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
-├── grid: 1×1×5 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: bz_ccc (generic function with 2 methods)
-└── arguments: ("1×1×5 Array{Float64, 3}",)
-
-julia> bpe_field = Field(bpe);
-
-julia> compute!(bpe_field);
-
-julia> interior(bpe_field, 1, 1, :)
-5-element view(::Array{Float64, 3}, 1, 1, 4:8) with eltype Float64:
-  4.210987179834119
-  2.7569612420407217
- -0.2378635817111554
- -1.9661360020036125
- -0.8066444137358468
+└── arguments: ("1×1×100 Array{Float64, 3}",)
 ```
 """
 @inline function BackgroundPotentialEnergy(model; location = (Center, Center, Center),

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -4,7 +4,7 @@ using DocStringExtensions
 
 export PotentialEnergy, BackgroundPotentialEnergy, OneDReferenceField
 
-using Oceananigans.AbstractOperations: KernelFunctionOperation, volume, Az, GridMetricOperation
+using Oceananigans.AbstractOperations: AbstractOperation, KernelFunctionOperation, volume, Az, GridMetricOperation
 using Oceananigans.Models: seawater_density
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 using Oceananigans.Grids
@@ -187,7 +187,7 @@ ensures that `z✶` is increasing over the same range and same direction as `f.g
 **Note:** `OneDReferenceField` is currently only appropriate for grids that have uniform
 horizontal area.
 """
-function OneDReferenceField(f::Field; rev = false)
+function OneDReferenceField(f::Union{Field, AbstractOperation}; rev = false)
 
     area = sum(AreaField(f.grid))
     volume_field = VolumeField(f.grid)

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -189,6 +189,11 @@ end
 @inline resorted_field(i, j, k, grid, sf) = sf[i, j, k]
 @inline function sort_field(f::Field)
     grid = f.grid
+    sorted_field = reshape(sort(reshape(f, :)), size(f))
+    return KernelFunctionOperation{Center, Center, Center}(resorted_field, grid, sorted_field)
+end
+@inline function sort_field_rev(f::Field)
+    grid = f.grid
     sorted_field = reshape(sort(reshape(f, :), rev = true), size(f))
     return KernelFunctionOperation{Center, Center, Center}(resorted_field, grid, sorted_field)
 end
@@ -249,7 +254,7 @@ end
 @inline function BackgroundPotentialEnergy(model, buoyancy_model::BuoyancyTracerModel, geopotential_height)
 
     grid = model.grid
-    b✶ = reshape(sort(reshape(model.tracers.b, :), rev = true), size(grid))
+    b✶ = reshape(sort(reshape(model.tracers.b, :)), size(grid))
 
     return KernelFunctionOperation{Center, Center, Center}(bz_ccc, grid, b✶)
 end
@@ -264,7 +269,7 @@ linear_eos_buoyancy(grid, buoyancy, tracers) = KernelFunctionOperation{Center, C
     b = linear_eos_buoyancy(grid, buoyancy, tracers)
     b = Field(b)
     compute!(b)
-    b✶ = reshape(sort(reshape(b, :), rev = true), size(grid))
+    b✶ = reshape(sort(reshape(b, :), rev = true))
 
     return KernelFunctionOperation{Center, Center, Center}(bz_ccc, grid, b✶)
 end

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -288,7 +288,7 @@ end
     parameters = (g = model.buoyancy.model.gravitational_acceleration,
                   ρ₀ = model.buoyancy.model.equation_of_state.reference_density)
 
-    return KernelFunctionOperation{Center, Center, Center}(g′z_ccc, grid, sorted_density, z✶, parameters)
+    return KernelFunctionOperation{Center, Center, Center}(g′z✶_ccc, grid, sorted_density, z✶, parameters)
 end
 
 @inline g′z✶_ccc(i, j, k, grid, ρ, z✶, p) = (p.g / p.ρ₀) * ρ[i, j, k] * z✶[i, j, k]

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -56,7 +56,7 @@ julia> using Oceanostics.PotentialEnergyEquationTerms: PotentialEnergy
 
 julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Bounded));
 
-julia> model = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=(:b,));
+julia> model = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -204,7 +204,7 @@ end
 Return a `kernelFunctionOperation` to compute the `BackgroundPotentialEnergy` per unit
 volume,
 ```math
-Eₚ = \\frac{gρ✶z}{ρ₀}.
+E_{b} = \\frac{gρ✶z}{ρ₀}.
 ```
 The `BackgroundPotentialEnergy` is the potential energy computed after adiabatically resorting
 the buoyancy or density field into a reference state of minimal potential energy.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -413,7 +413,7 @@ function test_1D_reference_field(model; geopotential_height = 0)
 
         v_grid = VolumeField(model.grid)
         A = sum(AreaField(model.grid))
-        z✶_check = cumsum(reshape(v_grid, :)[p]) / A
+        z✶_check = -cumsum(reshape(v_grid, :)[p]) / A
 
         sorted_buoyancy, z✶ = OneDReferenceField(model.tracers.b, rev = true)
 
@@ -430,7 +430,7 @@ function test_1D_reference_field(model; geopotential_height = 0)
 
         v_grid = VolumeField(model.grid)
         A = sum(AreaField(model.grid))
-        z✶_check = cumsum(reshape(v_grid, :)[p]) / A
+        z✶_check = -cumsum(reshape(v_grid, :)[p]) / A
 
         sorted_buoyancy, z✶ = OneDReferenceField(b, rev = true)
 
@@ -447,7 +447,7 @@ function test_1D_reference_field(model; geopotential_height = 0)
 
         v_grid = VolumeField(model.grid)
         A = sum(AreaField(model.grid))
-        z✶_check = cumsum(reshape(v_grid, :)[p]) / A
+        z✶_check = -cumsum(reshape(v_grid, :)[p]) / A
 
         sorted_density, z✶ = OneDReferenceField(ρ)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -364,10 +364,9 @@ function test_potential_energy_equation_terms_errors(model)
     return nothing
 end
 
-function test_potential_energy_equation_terms(model; geopotential_height = nothing)
+function test_potential_energy_equation_terms(model; geopotential_height = 0)
 
-    Eₚ = isnothing(geopotential_height) ? PotentialEnergy(model) :
-                                          PotentialEnergy(model; geopotential_height)
+    Eₚ = PotentialEnergy(model; geopotential_height)
 
     Eₚ_field = Field(Eₚ)
     @test Eₚ isa AbstractOperation
@@ -375,8 +374,7 @@ function test_potential_energy_equation_terms(model; geopotential_height = nothi
     compute!(Eₚ_field)
 
     if model.buoyancy isa BuoyancyBoussinesqEOSModel
-        ρ = isnothing(geopotential_height) ? Field(seawater_density(model)) :
-                                             Field(seawater_density(model; geopotential_height))
+        ρ = Field(seawater_density(model); geopotential_height)
 
         compute!(ρ)
         Z = Field(model_geopotential_height(model))
@@ -577,7 +575,7 @@ model_types = (NonhydrostaticModel, HydrostaticFreeSurfaceModel)
                     test_potential_energy_equation_terms_errors(model)
                 else
                     test_potential_energy_equation_terms(model)
-                    test_potential_energy_equation_terms(model, geopotential_height = 0)
+                    test_potential_energy_equation_terms(model, geopotential_height = 1000)
                 end
 
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -374,7 +374,7 @@ function test_potential_energy_equation_terms(model; geopotential_height = 0)
     compute!(Eₚ_field)
 
     if model.buoyancy isa BuoyancyBoussinesqEOSModel
-        ρ = Field(seawater_density(model); geopotential_height)
+        ρ = Field(seawater_density(model; geopotential_height))
 
         compute!(ρ)
         Z = Field(model_geopotential_height(model))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,9 @@ using SeawaterPolynomials: RoquetEquationOfState, TEOS10EquationOfState
 using Oceanostics
 using Oceanostics: TKEBudgetTerms, TracerVarianceBudgetTerms, FlowDiagnostics, PressureRedistributionTerm, BuoyancyProductionTerm, AdvectionTerm
 using Oceanostics.TKEBudgetTerms: AdvectionTerm
-using Oceanostics: PotentialEnergy, PotentialEnergyEquationTerms.BuoyancyBoussinesqEOSModel
+using Oceanostics: PotentialEnergy, BackgroundPotentialEnergy
+using Oceanostics.PotentialEnergyEquationTerms: OneDReferenceField, linear_eos_buoyancy
+using Oceanostics.PotentialEnergyEquationTerms: BuoyancyTracerModel, BuoyancyLinearEOSModel, BuoyancyBoussinesqEOSModel
 using Oceanostics.ProgressMessengers
 using Oceanostics: perturbation_fields
 
@@ -360,6 +362,8 @@ function test_potential_energy_equation_terms_errors(model)
 
     @test_throws ArgumentError PotentialEnergy(model)
     @test_throws ArgumentError PotentialEnergy(model, geopotential_height = 0)
+    @test_throws ArgumentError BackgroundPotentialEnergy(model)
+    @test_throws ArgumentError BackgroundPotentialEnergy(model, geopotential_height = 0)
 
     return nothing
 end
@@ -375,10 +379,11 @@ function test_potential_energy_equation_terms(model; geopotential_height = 0)
 
     if model.buoyancy isa BuoyancyBoussinesqEOSModel
         ρ = Field(seawater_density(model; geopotential_height))
-
         compute!(ρ)
+
         Z = Field(model_geopotential_height(model))
         compute!(Z)
+
         ρ₀ = model.buoyancy.model.equation_of_state.reference_density
         g = model.buoyancy.model.gravitational_acceleration
 
@@ -386,6 +391,45 @@ function test_potential_energy_equation_terms(model; geopotential_height = 0)
             true_value = (g / ρ₀) .* ρ.data .* Z.data
             @test isequal(Eₚ_field.data, true_value)
         end
+    end
+
+    Eb = BackgroundPotentialEnergy(model; geopotential_height)
+
+    Eb_field = Field(Eb)
+    @test Eb isa AbstractOperation
+    @test Eb_field isa Field
+    compute!(Eb_field)
+
+    return nothing
+end
+function test_1D_reference_field(model; geopotential_height = 0)
+
+    if model.buoyancy isa BuoyancyTracerModel
+
+        b_sorted = sort(reshape(interior(model.tracers.b), :), rev = true)
+
+        sorted_buoyancy, z✶ = OneDReferenceField(model.tracers.b, rev = true)
+
+        @test isequal(reshape(interior(sorted_buoyancy), :), b_sorted)
+
+    elseif model.buoyancy isa BuoyancyLinearEOSModel
+
+        b = Field(linear_eos_buoyancy(model.grid, model.buoyancy.model, model.tracers))
+        compute!(b)
+        b_sorted = sort(reshape(interior(b), :), rev = true)
+
+        sorted_buoyancy, z✶ = OneDReferenceField(b, rev = true)
+
+        @test isequal(reshape(interior(sorted_buoyancy), :), b_sorted)
+
+    elseif model.buoyancy isa BuoyancyBoussinesqEOSModel
+        ρ = Field(seawater_density(model; geopotential_height))
+        compute!(ρ)
+        ρ_data_sorted = sort(reshape(interior(ρ), :))
+
+        sorted_density, z✶ = OneDReferenceField(ρ)
+
+        @test isequal(reshape(interior(sorted_density), :), ρ_data_sorted)
     end
 
     return nothing
@@ -565,7 +609,7 @@ model_types = (NonhydrostaticModel, HydrostaticFreeSurfaceModel)
 
             end
 
-            @info "Testing `PotentialEnergy`"
+            @info "Testing `PotentialEnergy`, `BackgroundPotentialEnergy` and `OneDReferenceField`"
             for buoyancy in buoyancy_models
 
                 tracers = buoyancy isa BuoyancyTracer ? :b : (:S, :T)
@@ -576,6 +620,10 @@ model_types = (NonhydrostaticModel, HydrostaticFreeSurfaceModel)
                 else
                     test_potential_energy_equation_terms(model)
                     test_potential_energy_equation_terms(model, geopotential_height = 1000)
+                    buoyancy isa BuoyancyTracer ? set!(model, b = randn(size(model.grid))) :
+                                                  set!(model, S = randn(size(model.grid)), T = randn(size(model.grid)))
+                    test_1D_reference_field(model)
+                    test_1D_reference_field(model, geopotential_height = 1000)
                 end
 
             end


### PR DESCRIPTION
This PR adds functions to compute the `BackgroundPotentialEnergy`, BPE, (see #168 for discussion on function naming) during a `simulation`. It does so using the definition given in  [Winters et al. (1995)](https://www.cambridge.org/core/journals/journal-of-fluid-mechanics/article/available-potential-energy-and-mixing-in-densitystratified-fluids/A45F1A40521FF0A0DC82BC705AD398DA),

$$
E_{b} = g\int_{V}\rho z^{*}\mathrm{d}V.
$$

To compute $E_{b}$ the buoyancy/density `Field` from a model is first reshaped into a 1D `Array` and then sorted. The  $z^{*}$ (for a density `Field`) is defined as,

$$
z^{*} = \frac{1}{A}\int_{\rho_{\mathrm{min}}}^{\rho_{\mathrm{max}}}\mathrm{d}V.
$$

To compute  $z^{*}$, each volume element from the `model.grid` is computed, reshaped into a 1D `Array`, sorted using the `sortperm` from the buoyancy/density sorting, cumulatively summed then divided by the horizontal area of the `model.grid`.

These computations are done in `OneDReferenceField` which returns two new fields, the sorted buoyancy/density `Field` and the $z^{*}$ `Field`. These returned `Field`s are on a grid with a vertical extent equal to the original `model.grid` but with total number of elements equal to the number of points in the domain (i.e. `model.grid.Nx * model.grid.Ny * model.grid.Nz`). These two new `Field`s are then used to compute the BPE per unit volume. Calling `Integral(Field(BackgroundPotentialEnergy))` will give the volume integrated $E_{b}$ defined above.

I have handled the sorting of buoyancy and density separately because in the case of buoyancy, the buoyancy in the sorted profile should decrease as $z*$ increases,

$$
z^{*} = \frac{1}{A}\int_{b_{\mathrm{max}}}^{b_{\mathrm{min}}}\mathrm{d}V,
$$

whereas the density should increase as $z*$ increases. If this is not clear (or wrong!) please let me know!

I have not tried this using a `GPU` but I think that these functions (`reshape` and `sort`) work with `CuArray`s but I might have some scalar indexing that will cause problems --- when I get a chance to I will try on a `GPU`. 

The tests I have handled are really only validations that `OneDReferenceField` is computing things and returning things in the correct way. If you have any other suggestions for tests let me know.

Examples of the sorting for buoyancy and density using random noise as input data are below (they should be able to be run provided this branch of Oceanostics.jl is being used).

```julia
using Oceananigans, GLMakie
using Oceananigans.Models: seawater_density
using SeawaterPolynomials: TEOS10EquationOfState
using Oceanostics.PotentialEnergyEquationTerms

grid = RectilinearGrid(size=(10, 10, 50), x=(-10, 10), y=(-10, 10), z=(-100, 0),
                       topology=(Bounded, Bounded, Bounded))

## Using buoyancy
model = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=(:b,))
set!(model, b=randn(size(grid)))

buoyancy_reference_profile, z✶ = OneDReferenceField(model.tracers.b, rev = true)

fig1 = Figure(size = (1000, 500))
ax = Axis(fig1[1, 1], title = "x-z slice of buoyancy field",
            xlabel = "x",
            ylabel = "z")
x, z = xnodes(model.grid, Center()), znodes(model.grid, Center())
hm = heatmap!(ax, x, z, interior(model.tracers.b, :, 1, :), colormap = :balance)
Colorbar(fig1[1, 2], hm, label = "buoyancy")
ax2 = Axis(fig1[1, 3], title = "Buoyancy reference profile",
            xlabel = "buoyancy",
            ylabel = "z✶")
lines!(ax2, interior(buoyancy_reference_profile, 1, 1, :), interior(z✶, 1, 1, :))
```
![buoyancy_reference_profile](https://github.com/tomchor/Oceanostics.jl/assets/75812103/55d48ed5-0d47-4370-9818-c8318f9962df)

```julia
## Using density
eos = TEOS10EquationOfState()
model = NonhydrostaticModel(; grid, buoyancy=SeawaterBuoyancy(equation_of_state=eos), tracers=(:S, :T))
set!(model, S=randn(size(grid)), T=randn(size(grid)))
ρ = Field(seawater_density(model))
compute!(ρ)

density_reference_profile, z✶ = OneDReferenceField(ρ)

fig2 = Figure(size = (1000, 500))
ax = Axis(fig2[1, 1], title = "x-z slice of density field",
            xlabel = "x",
            ylabel = "z")
x, z = xnodes(model.grid, Center()), znodes(model.grid, Center())
hm = heatmap!(ax, x, z, interior(ρ, :, 1, :), colormap = :dense)
Colorbar(fig2[1, 2], hm, label = "density")
ax = Axis(fig2[1, 3], title = "Density reference profile",
            xlabel = "Density",
            ylabel = "z✶")
lines!(ax, interior(density_reference_profile, 1, 1, :), interior(z✶, 1, 1, :))
```
![density_reference_profile](https://github.com/tomchor/Oceanostics.jl/assets/75812103/c38058f3-2181-45f1-995e-5237d3f133ab)

cc @janzika