### PR TITLE
Bump patch version to create docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
 authors = ["tomchor <tomaschor@gmail.com>"]
-version = "0.15.0"
+version = "0.15.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
The docs for 0.15 (a breaking release) weren't created because of issues solved in https://github.com/tomchor/Oceanostics.jl/pull/192. I'm tagging a patch release to force building of the docs.