### PR TITLE
Use BulkDrag in tilted bottom boundary layer example

### DIFF
--- a/docs/examples/tilted_bottom_boundary_layer.jl
+++ b/docs/examples/tilted_bottom_boundary_layer.jl
@@ -87,14 +87,10 @@ z₀ = 0.1meters # (roughness length)
 z₁ = znodes(grid, Center())[1] # Closest grid center to the bottom
 cᴰ = (κ / log(z₁ / z₀))^2 # Drag coefficient
 
-@inline drag_u(x, t, u, v, p) = - p.cᴰ * √(u^2 + (v + p.V∞)^2) * u
-@inline drag_v(x, t, u, v, p) = - p.cᴰ * √(u^2 + (v + p.V∞)^2) * (v + p.V∞)
+drag_bc = BulkDrag(coefficient=cᴰ, background_velocities=(0, V∞, 0))
 
-drag_bc_u = FluxBoundaryCondition(drag_u, field_dependencies=(:u, :v), parameters=(; cᴰ, V∞))
-drag_bc_v = FluxBoundaryCondition(drag_v, field_dependencies=(:u, :v), parameters=(; cᴰ, V∞))
-
-u_bcs = FieldBoundaryConditions(bottom = drag_bc_u)
-v_bcs = FieldBoundaryConditions(bottom = drag_bc_v)
+u_bcs = FieldBoundaryConditions(bottom = drag_bc)
+v_bcs = FieldBoundaryConditions(bottom = drag_bc)
 
 # ## Create model and simulation
 #


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `FluxBoundaryCondition` drag (with custom `drag_u`/`drag_v` functions and shared `field_dependencies`/`parameters`) in `docs/examples/tilted_bottom_boundary_layer.jl` with Oceananigans' new `BulkDrag` boundary condition.
- A single `BulkDrag(coefficient=cᴰ, background_velocities=(0, V∞, 0))` is shared by both `u` and `v` bottom BCs; directions are auto-inferred from field location during regularization.
- Mathematically equivalent: the original 2D speed `√(u² + (v+V∞)²)` matches `BulkDrag`'s 3D speed because `w = 0` at the bottom by no-penetration.

## Test plan
- [x] Docs build runs the example end-to-end without errors
- [x] Resulting bottom-drag dynamics look qualitatively the same as before (negative PV production, centrifugal-symmetric instabilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)