### PR TITLE
Merge ThermalWindPotentialVorticity into ErtelPotentialVorticity

### DIFF
--- a/docs/src/flow_diagnostics.md
+++ b/docs/src/flow_diagnostics.md
@@ -103,20 +103,18 @@ The full Ertel potential vorticity:
 where ``\boldsymbol{\omega}_{\text{tot}}`` is the absolute (relative + planetary) vorticity.
 Computed at `(Face, Face, Face)`.
 
-```@docs
-Oceanostics.FlowDiagnostics.ErtelPotentialVorticity
-```
-
-### Thermal wind potential vorticity
-
-A simplified PV assuming thermal wind balance:
+Passing `thermal_wind = true` to `ErtelPotentialVorticity` returns the simplified PV that assumes
+thermal wind balance:
 
 ```math
-\text{TWPV} = (f + \omega^z)\,\partial_z b - f\left[(\partial_z U)^2 + (\partial_z V)^2\right]
+\text{EPV} = (f + \omega^z)\,\partial_z b - f\left[(\partial_z U)^2 + (\partial_z V)^2\right]
 ```
 
+The result is a subtype of both `ErtelPotentialVorticity` and `ThermalWindPotentialVorticity`, so
+the thermal-wind variant can still be identified by type.
+
 ```@docs
-Oceanostics.FlowDiagnostics.ThermalWindPotentialVorticity
+Oceanostics.FlowDiagnostics.ErtelPotentialVorticity
 ```
 
 ### Directional Ertel potential vorticity

--- a/docs/src/flow_diagnostics.md
+++ b/docs/src/flow_diagnostics.md
@@ -115,6 +115,7 @@ the thermal-wind variant can still be identified by type.
 
 ```@docs
 Oceanostics.FlowDiagnostics.ErtelPotentialVorticity
+Oceanostics.FlowDiagnostics.ThermalWindPotentialVorticity
 ```
 
 ### Directional Ertel potential vorticity

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -199,6 +199,14 @@ end
     return pv_x + pv_y + pv_z
 end
 
