### PR TITLE
Fixes urls in docs examples

### DIFF
--- a/docs/examples/kelvin_helmholtz.jl
+++ b/docs/examples/kelvin_helmholtz.jl
@@ -2,7 +2,7 @@
 #
 # This example simulates a simple 2D Kelvin-Helmholtz instability and is based on the similar
 # [Oceananigans
-# example](https://clima.github.io/OceananigansDocumentation/stable/generated/kelvin_helmholtz_instability/).
+# example](https://clima.github.io/OceananigansDocumentation/stable/literated/kelvin_helmholtz_instability/).
 #
 # Before starting, make sure you have the required packages installed for this example, which can be
 # done with

--- a/docs/examples/tilted_bottom_boundary_layer.jl
+++ b/docs/examples/tilted_bottom_boundary_layer.jl
@@ -1,7 +1,7 @@
 # # Tilted bottom boundary layer example
 #
 # This example is based on the similar [Oceananigans
-# example](https://clima.github.io/OceananigansDocumentation/stable/generated/tilted_bottom_boundary_layer/)
+# example](https://clima.github.io/OceananigansDocumentation/stable/literated/tilted_bottom_boundary_layer/)
 # and simulates a two-dimensional oceanic bottom boundary layer in a domain that's tilted with
 # respect to gravity. We simulate the perturbation away from a constant along-slope
 # (y-direction) velocity constant density stratification.  This perturbation develops into a

--- a/docs/examples/two_dimensional_turbulence.jl
+++ b/docs/examples/two_dimensional_turbulence.jl
@@ -1,7 +1,7 @@
 # # [Two-dimensional turbulence example](@id two_d_turbulence_example)
 #
 # In this example (based on the homonymous [Oceananigans
-# one](https://clima.github.io/OceananigansDocumentation/stable/generated/two_dimensional_turbulence/))
+# one](https://clima.github.io/OceananigansDocumentation/stable/literated/two_dimensional_turbulence/))
 # we simulate a 2D flow initialized with random noise and observe the flow evolve.
 #
 # Before starting, make sure you have the required packages installed for this example, which can be


### PR DESCRIPTION
Apparently the links to Oceananigans examples from the Oceanostics examples are broken. This PR fixes them