### PR TITLE
Export PressureRedistributionTerm

### DIFF
--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -5,7 +5,7 @@ using DocStringExtensions
 export TurbulentKineticEnergy, KineticEnergy
 export KineticEnergyTendency, KineticEnergyStressTerm, KineticEnergyForcingTerm
 export IsotropicKineticEnergyDissipationRate, KineticEnergyDissipationRate
-export XPressureRedistribution, YPressureRedistribution, ZPressureRedistribution
+export PressureRedistributionTerm
 export XShearProductionRate, YShearProductionRate, ZShearProductionRate
 #---
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -367,7 +367,7 @@ function test_tracer_diagnostics(model)
         @test χ_field isa Field
 
         @compute ∂ₜc² = Field(Average(TracerVarianceTendency(model, :b)))
-        @test ≈(Array(interior(ε̄ₚ, 1, 1, 1)), -Array(interior(∂ₜc², 1, 1, 1)), rtol=1e-10, atol=eps())
+        @test ≈(Array(interior(ε̄ₚ, 1, 1, 1)), -Array(interior(∂ₜc², 1, 1, 1)), rtol=1e-10, atol=2*eps())
     end
 
     return nothing


### PR DESCRIPTION
At the moment we're not exporting `PressureRedistributionTerm` at the top level. We're actually exporting `XPressureRedistribution`, etc., which is leftover from old code. This PR fixes that.