### PR TITLE
Add StrainRateTensor diagnostic

### DIFF
--- a/docs/src/flow_diagnostics.md
+++ b/docs/src/flow_diagnostics.md
@@ -153,6 +153,24 @@ Oceanostics.FlowDiagnostics.StrainRateTensor
 Oceanostics.FlowDiagnostics.StrainRateTensorModulus
 ```
 
+### Principal strain rates
+
+The principal strain rates are the eigenvalues ``\lambda_1 \ge \lambda_2 \ge \lambda_3`` of the strain
+rate tensor, returned as a `NamedTuple` at `(Center, Center, Center)`. They quantify stretching
+(``\lambda > 0``) and compression (``\lambda < 0``) along the principal axes and are rotation
+invariants of the tensor:
+
+```math
+\lambda_1 + \lambda_2 + \lambda_3 = \nabla\cdot\mathbf{u}, \qquad
+\lambda_1^2 + \lambda_2^2 + \lambda_3^2 = S_{ij} S_{ij}
+```
+
+so for incompressible flow they sum to zero and their root-sum-of-squares equals ``\|S_{ij}\|``.
+
+```@docs
+Oceanostics.FlowDiagnostics.PrincipalStrainRates
+```
+
 ### Vorticity tensor modulus
 
 ```math

--- a/docs/src/flow_diagnostics.md
+++ b/docs/src/flow_diagnostics.md
@@ -156,24 +156,6 @@ Oceanostics.FlowDiagnostics.StrainRateTensor
 Oceanostics.FlowDiagnostics.StrainRateTensorModulus
 ```
 
-### Principal strain rates
-
-The principal strain rates are the eigenvalues ``\lambda_1 \ge \lambda_2 \ge \lambda_3`` of the strain
-rate tensor, returned as a `NamedTuple` at `(Center, Center, Center)`. They quantify stretching
-(``\lambda > 0``) and compression (``\lambda < 0``) along the principal axes and are rotation
-invariants of the tensor:
-
-```math
-\lambda_1 + \lambda_2 + \lambda_3 = \nabla\cdot\mathbf{u}, \qquad
-\lambda_1^2 + \lambda_2^2 + \lambda_3^2 = S_{ij} S_{ij}
-```
-
-so for incompressible flow they sum to zero and their root-sum-of-squares equals ``\|S_{ij}\|``.
-
-```@docs
-Oceanostics.FlowDiagnostics.PrincipalStrainRates
-```
-
 ### Vorticity tensor modulus
 
 ```math

--- a/docs/src/flow_diagnostics.md
+++ b/docs/src/flow_diagnostics.md
@@ -126,7 +126,7 @@ The contribution to the Ertel PV from a single user-specified direction.
 Oceanostics.FlowDiagnostics.DirectionalErtelPotentialVorticity
 ```
 
-## Velocity gradient tensor invariants
+## Velocity gradient tensor diagnostics
 
 ### Strain rate tensor
 

--- a/docs/src/flow_diagnostics.md
+++ b/docs/src/flow_diagnostics.md
@@ -16,9 +16,9 @@ The module includes:
   a materially conserved quantity under adiabatic, inviscid conditions that is
   fundamental for understanding large-scale ocean dynamics. A thermal-wind-balance
   approximation and a directional decomposition are also provided.
-- **Velocity gradient tensor invariants**: the strain rate tensor modulus
-  (``\|S_{ij}\|``), vorticity tensor modulus (``\|\Omega_{ij}\|``), and the
-  ``Q``-criterion for vortex identification.
+- **Velocity gradient tensor diagnostics**: the full strain rate tensor ``S_{ij}``
+  and its modulus (``\|S_{ij}\|``), the vorticity tensor modulus (``\|\Omega_{ij}\|``),
+  and the ``Q``-criterion for vortex identification.
 - **Mixed layer depth**: computed by scanning downward from the surface to find
   where buoyancy or density departs from the surface value by more than a
   user-specified threshold.
@@ -127,6 +127,21 @@ Oceanostics.FlowDiagnostics.DirectionalErtelPotentialVorticity
 ```
 
 ## Velocity gradient tensor invariants
+
+### Strain rate tensor
+
+The full (symmetric) strain rate tensor, returned as a `NamedTuple` of its 6 independent components.
+Each component is a `KernelFunctionOperation` evaluated at its natural location on the staggered grid
+(the diagonal components at `(Center, Center, Center)`; the off-diagonals at the edge locations
+`(Face, Face, Center)`, `(Face, Center, Face)`, and `(Center, Face, Face)`).
+
+```math
+S_{ij} = \tfrac{1}{2}(\partial_j u_i + \partial_i u_j)
+```
+
+```@docs
+Oceanostics.FlowDiagnostics.StrainRateTensor
+```
 
 ### Strain rate tensor modulus
 

--- a/docs/src/flow_diagnostics.md
+++ b/docs/src/flow_diagnostics.md
@@ -130,10 +130,13 @@ Oceanostics.FlowDiagnostics.DirectionalErtelPotentialVorticity
 
 ### Strain rate tensor
 
