### PR TITLE
Add doctest for `ErtelPotentialVorticty` in docstring

### DIFF
--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -233,6 +233,41 @@ is defined as
 
 where ωₜₒₜ is the total (relative + planetary) vorticity vector, `b` is the buoyancy and ∇ is the gradient
 operator.
+
+```jldoctest
+julia> using Oceananigans
+
+julia> grid = RectilinearGrid(topology = (Flat, Flat, Bounded), size = 4, extent = 1);
+
+julia> model = NonhydrostaticModel(; grid, coriolis=FPlane(1e-4), buoyancy=BuoyancyTracer(), tracers=:b);
+
+julia> stratification(z) = 1e-6 * z;
+
+julia> set!(model, b=stratification)
+
+julia> EPV = ErtelPotentialVorticity(model)
+KernelFunctionOperation at (Face, Face, Face)
+├── grid: 1×1×4 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
+├── kernel_function: ertel_potential_vorticity_fff (generic function with 1 method)
+└── arguments: ("1×1×4 Field{Face, Center, Center} on RectilinearGrid on CPU", "1×1×4 Field{Center, Face, Center} on RectilinearGrid on CPU", "1×1×5 Field{Center, Center, Face} on RectilinearGrid on CPU", "1×1×4 Field{Center, Center, Center} on RectilinearGrid on CPU", "0", "0", "0.0001")
+
+julia> interior(compute!(Field(EPV))) # Let's calculate the EPV for this grid:
+1×1×5 view(::Array{Float64, 3}, 1:1, 1:1, 4:8) with eltype Float64:
+[:, :, 1] =
+ 0.0
+
+[:, :, 2] =
+ 1.0000000000000002e-10
+
+[:, :, 3] =
+ 9.999999999999998e-11
+
+[:, :, 4] =
+ 1.0000000000000002e-10
+
+[:, :, 5] =
+ 0.0
+```
 """
 function ErtelPotentialVorticity(model; location = (Face, Face, Face), add_background = true)
     validate_location(location, "ErtelPotentialVorticity", (Face, Face, Face))

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -239,7 +239,7 @@ julia> using Oceananigans
 
 julia> grid = RectilinearGrid(topology = (Flat, Flat, Bounded), size = 4, extent = 1);
 
-julia> N² = 1e-6
+julia> N² = 1e-6;
 
 julia> b_bcs = FieldBoundaryConditions(top=GradientBoundaryCondition(N²));
 

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -249,6 +249,8 @@ julia> stratification(z) = N² * z;
 
 julia> set!(model, b=stratification)
 
+julia> using Oceanostics: ErtelPotentialVorticity
+
 julia> EPV = ErtelPotentialVorticity(model)
 KernelFunctionOperation at (Face, Face, Face)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
@@ -276,7 +278,6 @@ julia> interior(compute!(Field(EPV)))
 Note that EPV values are correctly calculated both in the interior and the boundaries. In the
 interior and top boundary, EPV = f×N² = 10⁻¹⁰, while EPV = 0 at the bottom boundary since ∂b/∂z
 is zero there.
-
 """
 function ErtelPotentialVorticity(model; location = (Face, Face, Face), add_background = true)
     validate_location(location, "ErtelPotentialVorticity", (Face, Face, Face))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,8 +144,8 @@ function test_buoyancy_diagnostics(model)
     stratification(x, y, z) = N² * z;
 
     S = 1e-3;
-    z_shear(x, y, z) = S * z + S * y;
-    set!(model, u=z_shear, b=stratification)
+    shear(x, y, z) = S*z + S*y;
+    set!(model, u=shear, b=stratification)
 
     Ri = RichardsonNumber(model)
     @test Ri isa AbstractOperation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,21 +140,36 @@ function test_buoyancy_diagnostics(model)
     u, v, w = model.velocities
     b = model.tracers.b
 
+    N² = 1e-5;
+    stratification(x, y, z) = N² * z;
+
+    S = 1e-3;
+    z_shear(x, y, z) = S * z + S * y;
+    set!(model, u=z_shear, b=stratification)
+
     Ri = RichardsonNumber(model)
     @test Ri isa AbstractOperation
-    @test compute!(Field(Ri)) isa Field
+    Ri_field = compute!(Field(Ri))
+    @test Ri_field isa Field
+    @test interior(Ri_field, 3, 3, 3)[1] ≈ N² / S^2
 
     Ri = RichardsonNumber(model, u, v, w, b)
     @test Ri isa AbstractOperation
-    @test compute!(Field(Ri)) isa Field
+    Ri_field = compute!(Field(Ri))
+    @test Ri_field isa Field
+    @test interior(Ri_field, 3, 3, 3)[1] ≈ N² / S^2
 
-    PVe = ErtelPotentialVorticity(model)
-    @test PVe isa AbstractOperation
-    @test compute!(Field(PVe)) isa Field
+    EPV = ErtelPotentialVorticity(model)
+    @test EPV isa AbstractOperation
+    EPV_field = compute!(Field(EPV))
+    @test EPV_field isa Field
+    @test interior(EPV_field, 3, 3, 3)[1] ≈ N² * (model.coriolis.f - S)
 
-    PVe = ErtelPotentialVorticity(model, u, v, w, b, model.coriolis)
-    @test PVe isa AbstractOperation
-    @test compute!(Field(PVe)) isa Field
+    EPV = ErtelPotentialVorticity(model, u, v, w, b, model.coriolis)
+    @test EPV isa AbstractOperation
+    EPV_field = compute!(Field(EPV))
+    @test EPV_field isa Field
+    @test interior(EPV_field, 3, 3, 3)[1] ≈ N² * (model.coriolis.f - S)
 
     PVtw = ThermalWindPotentialVorticity(model)
     @test PVtw isa AbstractOperation


### PR DESCRIPTION
This PR adds a doctest with an example of how to compute the `ErtelPotentialVorticity` to its docstring. It's probably a good idea to improve the test for `ErtelPotentialVorticity` too since right now it only tests that it calculates _something_, when really we wanna make sure it calculates the correct output.