### PR TITLE
Support variably spaced grids in GaussianFilter

### DIFF
--- a/docs/examples/spatial_filtering.jl
+++ b/docs/examples/spatial_filtering.jl
@@ -28,8 +28,10 @@
 # doubly-periodic 2D turbulence simulation, initialized with a smooth, well-resolved sum of Gaussian
 # velocity blobs and a sine/cosine tracer that the flow stirs into thin filaments. See that example
 # for a detailed walk-through of the setup — here we only summarize it, with two differences: we use
-# a smaller grid and a shorter run time, since we just need a developed, multi-scale field. Note that,
-# for now, a `GaussianFilter` requires **uniform spacing** along each filtered direction.
+# a smaller grid and a shorter run time, since we just need a developed, multi-scale field. (The
+# grid here is uniform, but [`GaussianFilter`](@ref) also supports stretched directions, choosing a
+# fast precomputed-weight path on uniform directions and a node-distance path on variably spaced
+# ones.)
 
 using Oceananigans
 

--- a/docs/src/filters.md
+++ b/docs/src/filters.md
@@ -68,15 +68,17 @@ BoxFilter
 ## Gaussian filter
 
 The [`GaussianFilter`](@ref) computes a Gaussian-weighted local average of a
-field over one or more grid directions. Each stencil point at offset `Δ` from
-the current cell receives weight `exp(-Δ²/(2σ²))`, where `σ` is the standard
-deviation of the kernel in **physical units** (the same units as the grid
-spacing). The filter is always normalized: the weighted sum is divided by the
-sum of the surviving weights, so all boundary policies behave consistently.
+field over one or more grid directions. A stencil cell of width `Δ` whose centre
+is a physical distance `r` from the current cell contributes weight
+`Δ · exp(-r²/(2σ²))`, where `σ` is the standard deviation of the kernel in
+**physical units** (the same units as the grid spacing). This is the discrete
+form of the continuous Gaussian convolution; the filter is always normalized
+(the weighted sum is divided by the sum of the surviving weights), so all
+boundary policies behave consistently.
 
 `σ` is the only required parameter beyond `dims` — `N` is inferred
 per-direction from `σ` and the minimum cell spacing in that direction so the
-stencil extends roughly `2σ` on each side of the current cell. To override,
+stencil extends at least `2σ` on each side of the current cell. To override,
 pass `N` explicitly: a single odd integer (≥ 3) applies to every filtered
 dim, or a tuple of odd integers sets one count per dim.
 
@@ -85,7 +87,49 @@ dim, or a tuple of odd integers sets one count per dim.
 For a worked end-to-end example — coarse-graining a turbulent flow, a filter-width sweep, and a
 subfilter tracer flux — see the [Spatial filtering example](@ref spatial_filtering_example).
 
-### Basic usage
+### Variably spaced (stretched) grids
+
+`GaussianFilter` works on stretched grids — for example a grid with a refined
+boundary layer in the vertical. It decides per direction at construction time
+how to evaluate the weights, so a regular grid keeps the original fast path:
+
+- Along a **uniformly spaced** direction the weights are identical for every
+  cell, so they are precomputed once and looked up.
+- Along a **variably spaced** direction the weights depend on the local node
+  coordinates, so each is evaluated on the fly. The cell-width factor `Δ` above
+  is the quadrature weight that keeps the average from being biased toward
+  finely resolved regions; it makes the filter preserve constants exactly (and
+  linear fields to quadrature accuracy), and it reduces to the uniform weighting
+  when the spacing is constant.
+
+Directions are handled independently, so a grid that is uniform in `x` and `y`
+but stretched in `z` uses the fast path for the horizontal directions and the
+node-distance path for the vertical:
+
+```jldoctest filters
+julia> stretched_grid = RectilinearGrid(size=(16, 16),
+                                        x=(0, 1),
+                                        z=k -> -1 + (k-1)/16 + 0.05sin(2π*(k-1)/16),
+                                        topology=(Periodic, Flat, Bounded));
+
+julia> cz = CenterField(stretched_grid); set!(cz, (x, z) -> sin(2π*x) * z);
+
+julia> c̄z = Field(GaussianFilter(cz; dims=(1, 3), σ=0.1));
+
+julia> c̄z isa Field
+true
+```
+
+!!! note "Performance on stretched directions"
+    Filtering *along* a stretched direction is several times slower per
+    direction than along a uniform one: instead of looking up a precomputed
+    weight, the kernel reads the node coordinate and cell width and evaluates an
+    `exp` at every stencil point. Because multi-direction filters run as
+    independent 1D passes, only the stretched directions pay this cost — so a
+    filter over a grid stretched in `z` only (e.g. `dims=(1, 2, 3)`) is far
+    closer to the uniform cost than the per-direction factor suggests, since the
+    `x` and `y` passes still use the fast precomputed-weight path. The
+    regular-grid path itself is unchanged.
 
 ```jldoctest filters
 julia> c̄_gauss = Field(GaussianFilter(c; dims=(1, 3), σ=0.05));

--- a/docs/src/filters.md
+++ b/docs/src/filters.md
@@ -89,15 +89,14 @@ subfilter tracer flux — see the [Spatial filtering example](@ref spatial_filte
 
 ### Variably spaced (stretched) grids
 
-`GaussianFilter` works on stretched grids — for example a grid with a refined
-boundary layer in the vertical. It decides per direction at construction time
-how to evaluate the weights, so a regular grid keeps the original fast path:
+`GaussianFilter` works on stretched grids, but it is around 4 times slower than
+on regular grids:
 
 - Along a **uniformly spaced** direction the weights are identical for every
   cell, so they are precomputed once and looked up.
 - Along a **variably spaced** direction the weights depend on the local node
-  coordinates, so each is evaluated on the fly. The cell-width factor `Δ` above
-  is the quadrature weight that keeps the average from being biased toward
+  coordinates, so each is evaluated on the fly. We use the cell-width factor `Δ`,
+  which is the quadrature weight that keeps the average from being biased toward
   finely resolved regions; it makes the filter preserve constants exactly (and
   linear fields to quadrature accuracy), and it reduces to the uniform weighting
   when the spacing is constant.
@@ -120,16 +119,6 @@ julia> c̄z isa Field
 true
 ```
 
