### PR TITLE
Make CI trigger for any pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 on:
-  - push
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
 
 jobs:
   vel_diagnostics:


### PR DESCRIPTION
CI apparently isn't triggered my PRs from forks at the moment (see https://github.com/tomchor/Oceanostics.jl/pull/182) and, according to [this page](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/approving-workflow-runs-from-public-forks) the changes here should change that.