-The full (symmetric) strain rate tensor, returned as a `NamedTuple` of its 6 independent components.
-Each component is a `KernelFunctionOperation` evaluated at its natural location on the staggered grid
+The (symmetric) strain rate tensor, returned as a `NamedTuple` of its independent components. Each
+component is a `KernelFunctionOperation` evaluated at its natural location on the staggered grid
 (the diagonal components at `(Center, Center, Center)`; the off-diagonals at the edge locations
-`(Face, Face, Center)`, `(Face, Center, Face)`, and `(Center, Face, Face)`).
+`(Face, Face, Center)`, `(Face, Center, Face)`, and `(Center, Face, Face)`). The `dims` keyword
+selects a sub-dimensional tensor — component ``S_{ij}`` is included only when both ``i`` and ``j``
+are in `dims` — so `dims=(1, 3)` returns the 2D strain rate tensor in the ``x``–``z`` plane
+(``S_{11}``, ``S_{33}``, ``S_{13}``).
 
 ```math
 S_{ij} = \tfrac{1}{2}(\partial_j u_i + \partial_i u_j)

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -3,7 +3,7 @@ using DocStringExtensions
 
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity, DirectionalErtelPotentialVorticity
-export StrainRateTensor, PrincipalStrainRates, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
+export StrainRateTensor, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
 export MixedLayerDepth, BuoyancyAnomalyCriterion, DensityAnomalyCriterion
 export BottomCellValue
 
@@ -458,67 +458,6 @@ function StrainRateTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3))
     )
 
     return (; (k => op for (k, op) in pairs(components) if op !== nothing)...)
-end
-
-# Analytical eigenvalues of the symmetric 3×3 matrix [a d e; d b f; e f c], returned sorted as
-# λ₁ ≥ λ₂ ≥ λ₃ (Smith's trigonometric method). Operates entirely on scalars, so it stays
-# allocation-free and GPU-safe inside a kernel without pulling in an external tensor package.
-@inline function eigvals_symmetric_3x3(a, b, c, d, e, f)
-    p1 = d^2 + e^2 + f^2
-    q  = (a + b + c) / 3
-    p2 = (a - q)^2 + (b - q)^2 + (c - q)^2 + 2p1
-    p  = sqrt(p2 / 6)
-    p == 0 && return (q, q, q) # A is isotropic (A = qI), e.g. a quiescent flow
-
-    a′ = a - q; b′ = b - q; c′ = c - q
-    detB = (a′ * (b′*c′ - f^2) - d * (d*c′ - e*f) + e * (d*f - e*b′)) / p^3
-    r = clamp(detB / 2, -one(p), one(p)) # clamp absorbs roundoff so acos stays in range
-    φ = acos(r) / 3
-
-    λ₁ = q + 2p * cos(φ)
-    λ₃ = q + 2p * cos(φ + oftype(φ, 2π/3))
-    λ₂ = 3q - λ₁ - λ₃ # the eigenvalues sum to the trace
-    return (λ₁, λ₂, λ₃)
-end
-
-# Strain rate components co-located at ccc (off-diagonals interpolated from their natural edges),
-# fed to the symmetric eigensolver.
-@inline function strain_rate_eigenvalues_ccc(i, j, k, grid, u, v, w)
-    S₁₁ = ∂xᶜᶜᶜ(i, j, k, grid, u)
-    S₂₂ = ∂yᶜᶜᶜ(i, j, k, grid, v)
-    S₃₃ = ∂zᶜᶜᶜ(i, j, k, grid, w)
-    S₁₂ = ℑxyᶜᶜᵃ(i, j, k, grid, strain_rate_tensor_xy_ffc, u, v)
-    S₁₃ = ℑxzᶜᵃᶜ(i, j, k, grid, strain_rate_tensor_xz_fcf, u, w)
-    S₂₃ = ℑyzᵃᶜᶜ(i, j, k, grid, strain_rate_tensor_yz_cff, v, w)
-    return eigvals_symmetric_3x3(S₁₁, S₂₂, S₃₃, S₁₂, S₁₃, S₂₃)
-end
-
-@inline strain_rate_eigenvalue_1_ccc(i, j, k, grid, u, v, w) = strain_rate_eigenvalues_ccc(i, j, k, grid, u, v, w)[1]
-@inline strain_rate_eigenvalue_2_ccc(i, j, k, grid, u, v, w) = strain_rate_eigenvalues_ccc(i, j, k, grid, u, v, w)[2]
-@inline strain_rate_eigenvalue_3_ccc(i, j, k, grid, u, v, w) = strain_rate_eigenvalues_ccc(i, j, k, grid, u, v, w)[3]
-
-"""
-    $(SIGNATURES)
-
-Return the principal strain rates — the eigenvalues of the strain rate tensor
-`Sᵢⱼ = ½(∂ⱼuᵢ + ∂ᵢuⱼ)` — as a `NamedTuple` `(; λ₁, λ₂, λ₃)` ordered so that `λ₁ ≥ λ₂ ≥ λ₃`. Each is a
-`KernelFunctionOperation` at `(Center, Center, Center)`: the full tensor is assembled there (the
-off-diagonal components are interpolated from their natural edge locations) and its eigenvalues are
-computed analytically with a symmetric-3×3 eigensolver.
-
-The principal strain rates describe stretching (`λ > 0`) and compression (`λ < 0`) along the
-principal axes. They are rotation invariants of the tensor: `λ₁ + λ₂ + λ₃ = ∇·u` and
-`λ₁² + λ₂² + λ₃² = SᵢⱼSᵢⱼ`, so for incompressible flow they sum to zero and their root-sum-of-squares
-equals [`StrainRateTensorModulus`](@ref). Can also be called as
-`PrincipalStrainRates(grid, u, v, w)`. See also [`StrainRateTensor`](@ref) for the tensor components.
-"""
-PrincipalStrainRates(model) = PrincipalStrainRates(model.grid, model.velocities...)
-
-function PrincipalStrainRates(grid::AbstractGrid, u, v, w)
-    λ₁ = KernelFunctionOperation{Center, Center, Center}(strain_rate_eigenvalue_1_ccc, grid, u, v, w)
-    λ₂ = KernelFunctionOperation{Center, Center, Center}(strain_rate_eigenvalue_2_ccc, grid, u, v, w)
-    λ₃ = KernelFunctionOperation{Center, Center, Center}(strain_rate_eigenvalue_3_ccc, grid, u, v, w)
-    return (; λ₁, λ₂, λ₃)
 end
 
 @inline fψ_minus_gφ²(i, j, k, grid, f, ψ, g, φ) = (f(i, j, k, grid, ψ) - g(i, j, k, grid, φ))^2

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -402,6 +402,11 @@ end
 @inline strain_rate_tensor_xz_fcf(i, j, k, grid, u, w) = (∂zᶠᶜᶠ(i, j, k, grid, u) + ∂xᶠᶜᶠ(i, j, k, grid, w)) / 2
 @inline strain_rate_tensor_yz_cff(i, j, k, grid, v, w) = (∂zᶜᶠᶠ(i, j, k, grid, v) + ∂yᶜᶠᶠ(i, j, k, grid, w)) / 2
 
+validate_dims(dims::Tuple{Vararg{Int}}) =
+    (!isempty(dims) & all(d -> d in (1, 2, 3), dims) & allunique(dims)) ||
+        throw(ArgumentError("`dims` must be a non-empty tuple of distinct integers drawn from (1, 2, 3); got $dims"))
+validate_dims(dims) = throw(ArgumentError("`dims` must be a tuple of integers; got $(typeof(dims))"))
+
 """
     $(SIGNATURES)
 
@@ -412,7 +417,7 @@ gradient tensor:
     Sᵢⱼ = ½(∂ⱼuᵢ + ∂ᵢuⱼ)
 ```
 