-!!! note "Performance on stretched directions"
-    Filtering *along* a stretched direction is several times slower per
-    direction than along a uniform one: instead of looking up a precomputed
-    weight, the kernel reads the node coordinate and cell width and evaluates an
-    `exp` at every stencil point. Because multi-direction filters run as
-    independent 1D passes, only the stretched directions pay this cost — so a
-    filter over a grid stretched in `z` only (e.g. `dims=(1, 2, 3)`) is far
-    closer to the uniform cost than the per-direction factor suggests, since the
-    `x` and `y` passes still use the fast precomputed-weight path. The
-    regular-grid path itself is unchanged.
 
 ```jldoctest filters
 julia> c̄_gauss = Field(GaussianFilter(c; dims=(1, 3), σ=0.05));

--- a/docs/src/filters.md
+++ b/docs/src/filters.md
@@ -68,13 +68,27 @@ BoxFilter
 ## Gaussian filter
 
 The [`GaussianFilter`](@ref) computes a Gaussian-weighted local average of a
-field over one or more grid directions. A stencil cell of width `Δ` whose centre
-is a physical distance `r` from the current cell contributes weight
-`Δ · exp(-r²/(2σ²))`, where `σ` is the standard deviation of the kernel in
-**physical units** (the same units as the grid spacing). This is the discrete
-form of the continuous Gaussian convolution; the filter is always normalized
-(the weighted sum is divided by the sum of the surviving weights), so all
-boundary policies behave consistently.
+field over one or more grid directions. Along a single filtered direction the
+filtered value at cell ``i`` is
+
+```math
+\bar{\psi}_i = \frac{\sum_m \Delta_m \, e^{-(x_m - x_i)^2 / (2\sigma^2)} \, \psi_m}
+                    {\sum_m \Delta_m \, e^{-(x_m - x_i)^2 / (2\sigma^2)}} ,
+```
+
+where ``m`` runs over the cells of the stencil centred on ``i``; ``x_m`` and
+``\Delta_m`` are the coordinate and width of cell ``m`` along the filtered
+direction, ``x_i`` is the current cell's coordinate, and ``\sigma`` is the
+kernel's standard deviation in **physical units** (the same as the grid
+spacing). In words: each cell's Gaussian weight
+``e^{-(x_m - x_i)^2 / (2\sigma^2)}`` is multiplied by that cell's own width
+``\Delta_m``, and the **same** ``\Delta_m``-weighted sum appears in the
+normalizing denominator. The normalization returns a constant field unchanged
+and keeps every boundary policy consistent, while the ``\Delta_m`` factor is the
+quadrature weight (the ``dx'`` of ``\int G_\sigma(x-x')\,\psi(x')\,dx' \big/
+\int G_\sigma(x-x')\,dx'``) that makes the discrete sum approximate the
+continuous Gaussian convolution. Multi-direction filters apply this to each
+filtered direction in turn.
 
 `σ` is the only required parameter beyond `dims` — `N` is inferred
 per-direction from `σ` and the minimum cell spacing in that direction so the
@@ -92,14 +106,16 @@ subfilter tracer flux — see the [Spatial filtering example](@ref spatial_filte
 `GaussianFilter` works on stretched grids, but it is around 4 times slower than
 on regular grids:
 
-- Along a **uniformly spaced** direction the weights are identical for every
-  cell, so they are precomputed once and looked up.
-- Along a **variably spaced** direction the weights depend on the local node
-  coordinates, so each is evaluated on the fly. We use the cell-width factor `Δ`,
-  which is the quadrature weight that keeps the average from being biased toward
-  finely resolved regions; it makes the filter preserve constants exactly (and
-  linear fields to quadrature accuracy), and it reduces to the uniform weighting
-  when the spacing is constant.
+- Along a **uniformly spaced** direction every ``\Delta_m`` is equal, so it
+  factors out of the sum and cancels between numerator and denominator. The
+  weights then reduce to a plain ``e^{-(x_m - x_i)^2 / (2\sigma^2)}`` that is
+  identical for every cell, so they are precomputed once and looked up — the
+  fast path used on regular grids.
+- Along a **variably spaced** direction ``x_m`` and ``\Delta_m`` differ from cell
+  to cell, so the weights cannot be precomputed and are evaluated on the fly.
+  Keeping the per-cell ``\Delta_m`` factor is what stops the average from being
+  biased toward finely resolved regions; it makes the filter preserve constants
+  exactly and linear fields to quadrature accuracy.
 
 Directions are handled independently, so a grid that is uniform in `x` and `y`
 but stretched in `z` uses the fast path for the horizontal directions and the

--- a/src/Filters/Filters.jl
+++ b/src/Filters/Filters.jl
@@ -6,7 +6,9 @@ export BoxFilter, GaussianFilter
 using Oceananigans: location
 using Oceananigans.Grids: topology, Periodic,
                           minimum_xspacing, minimum_yspacing, minimum_zspacing,
-                          xspacings, yspacings, zspacings
+                          xspacings, yspacings, zspacings,
+                          xnode, ynode, znode
+using Oceananigans.Operators: xspacing, yspacing, zspacing
 using Oceananigans.AbstractOperations: KernelFunctionOperation
 
 using Oceanostics: CustomKFO

--- a/src/Filters/gaussian_filter.jl
+++ b/src/Filters/gaussian_filter.jl
@@ -1,16 +1,34 @@
 """
-    GaussianFilterKernel{D, W} <: Function
+    AbstractGaussianFilterKernel{D} <: Function
 
-Callable struct that computes a 1D Gaussian-weighted average along direction
-`D` (1, 2, or 3). Stores precomputed unnormalized weights in `weights::W`.
-Like `BoxFilterKernel`, has terminal (indexable input) and recursive (function
-input) methods.
+Supertype for the two 1D Gaussian-filter kernels along direction `D` (1, 2, or
+3). The two concrete kernels share the same stencil shape and accumulation but
+differ in how they obtain the per-offset weight:
+
+  - [`GaussianFilterKernel`](@ref) — for **uniformly spaced** directions; looks
+    up precomputed weights (the fast path, used on regular grids).
+  - [`StretchedGaussianFilterKernel`](@ref) — for **variably spaced** directions;
+    computes each weight on the fly from the physical node positions.
+
+Both are tagged with `D` so the staged multi-direction evaluation and the
+dispatch aliases can treat a mixed-spacing filter (e.g. uniform `x`, stretched
+`z`) uniformly.
 """
-struct GaussianFilterKernel{D, W} <: Function
+abstract type AbstractGaussianFilterKernel{D} <: Function end
+
+"""
+    GaussianFilterKernel{D, W} <: AbstractGaussianFilterKernel{D}
+
+Callable struct that computes a 1D Gaussian-weighted average along a
+**uniformly spaced** direction `D` (1, 2, or 3). Stores precomputed
+unnormalized weights in `weights::W`. Like `BoxFilterKernel`, has terminal
+(indexable input) and recursive (function input) methods.
+"""
+struct GaussianFilterKernel{D, W} <: AbstractGaussianFilterKernel{D}
     weights::W
 end
 
-const GaussianFilter = CustomKFO{<:GaussianFilterKernel}
+const GaussianFilter = CustomKFO{<:AbstractGaussianFilterKernel}
 
 GaussianFilterKernel{D}(weights::W) where {D, W} = GaussianFilterKernel{D, W}(weights)
 
@@ -104,6 +122,183 @@ end
 end
 #---
 
+#+++ Stretched (variably spaced) direction kernel
+"""
+    StretchedGaussianFilterKernel{D, S, L} <: AbstractGaussianFilterKernel{D}
+
+Callable struct that computes a 1D Gaussian-weighted average along a
+**variably spaced** direction `D` (1, 2, or 3). Because the grid spacing varies
+along the direction, the per-offset weights cannot be precomputed once; instead
+each weight is evaluated on the fly as
+
+```
+w = Δₘ · exp(-(xₘ - xᵢ)² / 2σ²),
+```
+
+where `xᵢ` is the centre cell's coordinate, `xₘ` the stencil cell's coordinate,
+and `Δₘ` the stencil cell's width along `D`. The `Δₘ` factor is the quadrature
+weight that makes the normalized sum a consistent approximation of the
+continuous Gaussian convolution `∫ G_σ(x-x') ψ(x') dx' / ∫ G_σ(x-x') dx'`; it
+keeps the filter from over-weighting finely resolved regions and preserves
+constants (and, to quadrature accuracy, linear fields) on a stretched grid.
+
+Fields:
+  - `σ::S` — the Gaussian standard deviation in physical units.
+  - `loc::L` — the field's location triple (instances, e.g. `(Center(), Center(),
+    Face())`), used to read node coordinates and spacings along `D`.
+  - `period::S` — the domain length along `D`, used only for `Periodic`
+    directions to recover the unwrapped image coordinate of a wrapped stencil
+    point.
+
+This kernel reduces *exactly* to [`GaussianFilterKernel`](@ref) on a uniform
+grid: there `Δₘ` is constant (cancels in the normalization) and `xₘ - xᵢ = Δm·Δ`,
+matching the precomputed cell-offset weights. It has terminal (indexable input)
+and recursive (function input) methods, like the uniform kernel.
+"""
+struct StretchedGaussianFilterKernel{D, S, L} <: AbstractGaussianFilterKernel{D}
+    σ::S
+    loc::L
+    period::S
+end
+
+StretchedGaussianFilterKernel{D}(σ::S, loc::L, period::S) where {D, S, L} =
+    StretchedGaussianFilterKernel{D, S, L}(σ, loc, period)
+
+# `(coordinate, cell width)` of the stencil cell at the (possibly out-of-range)
+# index `m` along a filtered direction, honoring the boundary policy's geometry.
+# Only *interior* nodes/spacings are read (the index is wrapped or clamped into
+# `1:N` up front), so these never index past the grid's coordinate arrays no
+# matter how wide the stencil is:
+#   • Periodic — the *unwrapped* image coordinate: the wrapped-index node shifted
+#     by ±`period`, so the distance to the centre cell is the geometric distance
+#     to the near periodic image rather than across the whole domain. The
+#     periodic-`N` validation guarantees the stencil spans at most one period, so
+#     a single ±`period` correction is exact (even on a stretched periodic grid,
+#     where node positions tile with the period). The width at the wrapped index
+#     equals the width of the true image cell.
+#   • Bounded (shrink/edge/constant) — the clamped boundary cell's coordinate and
+#     width. For `:shrink` this is irrelevant (out-of-range offsets carry count
+#     0); for `:edge`/constant padding it places the contributing value at the
+#     boundary, matching where that value is read from.
+@inline function x_node_geometry(::PeriodicBoundary, grid, loc, i, j, k, m, N, L)
+    mr = wrap_periodic_index(m, N)
+    return xnode(mr, j, k, grid, loc...) - L * (m < 1) + L * (m > N), xspacing(mr, j, k, grid, loc...)
+end
+@inline function x_node_geometry(::AbstractBoundaryPolicy, grid, loc, i, j, k, m, N, L)
+    mr = clamp(m, 1, N)
+    return xnode(mr, j, k, grid, loc...), xspacing(mr, j, k, grid, loc...)
+end
+@inline function y_node_geometry(::PeriodicBoundary, grid, loc, i, j, k, m, N, L)
+    mr = wrap_periodic_index(m, N)
+    return ynode(i, mr, k, grid, loc...) - L * (m < 1) + L * (m > N), yspacing(i, mr, k, grid, loc...)
+end
+@inline function y_node_geometry(::AbstractBoundaryPolicy, grid, loc, i, j, k, m, N, L)
+    mr = clamp(m, 1, N)
+    return ynode(i, mr, k, grid, loc...), yspacing(i, mr, k, grid, loc...)
+end
+@inline function z_node_geometry(::PeriodicBoundary, grid, loc, i, j, k, m, N, L)
+    mr = wrap_periodic_index(m, N)
+    return znode(i, j, mr, grid, loc...) - L * (m < 1) + L * (m > N), zspacing(i, j, mr, grid, loc...)
+end
+@inline function z_node_geometry(::AbstractBoundaryPolicy, grid, loc, i, j, k, m, N, L)
+    mr = clamp(m, 1, N)
+    return znode(i, j, mr, grid, loc...), zspacing(i, j, mr, grid, loc...)
+end
+
+#+++ Terminal methods (indexable input).
+@inline function (kern::StretchedGaussianFilterKernel{1})(i, j, k, grid, ::Val{width}, policy, ψ) where {width}
+    Nx = size(grid, 1); loc = kern.loc
+    x₀ = xnode(i, j, k, grid, loc...); σ = kern.σ
+    s = zero(grid); w_sum = zero(grid)
+    @unroll_full for idx in 1:(2*width+1)
+        Δi = idx - width - 1
+        x, Δx = x_node_geometry(policy, grid, loc, i, j, k, i + Δi, Nx, kern.period)
+        w = Δx * exp(-(x - x₀)^2 / (2σ^2))
+        val, cnt = x_stencil_fetch(policy, ψ, i + Δi, j, k, Nx)
+        s += w * val
+        w_sum += w * cnt
+    end
+    return s / w_sum
+end
+
+@inline function (kern::StretchedGaussianFilterKernel{2})(i, j, k, grid, ::Val{width}, policy, ψ) where {width}
+    Ny = size(grid, 2); loc = kern.loc
+    y₀ = ynode(i, j, k, grid, loc...); σ = kern.σ
+    s = zero(grid); w_sum = zero(grid)
+    @unroll_full for idx in 1:(2*width+1)
+        Δj = idx - width - 1
+        y, Δy = y_node_geometry(policy, grid, loc, i, j, k, j + Δj, Ny, kern.period)
+        w = Δy * exp(-(y - y₀)^2 / (2σ^2))
+        val, cnt = y_stencil_fetch(policy, ψ, i, j + Δj, k, Ny)
+        s += w * val
+        w_sum += w * cnt
+    end
+    return s / w_sum
+end
+
+@inline function (kern::StretchedGaussianFilterKernel{3})(i, j, k, grid, ::Val{width}, policy, ψ) where {width}
+    Nz = size(grid, 3); loc = kern.loc
+    z₀ = znode(i, j, k, grid, loc...); σ = kern.σ
+    s = zero(grid); w_sum = zero(grid)
+    @unroll_full for idx in 1:(2*width+1)
+        Δk = idx - width - 1
+        z, Δz = z_node_geometry(policy, grid, loc, i, j, k, k + Δk, Nz, kern.period)
+        w = Δz * exp(-(z - z₀)^2 / (2σ^2))
+        val, cnt = z_stencil_fetch(policy, ψ, i, j, k + Δk, Nz)
+        s += w * val
+        w_sum += w * cnt
+    end
+    return s / w_sum
+end
+#---
+
+#+++ Recursive methods (function input — typically another AbstractGaussianFilterKernel).
+@inline function (kern::StretchedGaussianFilterKernel{1})(i, j, k, grid, ::Val{width}, policy, f::Function, fargs...) where {width}
+    Nx = size(grid, 1); loc = kern.loc
+    x₀ = xnode(i, j, k, grid, loc...); σ = kern.σ
+    s = zero(grid); w_sum = zero(grid)
+    @unroll_full for idx in 1:(2*width+1)
+        Δi = idx - width - 1
+        x, Δx = x_node_geometry(policy, grid, loc, i, j, k, i + Δi, Nx, kern.period)
+        w = Δx * exp(-(x - x₀)^2 / (2σ^2))
+        val, cnt = x_stencil_call(policy, f, i + Δi, j, k, Nx, grid, fargs...)
+        s += w * val
+        w_sum += w * cnt
+    end
+    return s / w_sum
+end
+
+@inline function (kern::StretchedGaussianFilterKernel{2})(i, j, k, grid, ::Val{width}, policy, f::Function, fargs...) where {width}
+    Ny = size(grid, 2); loc = kern.loc
+    y₀ = ynode(i, j, k, grid, loc...); σ = kern.σ
+    s = zero(grid); w_sum = zero(grid)
+    @unroll_full for idx in 1:(2*width+1)
+        Δj = idx - width - 1
+        y, Δy = y_node_geometry(policy, grid, loc, i, j, k, j + Δj, Ny, kern.period)
+        w = Δy * exp(-(y - y₀)^2 / (2σ^2))
+        val, cnt = y_stencil_call(policy, f, i, j + Δj, k, Ny, grid, fargs...)
+        s += w * val
+        w_sum += w * cnt
+    end
+    return s / w_sum
+end
+
+@inline function (kern::StretchedGaussianFilterKernel{3})(i, j, k, grid, ::Val{width}, policy, f::Function, fargs...) where {width}
+    Nz = size(grid, 3); loc = kern.loc
+    z₀ = znode(i, j, k, grid, loc...); σ = kern.σ
+    s = zero(grid); w_sum = zero(grid)
+    @unroll_full for idx in 1:(2*width+1)
+        Δk = idx - width - 1
+        z, Δz = z_node_geometry(policy, grid, loc, i, j, k, k + Δk, Nz, kern.period)
+        w = Δz * exp(-(z - z₀)^2 / (2σ^2))
+        val, cnt = z_stencil_call(policy, f, i, j, k + Δk, Nz, grid, fargs...)
+        s += w * val
+        w_sum += w * cnt
+    end
+    return s / w_sum
+end
+#---
+
 gaussian_weights(width, σ) = ntuple(idx -> exp(-(idx - width - 1)^2 / (2σ^2)), 2*width + 1)
 
 validate_σ(σ::Real) = σ > 0 || throw(ArgumentError("`σ` must be a positive number; got $σ"))
@@ -119,17 +314,34 @@ direction_spacings(grid, d) =
     d == 2 ? yspacings(grid) :
              zspacings(grid)
 
-# GaussianFilter precomputes its weights in cell-offset units assuming a
-# single Δ per direction. This helper rejects non-uniform filtered directions
-# up front with a helpful error.
-function validate_uniform_spacing(grid, sorted_dims, filter_name)
-    for d in sorted_dims
-        sp_min, sp_max = extrema(direction_spacings(grid, d))
-        sp_min == sp_max || throw(ArgumentError(
-            "$filter_name requires uniform grid spacing along filtered directions, but direction $d " *
-            "has variable spacing (min=$sp_min, max=$sp_max). Its weights are precomputed in cell-offset " *
-            "units assuming a constant Δ along the direction; on a stretched grid the filter's " *
-            "physical-space footprint would vary per cell. Filter only directions whose spacing is uniform."))
+direction_extent(grid, d) =
+    d == 1 ? grid.Lx :
+    d == 2 ? grid.Ly :
+             grid.Lz
+
+# A direction is "uniform" when every spacing along it is identical. Uniform
+# directions take the fast precomputed-weights path (`GaussianFilterKernel`);
+# variably spaced directions take the on-the-fly node-distance path
+# (`StretchedGaussianFilterKernel`). The check is done once per direction at
+# construction time, so it never touches the per-cell hot loop.
+function direction_is_uniform(grid, d)
+    sp_min, sp_max = extrema(direction_spacings(grid, d))
+    return sp_min == sp_max
+end
+
+# Build the 1D kernel for filtered direction `d` (the `i`-th entry of
+# `sorted_dims`). Uniform directions get a `GaussianFilterKernel` carrying
+# weights precomputed in cell-offset units (`σ_cells = σ / Δ`); variably spaced
+# directions get a `StretchedGaussianFilterKernel` that evaluates weights from
+# physical node distances at run time.
+function gaussian_kernel(grid, loc, σT, d, width)
+    if direction_is_uniform(grid, d)
+        σ_cells = σT / direction_min_spacing(grid, d)
+        return GaussianFilterKernel{d}(gaussian_weights(width, σ_cells))
+    else
+        loc_instances = map(ℓ -> ℓ(), loc)                 # (Center, Center, Face) types → instances
+        period = convert(eltype(grid), direction_extent(grid, d))
+        return StretchedGaussianFilterKernel{d}(σT, loc_instances, period)
     end
 end
 
@@ -140,24 +352,37 @@ Return a `KernelFunctionOperation` that computes a Gaussian-weighted local avera
 directions listed in `dims`.
 
 `σ` is the standard deviation of the Gaussian kernel in physical units (the same units as the grid
-spacing). Internally the filter precomputes its weights once per direction in cell-offset units
-using `σ_cells = σ / Δ`, where `Δ` is the (uniform) grid spacing along that direction; each
-stencil point at cell offset `Δi` then receives weight `exp(-Δi² / (2 σ_cells²))`. The filter is
-normalized: the weighted sum is divided by the sum of the surviving weights, so all boundary
-policies behave consistently.
+spacing). The filter approximates the continuous Gaussian convolution
+`∫ G_σ(x-x') ψ(x') dx' / ∫ G_σ(x-x') dx'`: a stencil cell of width `Δₘ` whose centre sits a
+physical distance `r` from the current cell centre contributes weight `Δₘ · exp(-r² / 2σ²)`, and
+the result is normalized by the sum of the surviving weights, so all boundary policies behave
+consistently. On a uniform direction the `Δₘ` factor is constant and cancels, recovering the plain
+`exp(-r² / 2σ²)` weighting.
 
