### PR TITLE
Correct sign inconsistency in `PotentialEnergy` diagnostics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
 authors = ["tomchor <tomaschor@gmail.com>"]
-version = "0.14.1"
+version = "0.14.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -17,8 +17,10 @@ using SeawaterPolynomials: BoussinesqEquationOfState
 
 const NoBuoyancyModel = Union{Nothing, ShallowWaterModel}
 const BuoyancyTracerModel = Buoyancy{<:BuoyancyTracer, g} where g
-const BuoyancyLinearEOSModel = Buoyancy{<:SeawaterBuoyancy{FT, <:LinearEquationOfState, T, S} where {FT, T, S}, g} where {g}
-const BuoyancyBoussinesqEOSModel = Buoyancy{<:SeawaterBuoyancy{FT, <:BoussinesqEquationOfState, T, S} where {FT, T, S}, g} where {g}
+const LinearSeawaterBuoyancy = SeawaterBuoyancy{FT, <:LinearEquationOfState, T, S} where {FT, T, S}
+const BuoyancyLinearEOSModel = Buoyancy{<:LinearSeawaterBuoyancy, g} where {g}
+const BoussinesqSeawaterBuoyancy = SeawaterBuoyancy{FT, <:BoussinesqEquationOfState, T, S} where {FT, T, S}
+const BuoyancyBoussinesqEOSModel = Buoyancy{<:BoussinesqSeawaterBuoyancy, g} where {g}
 
 validate_gravity_unit_vector(gravity_unit_vector::NegativeZDirection) = nothing
 validate_gravity_unit_vector(gravity_unit_vector) =
@@ -68,7 +70,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── kernel_function: minus_bz_ccc (generic function with 2 methods)
+├── kernel_function: minus_bz_ccc (generic function with 3 methods)
 └── arguments: ("1×1×100 Field{Center, Center, Center} on RectilinearGrid on CPU",)
 ```
 
@@ -111,7 +113,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── kernel_function: minus_bz_ccc (generic function with 1 method)
+├── kernel_function: minus_bz_ccc (generic function with 3 methods)
 └── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665, ρ₀=1020.0)")
 ```
 
@@ -128,7 +130,7 @@ julia> tracers = (:T, :S);
 
 julia> eos = TEOS10EquationOfState();
 
-julia> buoyancy = SeawaterBuoyancy(equation_of_state=eos);
+julia> tracers = (:T, :S);
 
 julia> model = NonhydrostaticModel(; grid, buoyancy, tracers);
 
@@ -137,7 +139,7 @@ julia> geopotential_height = 0; # density variable will be σ₀
 julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── kernel_function: minus_bz_ccc (generic function with 1 method)
+├── kernel_function: minus_bz_ccc (generic function with 3 methods)
 └── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665, ρ₀=1020.0)")
 ```
 """
@@ -172,7 +174,8 @@ end
     return KernelFunctionOperation{Center, Center, Center}(minus_bz_ccc, grid, b, C)
 end
 
-@inline minus_bz_ccc(i, j, k, grid, b, C) = - buoyancy_perturbationᶜᶜᶜ(i, j, k, grid, b, C) * Zᶜᶜᶜ(i, j, k, grid)
+@inline minus_bz_ccc(i, j, k, grid, b::LinearSeawaterBuoyancy, C) =
+    -buoyancy_perturbationᶜᶜᶜ(i, j, k, grid, b, C) * Zᶜᶜᶜ(i, j, k, grid)
 
 @inline function PotentialEnergy(model, buoyancy_model::BuoyancyBoussinesqEOSModel, geopotential_height)
 

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -29,7 +29,7 @@ validate_gravity_unit_vector(gravity_unit_vector) =
 
 Return a `KernelFunctionOperation` to compute the `PotentialEnergy` per unit volume,
 ```math
-Eₚ = \\frac{gρz}{ρ₀}
+Eₚ = \\frac{gρ}{ρ₀}z = -bz
 ```
 at each grid `location` in `model`. `PotentialEnergy` is defined for both `BuoyancyTracer`
 and `SeawaterBuoyancy`. See the relevant Oceananigans.jl documentation on
@@ -68,7 +68,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── kernel_function: bz_ccc (generic function with 2 methods)
+├── kernel_function: minus_bz_ccc (generic function with 2 methods)
 └── arguments: ("1×1×100 Field{Center, Center, Center} on RectilinearGrid on CPU",)
 ```
 
