### PR TITLE
Add Oceananigans 0.110 to compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
-version = "0.16.15"
+version = "0.16.16"
 authors = ["tomchor <tomaschor@gmail.com>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 [compat]
 Crayons = "4"
 DocStringExtensions = "0.9"
-Oceananigans = "0.102, 0.103, 0.104, 0.105, 0.106, 0.107, 0.108, 0.109"
+Oceananigans = "0.102, 0.103, 0.104, 0.105, 0.106, 0.107, 0.108, 0.109, 0.110"
 SeawaterPolynomials = "0.3"
 julia = "1.9"
 


### PR DESCRIPTION
## Summary

Adds `0.110` to the Oceananigans compat bound in `Project.toml`.

Oceananigans 0.110.0 ([CliMA/Oceananigans.jl#5648](https://github.com/CliMA/Oceananigans.jl/pull/5648)) is a breaking release that:
- renames the `Open` boundary-condition classification to `NormalFlow` (no longer exported),
- makes `Value` parametric (`Value{MS}`) and adds a `scheme` keyword to `ValueBoundaryCondition`,
- moves tracer `PerturbationAdvection` open boundaries from `Open` to `Value`,
- fixes an internal `BoundaryCondition{Value}` → `BoundaryCondition{<:Value}` alias.

## Compatibility check

Oceanostics uses **none** of the affected APIs. A search of `src/`, `test/`, and `docs/` for `Open`, `NormalFlow`, `OpenBoundaryCondition`, `ValueBoundaryCondition`, `Value{`, `BoundaryCondition{`, `fill_open_bcs`, and `PolarOpen...` returned nothing. The only boundary-condition machinery Oceanostics touches is `GradientBoundaryCondition` / `FluxBoundaryCondition` / `FieldBoundaryConditions` and the `.boundary_conditions.immersed` accessor — none of which changed in 0.110.0.

The only other commit between v0.109.2 and 0.110.0 is an io-benchmark tweak ([#5638](https://github.com/CliMA/Oceananigans.jl/pull/5638)), which is irrelevant here.

Locally, Oceanostics precompiles cleanly against Oceananigans 0.110.0. No source changes are required. Oceananigans 0.110.0 is registered in the General registry, so CI here resolves to and tests against it.