### PR TITLE
Extend test coverage to HydrostaticFreeSurfaceModel

### DIFF
--- a/test/test_canonical_flows.jl
+++ b/test/test_canonical_flows.jl
@@ -31,6 +31,9 @@ closures = (ScalarDiffusivity(ν=1e-6, κ=1e-7),
 
 grids = Dict("regular grid" => regular_grid,
              "stretched grid" => stretched_grid)
+
+model_types = (NonhydrostaticModel,
+               HydrostaticFreeSurfaceModel)
 #---
 
 #+++ Test functions
@@ -42,7 +45,11 @@ function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=
     model = model_type(grid; closure)
     u₀(x, y, z) = +α*x
     v₀(x, y, z) = -α*y
-    set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
+    if model isa NonhydrostaticModel
+        set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
+    else
+        set!(model, u=u₀, v=v₀)
+    end
 
     u, v, w = model.velocities
 
@@ -63,7 +70,7 @@ function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=
         ν = ν_field isa Number ? ν_field : getindex(ν_field, idxs...)
 
         @test getindex(S, idxs...) ≈ √2*α
-        @test getindex(Ω, idxs...) ≈ 0
+        @test ≈(getindex(Ω, idxs...), 0, atol=10eps())
         @test getindex(q, idxs...) ≈ (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2 ≈ -α^2
         @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2
     end
@@ -79,7 +86,11 @@ function test_solid_body_rotation_flow(grid; model_type=NonhydrostaticModel, clo
     model = model_type(grid; closure)
     u₀(x, y, z) = +ζ*y / 2
     v₀(x, y, z) = -ζ*x / 2
-    set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
+    if model isa NonhydrostaticModel
+        set!(model, u=u₀, v=v₀, w=0, enforce_incompressibility=false)
+    else
+        set!(model, u=u₀, v=v₀)
+    end
 
     u, v, w = model.velocities
 
@@ -113,7 +124,11 @@ and QVelocityGradientTensorInvariant have the right values for a uniform shear f
 function test_uniform_shear_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), σ=1)
     model = model_type(grid; closure)
     u₀(x, y, z) = σ * y
-    set!(model, u=u₀, v=0, w=0, enforce_incompressibility=false)
+    if model isa NonhydrostaticModel
+        set!(model, u=u₀, v=0, w=0, enforce_incompressibility=false)
+    else
+        set!(model, u=u₀)
+    end
 
     u, v, w = model.velocities
 
@@ -146,16 +161,19 @@ end
     @info "  Testing known flows"
     for (grid_class, grid) in zip(keys(grids), values(grids))
         @info "    with $grid_class"
-        for closure in closures
-            @info "        with $(summary(closure))"
-            @info "          Testing uniform strain flow"
-            test_uniform_strain_flow(grid; closure, α=3)
+        for model_type in model_types
+            @info "      with $model_type"
+            for closure in closures
+                @info "        with $(summary(closure))"
+                @info "          Testing uniform strain flow"
+                test_uniform_strain_flow(grid; model_type, closure, α=3)
 
-            @info "          Testing solid body rotation flow"
-            test_solid_body_rotation_flow(grid; closure, ζ=3)
+                @info "          Testing solid body rotation flow"
+                test_solid_body_rotation_flow(grid; model_type, closure, ζ=3)
 
-            @info "          Testing uniform shear flow"
-            test_uniform_shear_flow(grid; closure, σ=3)
+                @info "          Testing uniform shear flow"
+                test_uniform_shear_flow(grid; model_type, closure, σ=3)
+            end
         end
     end
 end

--- a/test/test_progress_messengers.jl
+++ b/test/test_progress_messengers.jl
@@ -15,11 +15,16 @@ regular_grid = RectilinearGrid(arch, size=(N, N, N), extent=(1, 1, 1))
 #---
 
 #+++ Testing options
-closures = (ScalarDiffusivity(ν=1e-6, κ=1e-7),
-            SmagorinskyLilly(),
-            DynamicSmagorinsky(averaging=(1, 2)),
-            DynamicSmagorinsky(averaging=LagrangianAveraging()),
-            (ScalarDiffusivity(ν=1e-6, κ=1e-7), AnisotropicMinimumDissipation()),)
+nonhydrostatic_closures = (ScalarDiffusivity(ν=1e-6, κ=1e-7),
+                           SmagorinskyLilly(),
+                           DynamicSmagorinsky(averaging=(1, 2)),
+                           DynamicSmagorinsky(averaging=LagrangianAveraging()),
+                           (ScalarDiffusivity(ν=1e-6, κ=1e-7), AnisotropicMinimumDissipation()),)
+
+hydrostatic_closures = (ScalarDiffusivity(ν=1e-6, κ=1e-7),)
+
+model_closures = ((NonhydrostaticModel, nonhydrostatic_closures),
+                  (HydrostaticFreeSurfaceModel, hydrostatic_closures))
 #---
 
 #+++ Testing functions
@@ -33,36 +38,39 @@ end
 
 @testset "ProgressMessenger tests" begin
     @info "    Testing ProgressMessengers"
-    for closure in closures
-        model = NonhydrostaticModel(regular_grid;
-                                    buoyancy = BuoyancyForce(BuoyancyTracer()),
-                                    coriolis = FPlane(f=1e-4),
-                                    tracers = :b,
-                                    closure = closure)
+    for (model_type, closures) in model_closures
+        @info "      with $model_type"
+        for closure in closures
+            model = model_type(regular_grid;
+                               buoyancy = BuoyancyForce(BuoyancyTracer()),
+                               coriolis = FPlane(f=1e-4),
+                               tracers = :b,
+                               closure = closure)
 
-        @info "        Testing BasicMessenger with $closure"
-        model.clock.iteration = 0
-        test_progress_messenger(model, BasicMessenger())
+            @info "        Testing BasicMessenger with $closure"
+            model.clock.iteration = 0
+            test_progress_messenger(model, BasicMessenger())
 
-        @info "        Testing SingleLineMessenger with $closure"
-        model.clock.iteration = 0
-        @test test_progress_messenger(model, SingleLineMessenger())
+            @info "        Testing SingleLineMessenger with $closure"
+            model.clock.iteration = 0
+            @test test_progress_messenger(model, SingleLineMessenger())
 
-        # Test that SingleLineMessenger is indeed a single line
-        simulation = Simulation(model; Δt=1e-2, stop_iteration=1)
-        msg = SingleLineMessenger(print=false)(simulation)
-        @test countlines(IOBuffer(msg)) == 1
+            # Test that SingleLineMessenger is indeed a single line
+            simulation = Simulation(model; Δt=1e-2, stop_iteration=1)
+            msg = SingleLineMessenger(print=false)(simulation)
+            @test countlines(IOBuffer(msg)) == 1
 
-        @info "        Testing TimedMessenger with $closure"
-        model.clock.iteration = 0
-        @test test_progress_messenger(model, TimedMessenger())
+            @info "        Testing TimedMessenger with $closure"
+            model.clock.iteration = 0
+            @test test_progress_messenger(model, TimedMessenger())
 
-        @info "        Testing custom progress messenger with $closure"
-        model.clock.iteration = 0
-        step_duration = StepDuration()
-        progress(simulation) = @info (PercentageProgress(with_prefix=false, with_units=false)
-                                      + SimulationTime() + TimeStep() + MaxVelocities()
-                                      + AdvectiveCFLNumber() + step_duration)(simulation)
-        @test test_progress_messenger(model, progress)
+            @info "        Testing custom progress messenger with $closure"
+            model.clock.iteration = 0
+            step_duration = StepDuration()
+            progress(simulation) = @info (PercentageProgress(with_prefix=false, with_units=false)
+                                          + SimulationTime() + TimeStep() + MaxVelocities()
+                                          + AdvectiveCFLNumber() + step_duration)(simulation)
+            @test test_progress_messenger(model, progress)
+        end
     end
 end

--- a/test/test_turbulent_kinetic_energy_equation.jl
+++ b/test/test_turbulent_kinetic_energy_equation.jl
@@ -142,10 +142,8 @@ end
                 @info "          Testing energy dissipation rate terms"
                 test_ke_dissipation_rate_terms(grid; model_type, closure)
 
-                if model_type == NonhydrostaticModel
-                    @info "          Testing shear production terms"
-                    test_shear_production_terms(model)
-                end
+                @info "          Testing shear production terms"
+                test_shear_production_terms(model)
             end
         end
 


### PR DESCRIPTION
## Summary

Three test groups previously exercised only `NonhydrostaticModel` even though the underlying diagnostics support both model types. This PR closes those gaps.

- **TKE shear production** (`test/test_turbulent_kinetic_energy_equation.jl`) — removed the `NonhydrostaticModel`-only guard around `test_shear_production_terms` so it now runs inside the existing `for model_type in model_types` loop. The four shear-production constructors (`X/Y/Z/total`) already accept any model in the source.
- **Canonical flows** (`test/test_canonical_flows.jl`) — added `HydrostaticFreeSurfaceModel` to the outer iteration for the uniform strain, solid body rotation, and uniform shear flow tests. The `set!` call branches on model type because HFSM's `set!` does not accept `enforce_incompressibility` or a `w` field. The strain-flow vorticity-zero comparison was relaxed to `atol=10eps()` to absorb HFSM's ~6e-16 roundoff (the same pattern is already used elsewhere in the file with `atol=eps()`).
- **Progress messengers** (`test/test_progress_messengers.jl`) — restructured the test loop to iterate over `(model_type, closures)` pairs. HFSM is tested with `ScalarDiffusivity` only; the LES closures in the existing list (`SmagorinskyLilly`, `DynamicSmagorinsky`, `AnisotropicMinimumDissipation`) are not generally compatible with HFSM.

Diagnostics that remain `NonhydrostaticModel`-only (`KineticEnergyTendency`, `KineticEnergyAdvection`, `KineticEnergyForcing`, `KineticEnergyPressureRedistribution`, `BuoyancyProduction`, `TracerVarianceTendency`) are restricted at the source-method level and are out of scope here.

## Test plan

- [x] `TEST_GROUP=tke_diagnostics julia --project -e 'using Pkg; Pkg.test()'` — 438/438 pass
- [x] `TEST_GROUP=canonical_flows julia --project -e 'using Pkg; Pkg.test()'` — 260/260 pass
- [x] `TEST_GROUP=progress_messengers julia --project -e 'using Pkg; Pkg.test()'` — 24/24 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)