### PR TITLE
Generalize `ErtelPotentialVorticity` and `RichardsonNumber` to work when `model.buoyancy` is not `BuoyancyTracer`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
 authors = ["tomchor <tomaschor@gmail.com>"]
-version = "0.14.6"
+version = "0.15.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/docs/examples/tilted_bottom_boundary_layer.jl
+++ b/docs/examples/tilted_bottom_boundary_layer.jl
@@ -146,9 +146,10 @@ simulation.callbacks[:progress] = Callback(progress, IterationInterval(400))
 
 using Oceanostics
 
-Ri = RichardsonNumber(model, add_background=true)
+b = model.tracers.b + model.background_fields.tracers.b
+Ri = RichardsonNumber(model, model.velocities..., b)
 Ro = RossbyNumber(model)
-PV = ErtelPotentialVorticity(model, add_background=true)
+PV = ErtelPotentialVorticity(model, model.velocities..., b, model.coriolis)
 
 # Note that the calculation of these quantities depends on the alignment with the true (geophysical)
 # vertical and the rotation axis. Oceanostics already takes that into consideration by using
@@ -159,7 +160,7 @@ PV = ErtelPotentialVorticity(model, add_background=true)
 #
 # Now we write these quantities to a NetCDF file:
 
-output_fields = (; Ri, Ro, PV, b = model.tracers.b + model.background_fields.tracers.b)
+output_fields = (; Ri, Ro, PV, b)
 
 filename = "tilted_bottom_boundary_layer"
 simulation.output_writers[:nc] = NetCDFOutputWriter(model, output_fields,

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -187,7 +187,7 @@ is defined as
 where `f` is the Coriolis frequency, `ωᶻ` is the relative vorticity in the `z` direction, `b` is the buoyancy, and
 `∂U/∂z` and `∂V/∂z` comprise the thermal wind shear.
 """
-function ThermalWindPotentialVorticity(model; tracer=:b, location = (Face, Face, Face))
+function ThermalWindPotentialVorticity(model; tracer = :b, location = (Face, Face, Face))
     validate_location(location, "ThermalWindPotentialVorticity", (Face, Face, Face))
     u, v, w = model.velocities
     return ThermalWindPotentialVorticity(model, u, v, model.tracers[tracer], model.coriolis; location)
@@ -276,7 +276,7 @@ Note that EPV values are correctly calculated both in the interior and the bound
 interior and top boundary, EPV = f×N² = 10⁻¹⁰, while EPV = 0 at the bottom boundary since ∂b/∂z
 is zero there.
 """
-function ErtelPotentialVorticity(model; tracer=:b, location = (Face, Face, Face))
+function ErtelPotentialVorticity(model; tracer = :b, location = (Face, Face, Face))
     validate_location(location, "ErtelPotentialVorticity", (Face, Face, Face))
     return ErtelPotentialVorticity(model, model.velocities..., model.tracers[tracer], model.coriolis; location)
 end
@@ -324,7 +324,7 @@ basde on a `model` and a `direction`. The Ertel Potential Vorticity is defined a
 where ωₜₒₜ is the total (relative + planetary) vorticity vector, `b` is the buoyancy and ∇ is the gradient
 operator.
 """
-function DirectionalErtelPotentialVorticity(model, direction; tracer=:b, location = (Face, Face, Face))
+function DirectionalErtelPotentialVorticity(model, direction; tracer = :b, location = (Face, Face, Face))
     validate_location(location, "DirectionalErtelPotentialVorticity", (Face, Face, Face))
     return DirectionalErtelPotentialVorticity(model, direction, model.velocities..., model.tracers[tracer], model.coriolis; location)
 end
@@ -369,7 +369,7 @@ symmetric part of the velocity gradient tensor:
 Its modulus is then defined (using Einstein summation notation) as
 
 ```
-    || Sᵢⱼ || = √( Sᵢⱼ Sᵢⱼ)
+    || Sᵢⱼ || = √(Sᵢⱼ Sᵢⱼ)
 ```
 """
 function StrainRateTensorModulus(model; location = (Center, Center, Center))
@@ -404,7 +404,7 @@ antisymmetric part of the velocity gradient tensor:
 Its modulus is then defined (using Einstein summation notation) as
 
 ```
-    || Ωᵢⱼ || = √( Ωᵢⱼ Ωᵢⱼ)
+    || Ωᵢⱼ || = √(Ωᵢⱼ Ωᵢⱼ)
 ```
 """
 function VorticityTensorModulus(model; location = (Center, Center, Center))
@@ -435,7 +435,7 @@ gradient tensor `∂ⱼuᵢ`:
 from where `Q` is defined as
 
 ```
-    Q = ½ ( ΩᵢⱼΩᵢⱼ - SᵢⱼSᵢⱼ)
+    Q = ½ (ΩᵢⱼΩᵢⱼ - SᵢⱼSᵢⱼ)
 ```
 and where `Sᵢⱼ= ½(∂ⱼuᵢ + ∂ᵢuⱼ)` and `Ωᵢⱼ= ½(∂ⱼuᵢ - ∂ᵢuⱼ)`. More info about it can be found in
 doi:10.1063/1.5124245.

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -68,20 +68,10 @@ Calculate the Richardson Number as
 
 where `z` is the true vertical direction (ie anti-parallel to gravity).
 """
-function RichardsonNumber(model; location = (Center, Center, Face), add_background=true)
+function RichardsonNumber(model; location = (Center, Center, Face))
     validate_location(location, "RichardsonNumber", (Center, Center, Face))
-
-    if (model isa NonhydrostaticModel) & add_background
-        full_fields = add_background_fields(model)
-        u, v, w, b = full_fields.u, full_fields.v, full_fields.w, full_fields.b
-    else
-        u, v, w = model.velocities
-        b = model.tracers.b
-    end
-
-    return RichardsonNumber(model, u, v, w, b; location)
+    return RichardsonNumber(model, model.velocities..., buoyancy(model); location)
 end
-
 
 function RichardsonNumber(model, u, v, w, b; location = (Center, Center, Face))
     validate_location(location, "RichardsonNumber", (Center, Center, Face))
@@ -93,6 +83,11 @@ function RichardsonNumber(model, u, v, w, b; location = (Center, Center, Face))
     else
         true_vertical_direction = .-model.buoyancy.gravity_unit_vector
     end
+    return RichardsonNumber(model, u, v, w, b, true_vertical_direction; location = (Center, Center, Face))
+end
+
+function RichardsonNumber(model, u, v, w, b, true_vertical_direction; location = (Center, Center, Face))
+    validate_location(location, "RichardsonNumber", (Center, Center, Face))
     return KernelFunctionOperation{Center, Center, Face}(richardson_number_ccf, model.grid,
                                                          u, v, w, b, true_vertical_direction)
 end

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -57,15 +57,15 @@ function add_background_fields(model)
     velocities = model.velocities
     # Adds background velocities to their perturbations only if background velocity isn't ZeroField
     full_velocities = NamedTuple{keys(velocities)}((model.background_fields.velocities[key] isa ZeroField) ?
-                                                   val :
-                                                   Field(val + model.background_fields.velocities[key])
-                                                   for (key,val) in zip(keys(velocities), velocities))
+                                                    val :
+                                                    Field(val + model.background_fields.velocities[key])
+                                                    for (key, val) in zip(keys(velocities), velocities))
     tracers = model.tracers
     # Adds background tracer fields to their perturbations only if background tracer field isn't ZeroField
     full_tracers = NamedTuple{keys(tracers)}((model.background_fields.tracers[key] isa ZeroField) ?
                                               val :
                                               Field(val + model.background_fields.tracers[key])
-                                              for (key,val) in zip(keys(tracers), tracers))
+                                              for (key, val) in zip(keys(tracers), tracers))
 
     return merge(full_velocities, full_tracers)
 end

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -98,6 +98,28 @@ function perturbation_fields(model; kwargs...)
 end
 #---
 