-!!! warning "Uniform spacing required"
-    Because the per-direction weights are precomputed assuming a single `Δ`, `GaussianFilter` only
-    supports **uniform spacing along each filtered direction**. Non-uniform (stretched) directions
-    raise an `ArgumentError` at construction time. Other directions on the same grid may be
-    non-uniform — only the ones listed in `dims` need to be uniform. Use [`BoxFilter`](@ref) on
-    stretched directions, since its weights do not depend on `Δ`.
+`GaussianFilter` supports **both uniformly and variably spaced (stretched) directions**, choosing
+the implementation per direction at construction time so the regular-grid case keeps its original
+speed:
+
+  - **Uniform direction** — the weights are identical for every cell, so they are precomputed once
+    in cell-offset units (`σ_cells = σ / Δ`, weight `exp(-Δi² / 2σ_cells²)` at cell offset `Δi`)
+    and looked up in the hot loop. This is the fast path used on regular grids.
+  - **Stretched direction** — the physical footprint of a fixed cell offset varies from cell to
+    cell, so the weights cannot be precomputed; each is evaluated on the fly from the node
+    coordinates and widths (`Δₘ · exp(-(xₘ - xᵢ)² / 2σ²)`). The cell-width factor `Δₘ` is the
+    quadrature weight of the continuous convolution; it stops the average from being biased toward
+    finely resolved regions and keeps constants (and, to quadrature accuracy, linear fields)
+    preserved. The two paths agree exactly where they overlap (a uniform direction has
+    `xₘ - xᵢ = Δm·Δ` and constant `Δₘ`). Directions are decided independently, so a grid that is
+    uniform in `x` but stretched in `z` uses the fast path for `x` and the node-distance path for
+    `z`.
 
 `N` is the **total number of grid points used by the filter stencil** along each filtered
 direction — i.e. how many cells contribute to a single filtered output value. `N` must be an
 **odd integer ≥ 3** so the stencil is symmetric around the current cell. (This is the size of the
 filter stencil — *not* the size of the grid.) If unspecified, `N` is inferred per-direction from