-The result is a `NamedTuple` with the 6 independent components, each a `KernelFunctionOperation`
+The result is a `NamedTuple` with the independent components, each a `KernelFunctionOperation`
 living at its natural location on the staggered grid:
 
 | Component | Definition         | Location |
@@ -425,23 +430,34 @@ living at its natural location on the staggered grid:
 | `S₂₃`     | `½(∂v/∂z + ∂w/∂y)` | `cff`    |
 
 The tensor is symmetric, so the remaining components follow from `Sⱼᵢ = Sᵢⱼ` (i.e. `S₂₁ = S₁₂`,
-`S₃₁ = S₁₃`, `S₃₂ = S₂₃`). Each component can be wrapped in a `Field` and used with output writers,
-time-averaging, etc. Can also be called as `StrainRateTensor(grid, u, v, w)` to build the components
-from individual velocity fields. See also [`StrainRateTensorModulus`](@ref) for the scalar modulus
-`√(SᵢⱼSᵢⱼ)`.
+`S₃₁ = S₁₃`, `S₃₂ = S₂₃`).
+
+`dims` selects which spatial directions (`1 → x`, `2 → y`, `3 → z`) enter the tensor: component
+`Sᵢⱼ` is included only when both `i` and `j` are in `dims`. The default `dims = (1, 2, 3)` returns
+the full tensor, while e.g. `dims = (1, 3)` returns the 2D strain rate tensor in the `x`–`z` plane
+(`S₁₁`, `S₃₃`, `S₁₃`). Components are always ordered diagonals-first, independently of the order of
+`dims`.
+
+Each component can be wrapped in a `Field` and used with output writers, time-averaging, etc. Can
+also be called as `StrainRateTensor(grid, u, v, w; dims)` to build the components from individual
+velocity fields. See also [`StrainRateTensorModulus`](@ref) for the scalar modulus `√(SᵢⱼSᵢⱼ)`.
 """
-StrainRateTensor(model) = StrainRateTensor(model.grid, model.velocities...)
+StrainRateTensor(model; dims = (1, 2, 3)) = StrainRateTensor(model.grid, model.velocities...; dims)
 
-function StrainRateTensor(grid::AbstractGrid, u, v, w)
-    S₁₁ = KernelFunctionOperation{Center, Center, Center}(∂xᶜᶜᶜ, grid, u)
-    S₂₂ = KernelFunctionOperation{Center, Center, Center}(∂yᶜᶜᶜ, grid, v)
-    S₃₃ = KernelFunctionOperation{Center, Center, Center}(∂zᶜᶜᶜ, grid, w)
+function StrainRateTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3))
+    validate_dims(dims)
+    want(ij...) = all(in(dims), ij) # keep component Sᵢⱼ only if every index it needs is in `dims`
 
-    S₁₂ = KernelFunctionOperation{Face, Face, Center}(strain_rate_tensor_xy_ffc, grid, u, v)
-    S₁₃ = KernelFunctionOperation{Face, Center, Face}(strain_rate_tensor_xz_fcf, grid, u, w)
-    S₂₃ = KernelFunctionOperation{Center, Face, Face}(strain_rate_tensor_yz_cff, grid, v, w)
+    components = (
+        S₁₁ = want(1)    ? KernelFunctionOperation{Center, Center, Center}(∂xᶜᶜᶜ, grid, u) : nothing,
+        S₂₂ = want(2)    ? KernelFunctionOperation{Center, Center, Center}(∂yᶜᶜᶜ, grid, v) : nothing,
+        S₃₃ = want(3)    ? KernelFunctionOperation{Center, Center, Center}(∂zᶜᶜᶜ, grid, w) : nothing,
+        S₁₂ = want(1, 2) ? KernelFunctionOperation{Face, Face, Center}(strain_rate_tensor_xy_ffc, grid, u, v) : nothing,
+        S₁₃ = want(1, 3) ? KernelFunctionOperation{Face, Center, Face}(strain_rate_tensor_xz_fcf, grid, u, w) : nothing,
+        S₂₃ = want(2, 3) ? KernelFunctionOperation{Center, Face, Face}(strain_rate_tensor_yz_cff, grid, v, w) : nothing,
+    )
 
-    return (; S₁₁, S₂₂, S₃₃, S₁₂, S₁₃, S₂₃)
+    return (; (k => op for (k, op) in pairs(components) if op !== nothing)...)
 end
 
 # Analytical eigenvalues of the symmetric 3×3 matrix [a d e; d b f; e f c], returned sorted as

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -3,7 +3,7 @@ using DocStringExtensions
 
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity, DirectionalErtelPotentialVorticity
-export StrainRateTensor, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
+export StrainRateTensor, PrincipalStrainRates, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
 export MixedLayerDepth, BuoyancyAnomalyCriterion, DensityAnomalyCriterion
 export BottomCellValue
 
@@ -442,6 +442,67 @@ function StrainRateTensor(grid::AbstractGrid, u, v, w)
     S₂₃ = KernelFunctionOperation{Center, Face, Face}(strain_rate_tensor_yz_cff, grid, v, w)
 
     return (; S₁₁, S₂₂, S₃₃, S₁₂, S₁₃, S₂₃)
+end
+
+# Analytical eigenvalues of the symmetric 3×3 matrix [a d e; d b f; e f c], returned sorted as
+# λ₁ ≥ λ₂ ≥ λ₃ (Smith's trigonometric method). Operates entirely on scalars, so it stays
+# allocation-free and GPU-safe inside a kernel without pulling in an external tensor package.
+@inline function eigvals_symmetric_3x3(a, b, c, d, e, f)
+    p1 = d^2 + e^2 + f^2
+    q  = (a + b + c) / 3
+    p2 = (a - q)^2 + (b - q)^2 + (c - q)^2 + 2p1
+    p  = sqrt(p2 / 6)
+    p == 0 && return (q, q, q) # A is isotropic (A = qI), e.g. a quiescent flow
+
+    a′ = a - q; b′ = b - q; c′ = c - q
+    detB = (a′ * (b′*c′ - f^2) - d * (d*c′ - e*f) + e * (d*f - e*b′)) / p^3
+    r = clamp(detB / 2, -one(p), one(p)) # clamp absorbs roundoff so acos stays in range
+    φ = acos(r) / 3
+
+    λ₁ = q + 2p * cos(φ)
+    λ₃ = q + 2p * cos(φ + oftype(φ, 2π/3))
+    λ₂ = 3q - λ₁ - λ₃ # the eigenvalues sum to the trace
+    return (λ₁, λ₂, λ₃)
+end
+
+# Strain rate components co-located at ccc (off-diagonals interpolated from their natural edges),
+# fed to the symmetric eigensolver.
+@inline function strain_rate_eigenvalues_ccc(i, j, k, grid, u, v, w)
+    S₁₁ = ∂xᶜᶜᶜ(i, j, k, grid, u)
+    S₂₂ = ∂yᶜᶜᶜ(i, j, k, grid, v)
+    S₃₃ = ∂zᶜᶜᶜ(i, j, k, grid, w)
+    S₁₂ = ℑxyᶜᶜᵃ(i, j, k, grid, strain_rate_tensor_xy_ffc, u, v)
+    S₁₃ = ℑxzᶜᵃᶜ(i, j, k, grid, strain_rate_tensor_xz_fcf, u, w)
+    S₂₃ = ℑyzᵃᶜᶜ(i, j, k, grid, strain_rate_tensor_yz_cff, v, w)
+    return eigvals_symmetric_3x3(S₁₁, S₂₂, S₃₃, S₁₂, S₁₃, S₂₃)
+end
+
+@inline strain_rate_eigenvalue_1_ccc(i, j, k, grid, u, v, w) = strain_rate_eigenvalues_ccc(i, j, k, grid, u, v, w)[1]
+@inline strain_rate_eigenvalue_2_ccc(i, j, k, grid, u, v, w) = strain_rate_eigenvalues_ccc(i, j, k, grid, u, v, w)[2]
+@inline strain_rate_eigenvalue_3_ccc(i, j, k, grid, u, v, w) = strain_rate_eigenvalues_ccc(i, j, k, grid, u, v, w)[3]
+
+"""
+    $(SIGNATURES)
+
+Return the principal strain rates — the eigenvalues of the strain rate tensor
+`Sᵢⱼ = ½(∂ⱼuᵢ + ∂ᵢuⱼ)` — as a `NamedTuple` `(; λ₁, λ₂, λ₃)` ordered so that `λ₁ ≥ λ₂ ≥ λ₃`. Each is a
+`KernelFunctionOperation` at `(Center, Center, Center)`: the full tensor is assembled there (the
+off-diagonal components are interpolated from their natural edge locations) and its eigenvalues are
+computed analytically with a symmetric-3×3 eigensolver.
+
+The principal strain rates describe stretching (`λ > 0`) and compression (`λ < 0`) along the
+principal axes. They are rotation invariants of the tensor: `λ₁ + λ₂ + λ₃ = ∇·u` and
+`λ₁² + λ₂² + λ₃² = SᵢⱼSᵢⱼ`, so for incompressible flow they sum to zero and their root-sum-of-squares
+equals [`StrainRateTensorModulus`](@ref). Can also be called as
+`PrincipalStrainRates(grid, u, v, w)`. See also [`StrainRateTensor`](@ref) for the tensor components.
+"""
+PrincipalStrainRates(model) = PrincipalStrainRates(model.grid, model.velocities...)
+
+function PrincipalStrainRates(grid::AbstractGrid, u, v, w)
+    λ₁ = KernelFunctionOperation{Center, Center, Center}(strain_rate_eigenvalue_1_ccc, grid, u, v, w)
+    λ₂ = KernelFunctionOperation{Center, Center, Center}(strain_rate_eigenvalue_2_ccc, grid, u, v, w)
+    λ₃ = KernelFunctionOperation{Center, Center, Center}(strain_rate_eigenvalue_3_ccc, grid, u, v, w)
+    return (; λ₁, λ₂, λ₃)
 end
 
 @inline fψ_minus_gφ²(i, j, k, grid, f, ψ, g, φ) = (f(i, j, k, grid, ψ) - g(i, j, k, grid, φ))^2

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -3,7 +3,7 @@ using DocStringExtensions
 
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity, DirectionalErtelPotentialVorticity
-export StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
+export StrainRateTensor, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
 export MixedLayerDepth, BuoyancyAnomalyCriterion, DensityAnomalyCriterion
 export BottomCellValue
 
@@ -395,6 +395,53 @@ Its modulus is then defined (using Einstein summation notation) as
 function StrainRateTensorModulus(model; loc = (Center, Center, Center))
     validate_location(loc, "StrainRateTensorModulus", (Center, Center, Center))
     return KernelFunctionOperation{Center, Center, Center}(strain_rate_tensor_modulus_ccc, model.grid, model.velocities...)
+end
+
+# Off-diagonal strain rate components, each evaluated at its natural staggered location.
+@inline strain_rate_tensor_xy_ffc(i, j, k, grid, u, v) = (∂yᶠᶠᶜ(i, j, k, grid, u) + ∂xᶠᶠᶜ(i, j, k, grid, v)) / 2
+@inline strain_rate_tensor_xz_fcf(i, j, k, grid, u, w) = (∂zᶠᶜᶠ(i, j, k, grid, u) + ∂xᶠᶜᶠ(i, j, k, grid, w)) / 2
+@inline strain_rate_tensor_yz_cff(i, j, k, grid, v, w) = (∂zᶜᶠᶠ(i, j, k, grid, v) + ∂yᶜᶠᶠ(i, j, k, grid, w)) / 2
+
+"""
+    $(SIGNATURES)
+
+Return the components of the strain rate tensor `S`, defined as the symmetric part of the velocity
+gradient tensor:
+
+```
+    Sᵢⱼ = ½(∂ⱼuᵢ + ∂ᵢuⱼ)
+```
+
+The result is a `NamedTuple` with the 6 independent components, each a `KernelFunctionOperation`
+living at its natural location on the staggered grid:
+
+| Component | Definition         | Location |
+|:---------:|:------------------:|:--------:|
+| `S₁₁`     | `∂u/∂x`            | `ccc`    |
+| `S₂₂`     | `∂v/∂y`            | `ccc`    |
+| `S₃₃`     | `∂w/∂z`            | `ccc`    |
+| `S₁₂`     | `½(∂u/∂y + ∂v/∂x)` | `ffc`    |
+| `S₁₃`     | `½(∂u/∂z + ∂w/∂x)` | `fcf`    |
+| `S₂₃`     | `½(∂v/∂z + ∂w/∂y)` | `cff`    |
+
+The tensor is symmetric, so the remaining components follow from `Sⱼᵢ = Sᵢⱼ` (i.e. `S₂₁ = S₁₂`,
+`S₃₁ = S₁₃`, `S₃₂ = S₂₃`). Each component can be wrapped in a `Field` and used with output writers,
+time-averaging, etc. Can also be called as `StrainRateTensor(grid, u, v, w)` to build the components
+from individual velocity fields. See also [`StrainRateTensorModulus`](@ref) for the scalar modulus
+`√(SᵢⱼSᵢⱼ)`.
+"""
+StrainRateTensor(model) = StrainRateTensor(model.grid, model.velocities...)
+
+function StrainRateTensor(grid::AbstractGrid, u, v, w)
+    S₁₁ = KernelFunctionOperation{Center, Center, Center}(∂xᶜᶜᶜ, grid, u)
+    S₂₂ = KernelFunctionOperation{Center, Center, Center}(∂yᶜᶜᶜ, grid, v)
+    S₃₃ = KernelFunctionOperation{Center, Center, Center}(∂zᶜᶜᶜ, grid, w)
+
+    S₁₂ = KernelFunctionOperation{Face, Face, Center}(strain_rate_tensor_xy_ffc, grid, u, v)
+    S₁₃ = KernelFunctionOperation{Face, Center, Face}(strain_rate_tensor_xz_fcf, grid, u, w)
+    S₂₃ = KernelFunctionOperation{Center, Face, Face}(strain_rate_tensor_yz_cff, grid, v, w)
+
+    return (; S₁₁, S₂₂, S₃₃, S₁₂, S₁₃, S₂₃)
 end
 
 @inline fψ_minus_gφ²(i, j, k, grid, f, ψ, g, φ) = (f(i, j, k, grid, ψ) - g(i, j, k, grid, φ))^2

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -53,7 +53,7 @@ export TurbulentKineticEnergy,
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity
 export DirectionalErtelPotentialVorticity
-export StrainRateTensor, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
+export StrainRateTensor, PrincipalStrainRates, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
 export MixedLayerDepth, BuoyancyAnomalyCriterion, DensityAnomalyCriterion
 export BottomCellValue
 #---

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -53,7 +53,7 @@ export TurbulentKineticEnergy,
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity
 export DirectionalErtelPotentialVorticity
-export StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
+export StrainRateTensor, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
 export MixedLayerDepth, BuoyancyAnomalyCriterion, DensityAnomalyCriterion
 export BottomCellValue
 #---

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -53,7 +53,7 @@ export TurbulentKineticEnergy,
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity
 export DirectionalErtelPotentialVorticity
-export StrainRateTensor, PrincipalStrainRates, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
+export StrainRateTensor, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
 export MixedLayerDepth, BuoyancyAnomalyCriterion, DensityAnomalyCriterion
 export BottomCellValue
 #---

--- a/test/test_canonical_flows.jl
+++ b/test/test_canonical_flows.jl
@@ -62,9 +62,6 @@ function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=
     S₁₁ = Field(Sij.S₁₁); S₂₂ = Field(Sij.S₂₂); S₃₃ = Field(Sij.S₃₃)
     S₁₂ = Field(Sij.S₁₂); S₁₃ = Field(Sij.S₁₃); S₂₃ = Field(Sij.S₂₃)
 
-    Λ = PrincipalStrainRates(model)
-    λ₁ = Field(Λ.λ₁); λ₂ = Field(Λ.λ₂); λ₃ = Field(Λ.λ₃)
-
     idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
 
     if model.closure isa Tuple
@@ -93,17 +90,6 @@ function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=
         SᵢⱼSᵢⱼ = getindex(S₁₁, idxs...)^2 + getindex(S₂₂, idxs...)^2 + getindex(S₃₃, idxs...)^2 +
                  2 * (getindex(S₁₂, idxs...)^2 + getindex(S₁₃, idxs...)^2 + getindex(S₂₃, idxs...)^2)
         @test √(SᵢⱼSᵢⱼ) ≈ getindex(S, idxs...)
-
-        # Principal strain rates are the sorted eigenvalues of S = diag(α, -α, 0): (α, 0, -α)
-        l₁, l₂, l₃ = getindex(λ₁, idxs...), getindex(λ₂, idxs...), getindex(λ₃, idxs...)
-        @test l₁ ≈ +α
-        @test ≈(l₂, 0, atol=10eps())
-        @test l₃ ≈ -α
-        @test l₁ ≥ l₂ ≥ l₃ # ordering convention λ₁ ≥ λ₂ ≥ λ₃
-
-        # Eigenvalue invariants: Σλ = ∇·u (≈ 0 here) and √(Σλ²) = ‖S‖
-        @test ≈(l₁ + l₂ + l₃, 0, atol=10eps())
-        @test √(l₁^2 + l₂^2 + l₃^2) ≈ getindex(S, idxs...)
     end
 
     return nothing

--- a/test/test_canonical_flows.jl
+++ b/test/test_canonical_flows.jl
@@ -62,6 +62,9 @@ function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=
     S₁₁ = Field(Sij.S₁₁); S₂₂ = Field(Sij.S₂₂); S₃₃ = Field(Sij.S₃₃)
     S₁₂ = Field(Sij.S₁₂); S₁₃ = Field(Sij.S₁₃); S₂₃ = Field(Sij.S₂₃)
 
+    Λ = PrincipalStrainRates(model)
+    λ₁ = Field(Λ.λ₁); λ₂ = Field(Λ.λ₂); λ₃ = Field(Λ.λ₃)
+
     idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
 
     if model.closure isa Tuple
@@ -90,6 +93,17 @@ function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=
         SᵢⱼSᵢⱼ = getindex(S₁₁, idxs...)^2 + getindex(S₂₂, idxs...)^2 + getindex(S₃₃, idxs...)^2 +
                  2 * (getindex(S₁₂, idxs...)^2 + getindex(S₁₃, idxs...)^2 + getindex(S₂₃, idxs...)^2)
         @test √(SᵢⱼSᵢⱼ) ≈ getindex(S, idxs...)
+
+        # Principal strain rates are the sorted eigenvalues of S = diag(α, -α, 0): (α, 0, -α)
+        l₁, l₂, l₃ = getindex(λ₁, idxs...), getindex(λ₂, idxs...), getindex(λ₃, idxs...)
+        @test l₁ ≈ +α
+        @test ≈(l₂, 0, atol=10eps())
+        @test l₃ ≈ -α
+        @test l₁ ≥ l₂ ≥ l₃ # ordering convention λ₁ ≥ λ₂ ≥ λ₃
+
+        # Eigenvalue invariants: Σλ = ∇·u (≈ 0 here) and √(Σλ²) = ‖S‖
+        @test ≈(l₁ + l₂ + l₃, 0, atol=10eps())
+        @test √(l₁^2 + l₂^2 + l₃^2) ≈ getindex(S, idxs...)
     end
 
     return nothing

--- a/test/test_canonical_flows.jl
+++ b/test/test_canonical_flows.jl
@@ -58,6 +58,10 @@ function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=
     Ω = Field(VorticityTensorModulus(model))
     q = Field(QVelocityGradientTensorInvariant(model))
 
+    Sij = StrainRateTensor(model)
+    S₁₁ = Field(Sij.S₁₁); S₂₂ = Field(Sij.S₂₂); S₃₃ = Field(Sij.S₃₃)
+    S₁₂ = Field(Sij.S₁₂); S₁₃ = Field(Sij.S₁₃); S₂₃ = Field(Sij.S₂₃)
+
     idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
 
     if model.closure isa Tuple
@@ -73,6 +77,19 @@ function test_uniform_strain_flow(grid; model_type=NonhydrostaticModel, closure=
         @test ≈(getindex(Ω, idxs...), 0, atol=10eps())
         @test getindex(q, idxs...) ≈ (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2 ≈ -α^2
         @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2
+
+        # Strain rate tensor for uⱼ = (αx, -αy, 0) is S = diag(α, -α, 0), off-diagonals zero
+        @test getindex(S₁₁, idxs...) ≈ +α
+        @test getindex(S₂₂, idxs...) ≈ -α
+        @test ≈(getindex(S₃₃, idxs...), 0, atol=10eps())
+        @test ≈(getindex(S₁₂, idxs...), 0, atol=10eps())
+        @test ≈(getindex(S₁₃, idxs...), 0, atol=10eps())
+        @test ≈(getindex(S₂₃, idxs...), 0, atol=10eps())
+
+        # The modulus is recovered from the components: ‖S‖ = √(Sᵢⱼ Sᵢⱼ)
+        SᵢⱼSᵢⱼ = getindex(S₁₁, idxs...)^2 + getindex(S₂₂, idxs...)^2 + getindex(S₃₃, idxs...)^2 +
+                 2 * (getindex(S₁₂, idxs...)^2 + getindex(S₁₃, idxs...)^2 + getindex(S₂₃, idxs...)^2)
+        @test √(SᵢⱼSᵢⱼ) ≈ getindex(S, idxs...)
     end
 
     return nothing

--- a/test/test_perf_invariants.jl
+++ b/test/test_perf_invariants.jl
@@ -173,6 +173,13 @@ end
         test_kfo_invariants("RossbyNumber",            RossbyNumber(model))
         test_kfo_invariants("ErtelPotentialVorticity", ErtelPotentialVorticity(model))
         test_kfo_invariants("StrainRateTensorModulus", StrainRateTensorModulus(model))
+
+        # Off-diagonal strain components live at edge locations (ffc/fcf/cff) and exercise the
+        # new per-component kernels; the diagonals reuse Oceananigans' ∂ᵢᶜᶜᶜ operators.
+        Sij = StrainRateTensor(model)
+        test_kfo_invariants("StrainRateTensor.S₁₂", Sij.S₁₂)
+        test_kfo_invariants("StrainRateTensor.S₁₃", Sij.S₁₃)
+        test_kfo_invariants("StrainRateTensor.S₂₃", Sij.S₂₃)
     end
     #---
 

--- a/test/test_perf_invariants.jl
+++ b/test/test_perf_invariants.jl
@@ -180,13 +180,6 @@ end
         test_kfo_invariants("StrainRateTensor.S₁₂", Sij.S₁₂)
         test_kfo_invariants("StrainRateTensor.S₁₃", Sij.S₁₃)
         test_kfo_invariants("StrainRateTensor.S₂₃", Sij.S₂₃)
-
-        # The principal strain rates run an analytical eigensolver (acos/cos) and return a tuple
-        # that must stay stack-allocated — a regression here would show up as a per-cell allocation.
-        Λ = PrincipalStrainRates(model)
-        test_kfo_invariants("PrincipalStrainRates.λ₁", Λ.λ₁)
-        test_kfo_invariants("PrincipalStrainRates.λ₂", Λ.λ₂)
-        test_kfo_invariants("PrincipalStrainRates.λ₃", Λ.λ₃)
     end
     #---
 

--- a/test/test_perf_invariants.jl
+++ b/test/test_perf_invariants.jl
@@ -180,6 +180,13 @@ end
         test_kfo_invariants("StrainRateTensor.S₁₂", Sij.S₁₂)
         test_kfo_invariants("StrainRateTensor.S₁₃", Sij.S₁₃)
         test_kfo_invariants("StrainRateTensor.S₂₃", Sij.S₂₃)
+
+        # The principal strain rates run an analytical eigensolver (acos/cos) and return a tuple
+        # that must stay stack-allocated — a regression here would show up as a per-cell allocation.
+        Λ = PrincipalStrainRates(model)
+        test_kfo_invariants("PrincipalStrainRates.λ₁", Λ.λ₁)
+        test_kfo_invariants("PrincipalStrainRates.λ₂", Λ.λ₂)
+        test_kfo_invariants("PrincipalStrainRates.λ₃", Λ.λ₃)
     end
     #---
 

--- a/test/test_velocity_diagnostics.jl
+++ b/test/test_velocity_diagnostics.jl
@@ -91,14 +91,6 @@ function test_velocity_only_flow_diagnostics(model)
     @test_throws ArgumentError StrainRateTensor(model; dims=())
     @test_throws ArgumentError StrainRateTensor(model; dims=1)
 
-    Λ = PrincipalStrainRates(model)
-    @test keys(Λ) == (:λ₁, :λ₂, :λ₃)
-    @test all(location(λ) == (Center, Center, Center) for λ in Λ)
-    @test Λ == PrincipalStrainRates(model.grid, model.velocities...) # field-based constructor agrees
-    for λ in Λ
-        @test all(interior(Field(λ)) .≈ 0)
-    end
-
     op = VorticityTensorModulus(model)
     @test op isa VorticityTensorModulus
     Ω = Field(op)

--- a/test/test_velocity_diagnostics.jl
+++ b/test/test_velocity_diagnostics.jl
@@ -70,6 +70,14 @@ function test_velocity_only_flow_diagnostics(model)
         @test all(interior(Field(Sᵢⱼ)) .≈ 0)
     end
 
+    Λ = PrincipalStrainRates(model)
+    @test keys(Λ) == (:λ₁, :λ₂, :λ₃)
+    @test all(location(λ) == (Center, Center, Center) for λ in Λ)
+    @test Λ == PrincipalStrainRates(model.grid, model.velocities...) # field-based constructor agrees
+    for λ in Λ
+        @test all(interior(Field(λ)) .≈ 0)
+    end
+
     op = VorticityTensorModulus(model)
     @test op isa VorticityTensorModulus
     Ω = Field(op)

--- a/test/test_velocity_diagnostics.jl
+++ b/test/test_velocity_diagnostics.jl
@@ -70,6 +70,27 @@ function test_velocity_only_flow_diagnostics(model)
         @test all(interior(Field(Sᵢⱼ)) .≈ 0)
     end
 
+    # `dims` selects sub-dimensional strain tensors: Sᵢⱼ is kept only if both i and j are in `dims`
+    @test keys(StrainRateTensor(model; dims=(1, 2, 3))) == keys(Sij)
+    @test keys(StrainRateTensor(model; dims=(1, 2))) == (:S₁₁, :S₂₂, :S₁₂)
+    @test keys(StrainRateTensor(model; dims=(1, 3))) == (:S₁₁, :S₃₃, :S₁₃)
+    @test keys(StrainRateTensor(model; dims=(2, 3))) == (:S₂₂, :S₃₃, :S₂₃)
+    @test keys(StrainRateTensor(model; dims=(1,)))   == (:S₁₁,)
+    @test keys(StrainRateTensor(model; dims=(2,)))   == (:S₂₂,)
+    @test keys(StrainRateTensor(model; dims=(3,)))   == (:S₃₃,)
+    @test keys(StrainRateTensor(model; dims=(3, 1))) == (:S₁₁, :S₃₃, :S₁₃) # order of `dims` doesn't matter
+
+    # selected components are the very same KFOs as in the full tensor, and `dims` is forwarded
+    Sxz = StrainRateTensor(model; dims=(1, 3))
+    @test (Sxz.S₁₁, Sxz.S₃₃, Sxz.S₁₃) == (Sij.S₁₁, Sij.S₃₃, Sij.S₁₃)
+    @test Sxz == StrainRateTensor(model.grid, model.velocities...; dims=(1, 3))
+
+    # invalid `dims` are rejected
+    @test_throws ArgumentError StrainRateTensor(model; dims=(1, 4))
+    @test_throws ArgumentError StrainRateTensor(model; dims=(1, 1))
+    @test_throws ArgumentError StrainRateTensor(model; dims=())
+    @test_throws ArgumentError StrainRateTensor(model; dims=1)
+
     Λ = PrincipalStrainRates(model)
     @test keys(Λ) == (:λ₁, :λ₂, :λ₃)
     @test all(location(λ) == (Center, Center, Center) for λ in Λ)

--- a/test/test_velocity_diagnostics.jl
+++ b/test/test_velocity_diagnostics.jl
@@ -2,6 +2,7 @@ using Test
 using CUDA: has_cuda_gpu, @allowscalar
 
 using Oceananigans
+using Oceananigans.Fields: location
 
 using Oceanostics
 using Oceanostics: perturbation_fields
@@ -57,6 +58,17 @@ function test_velocity_only_flow_diagnostics(model)
     @test op isa StrainRateTensorModulus
     S = Field(op)
     @test all(interior(S) .≈ 0)
+
+    Sij = StrainRateTensor(model)
+    @test keys(Sij) == (:S₁₁, :S₂₂, :S₃₃, :S₁₂, :S₁₃, :S₂₃)
+    @test location(Sij.S₁₁) == (Center, Center, Center)
+    @test location(Sij.S₁₂) == (Face, Face, Center)
+    @test location(Sij.S₁₃) == (Face, Center, Face)
+    @test location(Sij.S₂₃) == (Center, Face, Face)
+    @test Sij == StrainRateTensor(model.grid, model.velocities...) # field-based constructor agrees
+    for Sᵢⱼ in Sij
+        @test all(interior(Field(Sᵢⱼ)) .≈ 0)
+    end
 
     op = VorticityTensorModulus(model)
     @test op isa VorticityTensorModulus


### PR DESCRIPTION
Adds `StrainRateTensor`, returning the independent components of the strain rate tensor `Sᵢⱼ = ½(∂ⱼuᵢ + ∂ᵢuⱼ)` as a `NamedTuple` of KFOs at their natural staggered locations. A `dims` kwarg (default `(1, 2, 3)`) selects sub-dimensional tensors; e.g. `dims=(1, 3)` returns the 2D `x`–`z` tensor (`S₁₁`, `S₃₃`, `S₁₃`). Complements `StrainRateTensorModulus`. Tested and documented.