+"""
+    ThermalWindPotentialVorticity
+
+Narrower type alias matching only the thermal-wind variant of
+[`ErtelPotentialVorticity`](@ref). Useful for identifying or dispatching on the
+thermal-wind variant via `isa`. Construct via
+`ErtelPotentialVorticity(model; thermal_wind = true)`.
+"""
 const ThermalWindPotentialVorticity = CustomKFO{<:typeof(potential_vorticity_in_thermal_wind_fff)}
 
 const ErtelPotentialVorticity = CustomKFO{<:Union{typeof(ertel_potential_vorticity_fff),
@@ -223,9 +231,9 @@ If `thermal_wind = true`, the thermal-wind approximation is used instead, giving
 ```
 
 where `f` is the (vertical component of the) Coriolis frequency, `ωᶻ` is the vertical relative vorticity,
-and `∂U/∂z`, `∂V/∂z` comprise the thermal wind shear. The returned object is still a subtype of
-`ErtelPotentialVorticity`, and additionally a `ThermalWindPotentialVorticity` so it can be identified
-separately.
+and `∂U/∂z`, `∂V/∂z` comprise the thermal wind shear. The returned object is an instance of both
+`ErtelPotentialVorticity` and `ThermalWindPotentialVorticity`, so the thermal-wind variant can be
+identified separately.
 
 ```jldoctest
 julia> using Oceananigans
@@ -287,6 +295,14 @@ function ErtelPotentialVorticity(model, u, v, w, tracer, coriolis; thermal_wind 
     end
     return KernelFunctionOperation{Face, Face, Face}(ertel_potential_vorticity_fff, model.grid,
                                                      u, v, w, tracer, fx, fy, fz)
+end
+
+function ErtelPotentialVorticity(model, u, v, tracer, coriolis; thermal_wind = true, loc = (Face, Face, Face))
+    thermal_wind || throw(ArgumentError("ErtelPotentialVorticity called without `w` requires `thermal_wind = true`"))
+    validate_location(loc, "ErtelPotentialVorticity", (Face, Face, Face))
+    _, _, fz = get_coriolis_frequency_components(coriolis)
+    return KernelFunctionOperation{Face, Face, Face}(potential_vorticity_in_thermal_wind_fff, model.grid,
+                                                     u, v, tracer, fz)
 end
 
 @inline function directional_ertel_potential_vorticity_fff(i, j, k, grid, u, v, w, b, params)

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -180,34 +180,6 @@ end
     return pv_barot + pv_baroc
 end
 
-const ThermalWindPotentialVorticity = CustomKFO{<:typeof(potential_vorticity_in_thermal_wind_fff)}
-
-"""
-    $(SIGNATURES)
-
-Calculate the Potential Vorticty assuming thermal wind balance for `model`, where the characteristics of
-the Coriolis rotation are taken from `model.coriolis`. The Potential Vorticity in this case
-is defined as
-
-```
-    TWPV = (f + ωᶻ) ∂b/∂z - f ((∂U/∂z)² + (∂V/∂z)²)
-```
-where `f` is the Coriolis frequency, `ωᶻ` is the relative vorticity in the `z` direction, `b` is the buoyancy, and
-`∂U/∂z` and `∂V/∂z` comprise the thermal wind shear.
-"""
-function ThermalWindPotentialVorticity(model; tracer_name = :b, loc = (Face, Face, Face))
-    validate_location(loc, "ThermalWindPotentialVorticity", (Face, Face, Face))
-    u, v, w = model.velocities
-    return ThermalWindPotentialVorticity(model, u, v, model.tracers[tracer_name], model.coriolis; loc)
-end
-
-function ThermalWindPotentialVorticity(model, u, v, tracer, coriolis; loc = (Face, Face, Face))
-    validate_location(loc, "ThermalWindPotentialVorticity", (Face, Face, Face))
-    fx, fy, fz = get_coriolis_frequency_components(coriolis)
-    return KernelFunctionOperation{Face, Face, Face}(potential_vorticity_in_thermal_wind_fff, model.grid,
-                                                     u, v, tracer, fz)
-end
-
 @inline function ertel_potential_vorticity_fff(i, j, k, grid, u, v, w, b, fx, fy, fz)
     dWdy =  ℑxᶠᵃᵃ(i, j, k, grid, ∂yᶜᶠᶠ, w) # C, C, F  → C, F, F  → F, F, F
     dVdz =  ℑxᶠᵃᵃ(i, j, k, grid, ∂zᶜᶠᶠ, v) # C, F, C  → C, F, F  → F, F, F
@@ -227,7 +199,10 @@ end
     return pv_x + pv_y + pv_z
 end
 
-const ErtelPotentialVorticity = CustomKFO{<:typeof(ertel_potential_vorticity_fff)}
+const ThermalWindPotentialVorticity = CustomKFO{<:typeof(potential_vorticity_in_thermal_wind_fff)}
+
+const ErtelPotentialVorticity = CustomKFO{<:Union{typeof(ertel_potential_vorticity_fff),
+                                                  typeof(potential_vorticity_in_thermal_wind_fff)}}
 
 """
     $(SIGNATURES)
@@ -240,6 +215,17 @@ is defined as
 
 where ωₜₒₜ is the total (relative + planetary) vorticity vector, `b` is the buoyancy and ∇ is the gradient
 operator.
+
+If `thermal_wind = true`, the thermal-wind approximation is used instead, giving
+
+```
+    EPV = (f + ωᶻ) ∂b/∂z - f ((∂U/∂z)² + (∂V/∂z)²)
+```
+
+where `f` is the (vertical component of the) Coriolis frequency, `ωᶻ` is the vertical relative vorticity,
+and `∂U/∂z`, `∂V/∂z` comprise the thermal wind shear. The returned object is still a subtype of
+`ErtelPotentialVorticity`, and additionally a `ThermalWindPotentialVorticity` so it can be identified
+separately.
 
 ```jldoctest
 julia> using Oceananigans
@@ -286,14 +272,19 @@ Note that EPV values are correctly calculated both in the interior and the bound
 interior and top boundary, EPV = f×N² = 10⁻¹⁰, while EPV = 0 at the bottom boundary since ∂b/∂z
 is zero there.
 """
-function ErtelPotentialVorticity(model; tracer_name = :b, loc = (Face, Face, Face))
+function ErtelPotentialVorticity(model; tracer_name = :b, thermal_wind = false, loc = (Face, Face, Face))
     validate_location(loc, "ErtelPotentialVorticity", (Face, Face, Face))
-    return ErtelPotentialVorticity(model, model.velocities..., model.tracers[tracer_name], model.coriolis; loc)
+    return ErtelPotentialVorticity(model, model.velocities..., model.tracers[tracer_name], model.coriolis;
+                                   thermal_wind, loc)
 end
 
-function ErtelPotentialVorticity(model, u, v, w, tracer, coriolis; loc = (Face, Face, Face))
+function ErtelPotentialVorticity(model, u, v, w, tracer, coriolis; thermal_wind = false, loc = (Face, Face, Face))
     validate_location(loc, "ErtelPotentialVorticity", (Face, Face, Face))
     fx, fy, fz = get_coriolis_frequency_components(coriolis)
+    if thermal_wind
+        return KernelFunctionOperation{Face, Face, Face}(potential_vorticity_in_thermal_wind_fff, model.grid,
+                                                         u, v, tracer, fz)
+    end
     return KernelFunctionOperation{Face, Face, Face}(ertel_potential_vorticity_fff, model.grid,
                                                      u, v, w, tracer, fx, fy, fz)
 end

--- a/test/test_active_tracer_diagnostics.jl
+++ b/test/test_active_tracer_diagnostics.jl
@@ -84,10 +84,12 @@ function test_buoyancy_diagnostics(model)
     @test PVtw isa ErtelPotentialVorticity
     @test Field(PVtw) isa Field
 
-    PVtw = ErtelPotentialVorticity(model, u, v, w, b, FPlane(f=1e-4); thermal_wind = true)
+    PVtw = ErtelPotentialVorticity(model, u, v, b, FPlane(f=1e-4))
     @test PVtw isa ThermalWindPotentialVorticity
     @test PVtw isa ErtelPotentialVorticity
     @test Field(PVtw) isa Field
+
+    @test_throws ArgumentError ErtelPotentialVorticity(model, u, v, b, FPlane(f=1e-4); thermal_wind = false)
 
     DEPV = DirectionalErtelPotentialVorticity(model, (0, 0, 1))
     @test DEPV isa DirectionalErtelPotentialVorticity

--- a/test/test_active_tracer_diagnostics.jl
+++ b/test/test_active_tracer_diagnostics.jl
@@ -79,12 +79,14 @@ function test_buoyancy_diagnostics(model)
     @test EPV_field isa Field
     @test interior(EPV_field, 3, 3, 3)[1] ≈ N² * (fz - S)
 
-    PVtw = ThermalWindPotentialVorticity(model)
+    PVtw = ErtelPotentialVorticity(model; thermal_wind = true)
     @test PVtw isa ThermalWindPotentialVorticity
+    @test PVtw isa ErtelPotentialVorticity
     @test Field(PVtw) isa Field
 
-    PVtw = ThermalWindPotentialVorticity(model, u, v, b, FPlane(f=1e-4))
+    PVtw = ErtelPotentialVorticity(model, u, v, w, b, FPlane(f=1e-4); thermal_wind = true)
     @test PVtw isa ThermalWindPotentialVorticity
+    @test PVtw isa ErtelPotentialVorticity
     @test Field(PVtw) isa Field
 
     DEPV = DirectionalErtelPotentialVorticity(model, (0, 0, 1))


### PR DESCRIPTION
## Summary
- Replace the separate `ThermalWindPotentialVorticity` constructors with a `thermal_wind` keyword on `ErtelPotentialVorticity` (default `false`). Users now call `ErtelPotentialVorticity(model; thermal_wind=true)` instead of `ThermalWindPotentialVorticity(model)`.
- `ErtelPotentialVorticity` is redefined as a `Union` over both kernel function types; `ThermalWindPotentialVorticity` remains as a narrower type alias so the thermal-wind variant can still be identified by `isa` (and dispatched on, e.g. for a future custom `show` method).
- Both kernel functions are unchanged — no GPU code churn.
- Tests and docs updated accordingly.

Supersedes #194 and closes it once this PR is merged.

## Test plan
- [x] `TEST_GROUP=active_tracer_diagnostics julia --project -e 'using Pkg; Pkg.test()'` — 1156 / 1156 pass
- [x] `TEST_GROUP=general_flow_diagnostics julia --project -e 'using Pkg; Pkg.test()'` — 2 / 2 pass
- [x] CI green across all test groups
- [x] Docs build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)