-`σ` and `Δ` so that the stencil extends roughly `2σ` on each side of the current cell. To
+`σ` and the *smallest* spacing along that direction so that the stencil extends at least `2σ` to
+each side of the current cell everywhere (on a stretched direction it therefore reaches farther
+than `2σ` where cells are large, which is harmless since the Gaussian weights there are tiny). To
 override, pass either a single odd integer (applied to every filtered dim) or a tuple with one
 odd-integer count per dim in `dims` (in the order the user passed them). For `Periodic`
 directions the stencil must span at most one period (`N ≤ 2*Nd_grid + 1`, where `Nd_grid` is the
@@ -172,8 +397,9 @@ single composable `KernelFunctionOperation`, but when that operation is the oper
 (the standard `Field(GaussianFilter(...))` / `compute!` path), the implementation evaluates the
 filter as a sequence of 1D passes through intermediate fields. This reduces the per-output read
 count from `N^d` to `d × N`, which is the main reason multi-direction filters with wide stencils
-are competitive on GPUs. If the filter is composed into another `AbstractOperation` (e.g.
-`2 * GaussianFilter(c; dims=(1,2,3))`) it falls back to the fused, single-kernel evaluation.
+are competitive on GPUs. Mixed-spacing filters stage the same way — each direction's 1D pass uses
+its own (uniform or stretched) kernel. If the filter is composed into another `AbstractOperation`
+(e.g. `2 * GaussianFilter(c; dims=(1,2,3))`) it falls back to the fused, single-kernel evaluation.
 
 ## Examples
 
@@ -192,14 +418,12 @@ true
 function GaussianFilter(ψ; dims, σ, N=nothing, boundary=:shrink)
     validate_σ(σ)
     grid, loc, sorted_dims, policies = resolve_filter_policies(ψ, dims, boundary)
-    validate_uniform_spacing(grid, sorted_dims, "GaussianFilter")
 
     sorted_widths = resolve_gaussian_widths(N, σ, grid, dims, sorted_dims)
     validate_periodic_widths(grid, sorted_dims, policies, sorted_widths)
     σT = convert(eltype(grid), σ)
-    sorted_weights = ntuple(i -> gaussian_weights(sorted_widths[i], σT / direction_min_spacing(grid, sorted_dims[i])), length(sorted_dims))
 
-    return build_filter_kfo((d, i) -> GaussianFilterKernel{d}(sorted_weights[i]),
+    return build_filter_kfo((d, i) -> gaussian_kernel(grid, loc, σT, d, sorted_widths[i]),
                             grid, loc, sorted_dims, sorted_widths, policies, ψ)
 end
 
@@ -229,17 +453,23 @@ end
 # `_compute_staged_filter!` machinery defined in `Filters.jl`. The aliases
 # below pin the dispatch — 1D filters (`length(args) == 3`) fall through to
 # the default `compute!` and use the unrolled single-direction kernel.
+# Match a multi-direction GaussianFilter regardless of whether each direction's
+# 1D kernel is the uniform (`GaussianFilterKernel`) or stretched
+# (`StretchedGaussianFilterKernel`) variant — a mixed-spacing filter (e.g.
+# uniform x, stretched z) carries one of each. Pinning on the shared supertype
+# `AbstractGaussianFilterKernel` lets all combinations stage through the
+# separable `d × N` path.
 const _GaussianFilter2D = KernelFunctionOperation{LX, LY, LZ, G, T,
-                                                  <:GaussianFilterKernel,
+                                                  <:AbstractGaussianFilterKernel,
                                                   <:Tuple{Val, AbstractBoundaryPolicy,
-                                                          GaussianFilterKernel, Val, AbstractBoundaryPolicy,
+                                                          AbstractGaussianFilterKernel, Val, AbstractBoundaryPolicy,
                                                           Any}} where {LX, LY, LZ, G, T}
 
 const _GaussianFilter3D = KernelFunctionOperation{LX, LY, LZ, G, T,
-                                                  <:GaussianFilterKernel,
+                                                  <:AbstractGaussianFilterKernel,
                                                   <:Tuple{Val, AbstractBoundaryPolicy,
-                                                          GaussianFilterKernel, Val, AbstractBoundaryPolicy,
-                                                          GaussianFilterKernel, Val, AbstractBoundaryPolicy,
+                                                          AbstractGaussianFilterKernel, Val, AbstractBoundaryPolicy,
+                                                          AbstractGaussianFilterKernel, Val, AbstractBoundaryPolicy,
                                                           Any}} where {LX, LY, LZ, G, T}
 
 compute!(comp::Field{<:Any, <:Any, <:Any, <:_GaussianFilter2D}, time=nothing) = _compute_staged_filter!(comp, time)

--- a/test/test_filters.jl
+++ b/test/test_filters.jl
@@ -2,10 +2,13 @@ using Test
 using CUDA: has_cuda_gpu, @allowscalar
 using Oceananigans
 using Oceananigans: fill_halo_regions!, location
+using Oceananigans.Grids: topology, xnode, ynode, znode
+using Oceananigans.Operators: xspacing, yspacing, zspacing
 using Oceananigans.AbstractOperations: KernelFunctionOperation
 
 using Oceanostics
 using Oceanostics: BoxFilter, GaussianFilter
+using Oceanostics.Filters: GaussianFilterKernel, StretchedGaussianFilterKernel
 
 arch = has_cuda_gpu() ? GPU() : CPU()
 
@@ -454,27 +457,187 @@ function test_gaussian_N_tuple_order()
     @test_throws ArgumentError GaussianFilter(c; dims=(1, 3), σ=σ, N=(5, 3.5))  # non-integer
 end
 
-# GaussianFilter precomputes its weights using one Δ per direction, so it
-# only supports uniform spacing along every filtered direction. Non-uniform
-# directions must error at construction time with a clear message. Other
-# directions on the same grid may be non-uniform, as long as they aren't
-# being filtered.
-function test_gaussian_uniform_spacing_required()
+# GaussianFilter now supports variably spaced (stretched) directions: it picks
+# the implementation per direction at construction time, using the fast
+# precomputed-weights kernel where spacing is uniform and the on-the-fly
+# node-distance kernel where it is not. These tests check that the right kernel
+# is selected and that filtering a stretched direction no longer errors.
+function test_gaussian_stretched_supported()
     zfaces(k) = -1 + (k-1)/8 + 0.05 * sin(2π*(k-1)/8)
     grid = RectilinearGrid(arch, size=(8, 8, 8), x=(0, 1), y=(0, 1), z=zfaces,
                            topology=(Periodic, Periodic, Bounded))
     c = CenterField(grid)
 
-    # Filtering the stretched z direction must error — alone or alongside other dims.
-    @test_throws ArgumentError GaussianFilter(c; dims=(3,),   σ=0.1)
-    @test_throws ArgumentError GaussianFilter(c; dims=(1, 3), σ=0.1)
+    # Filtering the stretched z direction now succeeds and selects the stretched kernel.
+    @test GaussianFilter(c; dims=(3,),   σ=0.1) isa KernelFunctionOperation
+    @test GaussianFilter(c; dims=(3,),   σ=0.1).kernel_function isa StretchedGaussianFilterKernel
+    @test GaussianFilter(c; dims=(1, 3), σ=0.1) isa KernelFunctionOperation
 
-    # Filtering only the uniform x and y directions must still succeed.
-    @test GaussianFilter(c; dims=(1,),   σ=0.1) isa KernelFunctionOperation
+    # Uniform directions keep the fast precomputed-weights kernel.
+    @test GaussianFilter(c; dims=(1,),   σ=0.1).kernel_function isa GaussianFilterKernel
     @test GaussianFilter(c; dims=(1, 2), σ=0.1) isa KernelFunctionOperation
 
-    # BoxFilter is unaffected: its weights don't depend on Δ.
+    # BoxFilter is unaffected: its weights never depended on Δ.
     @test BoxFilter(c; dims=(3,), N=3) isa KernelFunctionOperation
+end
+
+# A stretched bounded grid for z (the canonical use case: a stretched vertical),
+# uniform in the periodic x and y. The z faces are monotonically increasing with
+# variable spacing.
+function make_stretched_z_grid(; Nx=6, Ny=6, Nz=8, halo=(3, 3, 3))
+    zfaces(k) = -1 + (k-1)/Nz + 0.08 * sin(2π*(k-1)/Nz)
+    return RectilinearGrid(arch, size=(Nx, Ny, Nz), x=(0, 1), y=(0, 1), z=zfaces,
+                           halo=halo, topology=(Periodic, Periodic, Bounded))
+end
+
+# Node coordinates and cell widths along direction `d` at the field location, for
+# the interior cells `1:Nd`. Uses Oceananigans' own accessors, so the reference
+# is independent of the filter's internals.
+function direction_coords_and_spacings(grid, d, loc)
+    N = size(grid, d)
+    ℓ = map(L -> L(), loc)
+    d == 1 && return ([xnode(m, 1, 1, grid, ℓ...) for m in 1:N], [xspacing(m, 1, 1, grid, ℓ...) for m in 1:N])
+    d == 2 && return ([ynode(1, m, 1, grid, ℓ...) for m in 1:N], [yspacing(1, m, 1, grid, ℓ...) for m in 1:N])
+    return ([znode(1, 1, m, grid, ℓ...) for m in 1:N], [zspacing(1, 1, m, grid, ℓ...) for m in 1:N])
+end
+
+# Independent reference for a 1D stretched Gaussian filter: the discrete quadrature
+# `Σₘ Δₘ G(xₘ-x₀) ψₘ / Σₘ Δₘ G(xₘ-x₀)` with the same boundary geometry as the
+# kernel — periodic offsets use the unwrapped image coordinate; bounded offsets
+# clamp to the boundary (and `:shrink` drops out-of-range offsets from sum and
+# count). `boundary` is ignored for periodic directions.
+function reference_gaussian_stretched(c, grid, d, σ, width; boundary=:shrink)
+    N = size(grid, d)
+    coords, spac = direction_coords_and_spacings(grid, d, location(c))
+    L = (grid.Lx, grid.Ly, grid.Lz)[d]
+    periodic = topology(grid, d) === Periodic
+    ic = Array(interior(c))
+    ref = similar(ic)
+    for I in CartesianIndices(ic)
+        idx = Tuple(I)
+        center = idx[d]
+        x₀ = coords[center]
+        s = zero(eltype(ic)); wsum = zero(eltype(ic))
+        for Δ in -width:width
+            m = center + Δ
+            if periodic
+                mr = mod1(m, N)
+                pos, sp = coords[mr] - L*(m < 1) + L*(m > N), spac[mr]
+                val, cnt = ic[Base.setindex(idx, mr, d)...], 1
+            elseif boundary === :shrink
+                inb = 1 <= m <= N
+                mr = clamp(m, 1, N)
+                pos, sp = coords[mr], spac[mr]
+                val, cnt = (inb ? ic[Base.setindex(idx, mr, d)...] : zero(eltype(ic))), Int(inb)
+            else # :edge
+                mr = clamp(m, 1, N)
+                pos, sp = coords[mr], spac[mr]
+                val, cnt = ic[Base.setindex(idx, mr, d)...], 1
+            end
+            w = sp * exp(-(pos - x₀)^2 / (2σ^2))
+            s += w * val; wsum += w * cnt
+        end
+        ref[I] = s / wsum
+    end
+    return ref
+end
+
+# The stretched filter must reproduce the discrete-quadrature reference exactly,
+# for a bounded direction (shrink + edge) and a periodic stretched direction.
+function test_gaussian_stretched_numerical()
+    σ = 0.15
+    for width in (2, 3)
+        # Bounded stretched z, :shrink and :edge
+        gz = make_stretched_z_grid()
+        cz = center_field_from(gz, (x, y, z) -> sin(2π*x) * cos(2π*y) + z^2 + 0.3z)
+        for boundary in (:shrink, :edge)
+            cf = compute_filter(cz, GaussianFilter, (3,), width; σ=σ, boundary=boundary)
+            ref = reference_gaussian_stretched(cz, gz, 3, σ, width; boundary=boundary)
+            @test Array(interior(cf)) ≈ ref
+        end
+
+        # Periodic stretched x (node positions tile with the domain period)
+        xfaces(i) = (i-1)/8 + 0.1 * sin(2π*(i-1)/8)
+        gx = RectilinearGrid(arch, size=(8, 4, 4), x=xfaces, y=(0, 1), z=(0, 1),
+                             halo=(3, 1, 1), topology=(Periodic, Periodic, Bounded))
+        cx = center_field_from(gx, (x, y, z) -> sin(2π*x))
+        cf = compute_filter(cx, GaussianFilter, (1,), width; σ=0.12)
+        ref = reference_gaussian_stretched(cx, gx, 1, 0.12, width)
+        @test Array(interior(cf)) ≈ ref
+    end
+end
+
+# A constant field is preserved exactly on a stretched grid (Σ w·const / Σ w =
+# const), and a linear field is preserved to quadrature accuracy in the interior
+# (where the stencil is fully covered) — the cell-width quadrature factor is what
+# makes this hold; a sample-average without it would bias toward finely resolved
+# cells. The linear check uses a smoothly (monotonically) stretched grid with a
+# well-resolved σ, so the residual midpoint-quadrature error is well under 1%.
+function test_gaussian_stretched_constant_and_linear()
+    Nz = 32
+    zsmooth(k) = 2 * ((k-1)/Nz + 0.5*((k-1)/Nz)^2) / 1.5     # monotonic, cells grow with k
+    gz = RectilinearGrid(arch, size=(4, 4, Nz), x=(0, 1), y=(0, 1), z=zsmooth,
+                         halo=(2, 2, 2), topology=(Periodic, Periodic, Bounded))
+
+    cc = center_field_from(gz, (x, y, z) -> 2.71)
+    fc = compute_filter(cc, GaussianFilter, (3,), 9; σ=0.18)
+    @test all(Array(interior(fc)) .≈ 2.71)
+
+    cl = center_field_from(gz, (x, y, z) -> 2z + 0.5)
+    fl = compute_filter(cl, GaussianFilter, (3,), 9; σ=0.18)
+    zc, _ = direction_coords_and_spacings(gz, 3, location(cl))
+    interiorᵏ = 11:Nz-10                            # cells whose full stencil stays in-domain
+    exact = [2*zc[k] + 0.5 for k in interiorᵏ]      # 2z+0.5 is independent of x, y, so check one column
+    @test Array(interior(fl))[1, 1, interiorᵏ] ≈ exact rtol=1e-2
+end
+
+# Multi-direction filters with at least one stretched direction must give the
+# same answer through the staged `compute!` path (the default `Field(filter)`)
+# as through the fused single-kernel path (`Field(1.0 * filter)`).
+function test_gaussian_stretched_staged_matches_fused()
+    gz = make_stretched_z_grid()
+    c = center_field_from(gz, (x, y, z) -> sin(2π*x) * cos(2π*y) + z^2)
+    for dims in [(1, 3), (3, 1), (1, 2, 3)]
+        staged = Field(GaussianFilter(c; dims=dims, σ=0.15))
+        fused  = Field(1.0 * GaussianFilter(c; dims=dims, σ=0.15))
+        compute!(staged); compute!(fused)
+        @test Array(interior(staged)) ≈ Array(interior(fused))
+    end
+end
+
+# On a Dirac delta the stretched filter's impulse response equals the normalized,
+# cell-width-weighted Gaussian sampled at the node coordinates.
+function test_gaussian_stretched_dirac_delta()
+    N = 21
+    zfaces(k) = (k-1)/N + 0.06 * sin(2π*(k-1)/N)
+    grid_1d = RectilinearGrid(arch, size=(1, 1, N), x=(0, 1), y=(0, 1), z=zfaces,
+                              halo=(1, 1, 4), topology=(Periodic, Periodic, Bounded))
+    zc, Δz = direction_coords_and_spacings(grid_1d, 3, (Center, Center, Center))
+    i₀ = N ÷ 2 + 1
+
+    for (width, σ) in [(3, 0.05), (4, 0.07)]
+        c = CenterField(grid_1d)
+        parent(c) .= 0
+        @allowscalar interior(c)[1, 1, i₀] = 1
+        fill_halo_regions!(c)
+
+        cf = compute_filter(c, GaussianFilter, (3,), width; σ=σ)
+
+        expected = zeros(N)
+        for k in 1:N
+            wsum = 0.0; w_i₀ = 0.0
+            for Δk in -width:width
+                m = k + Δk
+                if 1 <= m <= N
+                    w = Δz[m] * exp(-(zc[m] - zc[k])^2 / (2σ^2))
+                    wsum += w
+                    m == i₀ && (w_i₀ = w)
+                end
+            end
+            expected[k] = w_i₀ / wsum
+        end
+        @test Array(interior(cf))[1, 1, :] ≈ expected
+    end
 end
 
 # Apply the GaussianFilter to a discrete Dirac delta (a 1D field that is zero
@@ -580,7 +743,14 @@ filter_configs = [
         test_gaussian_N_inferred()
         test_gaussian_N_inferred_anisotropic()
         test_gaussian_N_tuple_order()
-        test_gaussian_uniform_spacing_required()
+    end
+
+    @testset "GaussianFilter on stretched grids" begin
+        test_gaussian_stretched_supported()
+        test_gaussian_stretched_numerical()
+        test_gaussian_stretched_constant_and_linear()
+        test_gaussian_stretched_staged_matches_fused()
+        test_gaussian_stretched_dirac_delta()
     end
 end
 #---

--- a/test/test_perf_invariants.jl
+++ b/test/test_perf_invariants.jl
@@ -121,6 +121,25 @@ end
             test_kfo_invariants("BoxFilter dims=$dims",      BoxFilter(c; dims=dims, N=3))
             test_kfo_invariants("GaussianFilter dims=$dims", GaussianFilter(c; dims=dims, σ=2/N))
         end
+
+        # Stretched (variably spaced) directions take the StretchedGaussianFilterKernel,
+        # which reads node coordinates/spacings and evaluates `exp` per offset instead
+        # of looking up a precomputed weight. That extra machinery (including the
+        # location-tuple splat) must still be allocation-free and type-stable per cell —
+        # an accidental boxing of the location tuple or a non-concrete spacing lookup
+        # would show up here immediately. The grid is stretched in z (the canonical
+        # case) and uniform in the periodic x and y.
+        zfaces(k) = -1 + (k-1)/N + 0.08 * sin(2π*(k-1)/N)
+        stretched_grid = RectilinearGrid(CPU(), size=(N, N, N), x=(0, 1), y=(0, 1), z=zfaces,
+                                         halo=(3, 3, 3), topology=(Periodic, Periodic, Bounded))
+        cs = CenterField(stretched_grid)
+        set!(cs, (x, y, z) -> sin(2π*x) + z^2)
+        # Pass an explicit (small) N: the alloc/type-stability invariant is
+        # independent of stencil width, and a fixed N keeps the fused 3D probe's
+        # compile time bounded regardless of the grid's minimum spacing.
+        for dims in ((3,), (1, 3), (1, 2, 3))
+            test_kfo_invariants("GaussianFilter stretched dims=$dims", GaussianFilter(cs; dims=dims, σ=2/N, N=5))
+        end
     end
 
     @testset "TracerEquation" begin
@@ -181,12 +200,27 @@ end
         set!(c, (x, y, z) -> sin(2π*x) * cos(2π*y))
         fill_halo_regions!(c)
 
+        # Same grid size but stretched in z, to track the variably spaced
+        # GaussianFilter: its 1D passes do more per-cell work (node/spacing reads
+        # plus `exp`) than the uniform path, but the staged evaluation must still
+        # beat the fused `N³` path by the same wide margin at a wide 3D stencil.
+        stretched_bench_grid = RectilinearGrid(CPU(), size=(16, 16, 16),
+                                               x=(0, 1), y=(0, 1),
+                                               z=k -> -1 + (k-1)/16 + 0.08*sin(2π*(k-1)/16),
+                                               halo=(5, 5, 5),
+                                               topology=(Periodic, Periodic, Bounded))
+        cs = CenterField(stretched_bench_grid)
+        set!(cs, (x, y, z) -> sin(2π*x) * cos(2π*y))
+        fill_halo_regions!(cs)
+
         # Each `(filter_name, build)` pair returns a fresh KFO for given
         # `(dims, width)`.
         configs = (("BoxFilter",
                     (dims, w) -> BoxFilter(c; dims=dims, N=2*w+1)),
                    ("GaussianFilter",
-                    (dims, w) -> GaussianFilter(c; dims=dims, σ=(w/2)/16, N=2*w+1)))
+                    (dims, w) -> GaussianFilter(c; dims=dims, σ=(w/2)/16, N=2*w+1)),
+                   ("GaussianFilter (stretched z)",
+                    (dims, w) -> GaussianFilter(cs; dims=dims, σ=(w/2)/16, N=2*w+1)))
 
         # Sanity: at a wide stencil width, the fused 3D path should be
         # *substantially* slower than the staged path. The threshold (2×)


### PR DESCRIPTION
## Summary

`GaussianFilter` previously required **uniform spacing** along every filtered direction and raised an `ArgumentError` otherwise. This PR makes it work on **variably spaced (stretched) grids** as well — e.g. a refined vertical boundary layer — while leaving the regular-grid path completely unchanged.

The choice is made **per direction at construction time**:

- **Uniform direction** → the original `GaussianFilterKernel`, which precomputes the weights once and looks them up in the hot loop. Byte-for-byte unchanged, so regular-grid performance is preserved.
- **Variably spaced direction** → a new `StretchedGaussianFilterKernel` that evaluates each weight on the fly from the node coordinates and cell widths, `Δₘ·exp(-(xₘ-x₀)²/2σ²)`.

So a grid that is uniform in `x`/`y` but stretched in `z` uses the fast path for the horizontals and the node-distance path for the vertical.

## Correctness

The stretched weight includes the **cell-width quadrature factor `Δₘ`**, making it a consistent discretization of the continuous Gaussian convolution `∫G_σ(x-x')ψ(x')dx' / ∫G_σ dx'`. As a result it:

- preserves constants exactly and linear fields to quadrature accuracy (a naive sample-average without the `Δ` factor biases toward finely resolved cells);
- reduces **exactly** to the uniform weighting when spacing is constant.

Periodic stretched directions use unwrapped image coordinates (node positions tile with the domain period); all node/spacing reads use clamped/wrapped interior indices, so a small halo never constrains the stencil width. Mixed-spacing multi-direction filters keep the separable staged `d×N` evaluation, each pass using its own kernel.

## Performance

Filtering *along* a stretched direction is several times slower per direction (node + spacing read + `exp` per stencil point instead of a lookup). Because multi-direction filters run as independent 1D passes, only the stretched directions pay this. Measured on a 128³ CPU grid (best of 10), same stencil `N`:

| Filter | Uniform | Stretched | Slowdown |
|---|---|---|---|
| `dims=(3,)`, N=9 | 34.5 ms | 155.7 ms | 4.5× |
| `dims=(3,)`, N=21 | 69.6 ms | 254.7 ms | 3.7× |
| `dims=(1,2,3)`, N=9 (z stretched) | 106.0 ms | 160.8 ms | 1.5× |
| `dims=(1,2,3)`, N=21 (z stretched) | 153.5 ms | 359.7 ms | 2.3× |

## Tests

- `test_filters.jl`: stretched-support + kernel-selection checks; numerical match against an independent quadrature reference (shrink/edge/periodic); constant & linear preservation; staged == fused; Dirac impulse response.
- `test_perf_invariants.jl`: zero-allocation/type-stability for the stretched kernel (1D/2D/3D) and the stretched filter added to the staged-vs-fused ratio invariant.

Both `filters` and `perf_invariants` test groups pass locally.

## Docs

Updated `filters.md` (new "Variably spaced grids" subsection + doctest + a performance note) and the note in the spatial-filtering example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)