### PR TITLE
Add stretched coordinates back to tilted BBL example

### DIFF
--- a/docs/examples/tilted_bottom_boundary_layer.jl
+++ b/docs/examples/tilted_bottom_boundary_layer.jl
@@ -201,7 +201,7 @@ xF = Array(dims(ds, :xF))
 zC = Array(dims(ds, :zC))
 zF = Array(dims(ds, :zF))
 
-bₙ = @lift set(ds.b[Ti=$n, yC=Near(0)], :xC => X, :zC => Z)
+bₙ = @lift Array(ds.b[Ti=$n, yC=Near(0)])
 
 Riₙ = @lift Array(ds.Ri[Ti=$n, yC=Near(0)])
 hm1 = heatmap!(ax1, xC, zF, Riₙ; colormap = :coolwarm, colorrange = (-1, +1))

--- a/docs/examples/tilted_bottom_boundary_layer.jl
+++ b/docs/examples/tilted_bottom_boundary_layer.jl
@@ -196,21 +196,26 @@ ax3 = Axis(fig[2, 3]; title = "PV", kwargs...);
 
 n = Observable(1)
 
+xC = Array(dims(ds, :xC))
+xF = Array(dims(ds, :xF))
+zC = Array(dims(ds, :zC))
+zF = Array(dims(ds, :zF))
+
 bₙ = @lift set(ds.b[Ti=$n, yC=Near(0)], :xC => X, :zC => Z)
 
-Riₙ = @lift set(ds.Ri[Ti=$n, yC=Near(0)], :xC => X, :zF => Z)
-hm1 = heatmap!(ax1, Riₙ; colormap = :coolwarm, colorrange = (-1, +1))
-contour!(ax1, bₙ; levels=10, color=:white, linestyle=:dash, linewidth=0.5)
+Riₙ = @lift Array(ds.Ri[Ti=$n, yC=Near(0)])
+hm1 = heatmap!(ax1, xC, zF, Riₙ; colormap = :coolwarm, colorrange = (-1, +1))
+contour!(ax1, xC, zC, bₙ; levels=10, color=:white, linestyle=:dash, linewidth=0.5)
 Colorbar(fig[3, 1], hm1, vertical=false, height=8, ticklabelsize=14)
 
-Roₙ = @lift set(ds.Ro[Ti=$n, yF=Near(0)], :xF => X, :zF => Z)
-hm2 = heatmap!(ax2, Roₙ; colormap = :balance, colorrange = (-10, +10))
-contour!(ax2, bₙ; levels=10, color=:black, linestyle=:dash, linewidth=0.5)
+Roₙ = @lift Array(ds.Ro[Ti=$n, yF=Near(0)])
+hm2 = heatmap!(ax2, xF, zF, Roₙ; colormap = :balance, colorrange = (-10, +10))
+contour!(ax2, xC, zC, bₙ; levels=10, color=:black, linestyle=:dash, linewidth=0.5)
 Colorbar(fig[3, 2], hm2, vertical=false, height=8, ticklabelsize=14)
 
-PVₙ = @lift set(ds.PV[Ti=$n, yF=Near(0)], :xF => X, :zF => Z)
-hm3 = heatmap!(ax3, PVₙ; colormap = :coolwarm, colorrange = N²*f₀.*(-1.5, +1.5))
-contour!(ax3, bₙ; levels=10, color=:white, linestyle=:dash, linewidth=0.5)
+PVₙ = @lift Array(ds.PV[Ti=$n, yF=Near(0)])
+hm3 = heatmap!(ax3, xF, zF, PVₙ; colormap = :coolwarm, colorrange = N²*f₀.*(-1.5, +1.5))
+contour!(ax3, xC, zC, bₙ; levels=10, color=:white, linestyle=:dash, linewidth=0.5)
 Colorbar(fig[3, 3], hm3, vertical=false, height=8, ticklabelsize=14);
 
 # Now we mark the time by placing a vertical line in the bottom panel and adding a helpful title

--- a/docs/examples/tilted_bottom_boundary_layer.jl
+++ b/docs/examples/tilted_bottom_boundary_layer.jl
@@ -186,7 +186,7 @@ using CairoMakie
 set_theme!(Theme(fontsize = 20))
 fig = Figure()
 
-kwargs = (xlabel="x", ylabel="z", height=150, width=250)
+kwargs = (xlabel="x [m]", ylabel="z [m]", height=150, width=250)
 ax1 = Axis(fig[2, 1]; title = "Ri", kwargs...)
 ax2 = Axis(fig[2, 2]; title = "Ro", kwargs...)
 ax3 = Axis(fig[2, 3]; title = "PV", kwargs...);


### PR DESCRIPTION
Stretched coordinates removed from the tilted bottom boundary layer example in https://github.com/tomchor/Oceanostics.jl/pull/157 because something about it was causing the docs to get stuck. This PR stretches the vertical coordinate on that grid again.

Closes https://github.com/tomchor/Oceanostics.jl/issues/159