@@ -111,7 +111,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── kernel_function: g′z_ccc (generic function with 1 method)
+├── kernel_function: minus_bz_ccc (generic function with 1 method)
 └── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665, ρ₀=1020.0)")
 ```
 
@@ -137,7 +137,7 @@ julia> geopotential_height = 0; # density variable will be σ₀
 julia> PotentialEnergy(model)
 KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
-├── kernel_function: g′z_ccc (generic function with 1 method)
+├── kernel_function: minus_bz_ccc (generic function with 1 method)
 └── arguments: ("KernelFunctionOperation at (Center, Center, Center)", "(g=9.80665, ρ₀=1020.0)")
 ```
 """
@@ -158,10 +158,10 @@ end
     grid = model.grid
     b = model.tracers.b
 
-    return KernelFunctionOperation{Center, Center, Center}(bz_ccc, grid, b)
+    return KernelFunctionOperation{Center, Center, Center}(minus_bz_ccc, grid, b)
 end
 
-@inline bz_ccc(i, j, k, grid, b) = b[i, j, k] * Zᶜᶜᶜ(i, j, k, grid)
+@inline minus_bz_ccc(i, j, k, grid, b) = -b[i, j, k] * Zᶜᶜᶜ(i, j, k, grid)
 
 @inline function PotentialEnergy(model, buoyancy_model::BuoyancyLinearEOSModel, geopotential_height)
 
@@ -169,10 +169,10 @@ end
     C = model.tracers
     b = buoyancy_model.model
 
-    return KernelFunctionOperation{Center, Center, Center}(bz_ccc, grid, b, C)
+    return KernelFunctionOperation{Center, Center, Center}(minus_bz_ccc, grid, b, C)
 end
 
-@inline bz_ccc(i, j, k, grid, b, C) = buoyancy_perturbationᶜᶜᶜ(i, j, k, grid, b, C) * Zᶜᶜᶜ(i, j, k, grid)
+@inline minus_bz_ccc(i, j, k, grid, b, C) = - buoyancy_perturbationᶜᶜᶜ(i, j, k, grid, b, C) * Zᶜᶜᶜ(i, j, k, grid)
 
 @inline function PotentialEnergy(model, buoyancy_model::BuoyancyBoussinesqEOSModel, geopotential_height)
 
@@ -181,9 +181,9 @@ end
     parameters = (g = model.buoyancy.model.gravitational_acceleration,
                   ρ₀ = model.buoyancy.model.equation_of_state.reference_density)
 
-    return KernelFunctionOperation{Center, Center, Center}(g′z_ccc, grid, ρ, parameters)
+    return KernelFunctionOperation{Center, Center, Center}(minus_bz_ccc, grid, ρ, parameters)
 end
 
-@inline g′z_ccc(i, j, k, grid, ρ, p) = (p.g / p.ρ₀) * ρ[i, j, k] * Zᶜᶜᶜ(i, j, k, grid)
+@inline minus_bz_ccc(i, j, k, grid, ρ, p) = (p.g / p.ρ₀) * ρ[i, j, k] * Zᶜᶜᶜ(i, j, k, grid)
 
 end # module

--- a/src/PotentialEnergyEquationTerms.jl
+++ b/src/PotentialEnergyEquationTerms.jl
@@ -130,7 +130,7 @@ julia> tracers = (:T, :S);
 
 julia> eos = TEOS10EquationOfState();
 
-julia> tracers = (:T, :S);
+julia> buoyancy = SeawaterBuoyancy(equation_of_state=eos);
 
 julia> model = NonhydrostaticModel(; grid, buoyancy, tracers);
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using CUDA
 
 using Oceananigans
 using Oceananigans.AbstractOperations: AbstractOperation
+using Oceananigans.BuoyancyModels: buoyancy_perturbationᶜᶜᶜ
 using Oceananigans.Fields: @compute
 using Oceananigans.TurbulenceClosures: ThreeDimensionalFormulation
 using Oceananigans.Models: seawater_density, model_geopotential_height
@@ -407,6 +408,27 @@ function test_potential_energy_equation_terms(model; geopotential_height = nothi
 
     return nothing
 end
+function test_PEbuoyancytracer_PElineareos(grid)
+
+    model_buoyancytracer = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=:b)
+    model_lineareos = NonhydrostaticModel(; grid, buoyancy=SeawaterBuoyancy(), tracers=(:S, :T))
+    C_grad(x, y, z) = 0.01 * z
+    set!(model_lineareos, S = C_grad, T = C_grad)
+    linear_eos_buoyancy(grid, buoyancy, tracers) =
+        KernelFunctionOperation{Center, Center, Center}(buoyancy_perturbationᶜᶜᶜ, grid, buoyancy, tracers)
+    b_field = Field(linear_eos_buoyancy(model_lineareos.grid, model_lineareos.buoyancy.model, model_lineareos.tracers))
+    compute!(b_field)
+    set!(model_buoyancytracer, b = interior(b_field))
+    pe_buoyancytracer = Field(PotentialEnergy(model_buoyancytracer))
+    compute!(pe_buoyancytracer)
+    pe_lineareos = Field(PotentialEnergy(model_lineareos))
+    compute!(pe_lineareos)
+
+    @test all(interior(pe_buoyancytracer) .== interior(pe_lineareos))
+
+    return nothing
+
+end
 #---
 
 #+++ Known-value function tests
@@ -596,6 +618,7 @@ model_types = (NonhydrostaticModel, HydrostaticFreeSurfaceModel)
                 end
 
             end
+            test_PEbuoyancytracer_PElineareos(grid)
 
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -618,7 +618,7 @@ model_types = (NonhydrostaticModel, HydrostaticFreeSurfaceModel)
                 end
 
             end
-            test_PEbuoyancytracer_PElineareos(grid)
+            test_PEbuoyancytracer_equals_PElineareos(grid)
 
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -408,7 +408,7 @@ function test_potential_energy_equation_terms(model; geopotential_height = nothi
 
     return nothing
 end
-function test_PEbuoyancytracer_PElineareos(grid)
+function test_PEbuoyancytracer_equals_PElineareos(grid)
 
     model_buoyancytracer = NonhydrostaticModel(; grid, buoyancy=BuoyancyTracer(), tracers=:b)
     model_lineareos = NonhydrostaticModel(; grid, buoyancy=SeawaterBuoyancy(), tracers=(:S, :T))


### PR DESCRIPTION
Thanks @hdrake for finding this! The changes are `bz_ccc` -> `minus_bz_ccc` plus defines $E_{p} = \frac{g \rho}{\rho_{0}}z = -bz$ in the docstring.

Closes #175 