+#+++ Utils for Coriolis frequency
+using Oceananigans: FPlane, ConstantCartesianCoriolis
+function get_coriolis_frequency_components(coriolis)
+    @show coriolis
+    if coriolis isa FPlane
+        fx = fy = 0
+        fz = coriolis.f
+    elseif coriolis isa ConstantCartesianCoriolis
+        fx = coriolis.fx
+        fy = coriolis.fy
+        fz = coriolis.fz
+    elseif coriolis == nothing
+        fx = fy = fz = 0
+    else
+        throw(ArgumentError("Extraction of rotation components is only implemented for `FPlane`, `ConstantCartesianCoriolis` and `nothing`."))
+    end
+    return fx, fy, fz
+end
+
+get_coriolis_frequency_components(model) = get_coriolis_frequency_components(model.coriolis)
+#---
+
 #+++ A few utils for closure tuples:
 using Oceananigans.TurbulenceClosures: νᶜᶜᶜ
 

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -101,7 +101,6 @@ end
 #+++ Utils for Coriolis frequency
 using Oceananigans: FPlane, ConstantCartesianCoriolis, AbstractModel
 function get_coriolis_frequency_components(coriolis)
-    @show coriolis
     if coriolis isa FPlane
         fx = fy = 0
         fz = coriolis.f

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -99,7 +99,7 @@ end
 #---
 
 #+++ Utils for Coriolis frequency
-using Oceananigans: FPlane, ConstantCartesianCoriolis
+using Oceananigans: FPlane, ConstantCartesianCoriolis, AbstractModel
 function get_coriolis_frequency_components(coriolis)
     @show coriolis
     if coriolis isa FPlane
@@ -117,7 +117,7 @@ function get_coriolis_frequency_components(coriolis)
     return fx, fy, fz
 end
 
-get_coriolis_frequency_components(model) = get_coriolis_frequency_components(model.coriolis)
+get_coriolis_frequency_components(model::AbstractModel) = get_coriolis_frequency_components(model.coriolis)
 #---
 
 #+++ A few utils for closure tuples:


### PR DESCRIPTION
Easy fix. I wasn't aware that the function `Oceananigans.BuoyancyFormulations.buoyancy` existed when I first coded EPV.