### PR TITLE
Add StressTensor diagnostic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
-version = "0.16.16"
+version = "0.16.17"
 authors = ["tomchor <tomaschor@gmail.com>"]
 
 [deps]

--- a/docs/src/flow_diagnostics.md
+++ b/docs/src/flow_diagnostics.md
@@ -19,6 +19,8 @@ The module includes:
 - **Velocity gradient tensor diagnostics**: the full strain rate tensor ``S_{ij}``
   and its modulus (``\|S_{ij}\|``), the vorticity tensor modulus (``\|\Omega_{ij}\|``),
   and the ``Q``-criterion for vortex identification.
+- **Stress tensor**: the (kinematic) stress tensor ``\tau_{ij} = u_i u_j``, which gives
+  the kinematic Reynolds stress when built from perturbation velocities.
 - **Mixed layer depth**: computed by scanning downward from the surface to find
   where buoyancy or density departs from the surface value by more than a
   user-specified threshold.
@@ -176,6 +178,26 @@ Used to identify vortices in fluid flow; positive values indicate vortex-dominat
 
 ```@docs
 Oceanostics.FlowDiagnostics.QVelocityGradientTensorInvariant
+```
+
+## Stress tensor
+
+The (symmetric, kinematic) stress tensor, returned as a `NamedTuple` of its independent components.
+Each component is a `KernelFunctionOperation` evaluated at its natural location on the staggered grid
+(the diagonal components at `(Center, Center, Center)`; the off-diagonals at the edge locations
+`(Face, Face, Center)`, `(Face, Center, Face)`, and `(Center, Face, Face)`). The velocities are
+interpolated to the target location before being multiplied. The `dims` keyword selects a
+sub-dimensional tensor — component ``\tau_{ij}`` is included only when both ``i`` and ``j`` are in
+`dims` — so `dims=(1, 3)` returns the 2D stress tensor in the ``x``–``z`` plane (``\tau_{11}``,
+``\tau_{33}``, ``\tau_{13}``). Building it from perturbation velocities yields the kinematic
+Reynolds stress tensor.
+
+```math
+\tau_{ij} = u_i u_j
+```
+
+```@docs
+Oceanostics.FlowDiagnostics.StressTensor
 ```
 
 ## Mixed layer depth

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -461,6 +461,54 @@ function StrainRateTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3))
     return (; (k => op for (k, op) in pairs(components) if op !== nothing)...)
 end
 
+@inline fψ_minus_gφ²(i, j, k, grid, f, ψ, g, φ) = (f(i, j, k, grid, ψ) - g(i, j, k, grid, φ))^2
+
+function vorticity_tensor_modulus_ccc(i, j, k, grid, u, v, w)
+    Ωˣʸ² = ℑxyᶜᶜᵃ(i, j, k, grid, fψ_minus_gφ², ∂yᶠᶠᶜ, u, ∂xᶠᶠᶜ, v) / 4
+    Ωˣᶻ² = ℑxzᶜᵃᶜ(i, j, k, grid, fψ_minus_gφ², ∂zᶠᶜᶠ, u, ∂xᶠᶜᶠ, w) / 4
+    Ωʸᶻ² = ℑyzᵃᶜᶜ(i, j, k, grid, fψ_minus_gφ², ∂zᶜᶠᶠ, v, ∂yᶜᶠᶠ, w) / 4
+
+    Ωʸˣ² = ℑxyᶜᶜᵃ(i, j, k, grid, fψ_minus_gφ², ∂xᶠᶠᶜ, v, ∂yᶠᶠᶜ, u) / 4
+    Ωᶻˣ² = ℑxzᶜᵃᶜ(i, j, k, grid, fψ_minus_gφ², ∂xᶠᶜᶠ, w, ∂zᶠᶜᶠ, u) / 4
+    Ωᶻʸ² = ℑyzᵃᶜᶜ(i, j, k, grid, fψ_minus_gφ², ∂yᶜᶠᶠ, w, ∂zᶜᶠᶠ, v) / 4
+
+    return √(Ωˣʸ² + Ωˣᶻ² + Ωʸᶻ² + Ωʸˣ² + Ωᶻˣ² + Ωᶻʸ²)
+end
+
+const VorticityTensorModulus = CustomKFO{<:typeof(vorticity_tensor_modulus_ccc)}
+
+"""
+    $(SIGNATURES)
+
+Calculate the modulus (absolute value) of the vorticity tensor `Ω`, which is defined as the
+antisymmetric part of the velocity gradient tensor:
+
+```
+    Ωᵢⱼ = ½(∂ⱼuᵢ - ∂ᵢuⱼ)
+```
+Its modulus is then defined (using Einstein summation notation) as
+
+```
+    || Ωᵢⱼ || = √(Ωᵢⱼ Ωᵢⱼ)
+```
+"""
+function VorticityTensorModulus(model; loc = (Center, Center, Center))
+    validate_location(loc, "VorticityTensorModulus", (Center, Center, Center))
+    return KernelFunctionOperation{Center, Center, Center}(vorticity_tensor_modulus_ccc, model.grid, model.velocities...)
+end
+
+
+# From doi:10.1063/1.5124245
+@inline function Q_velocity_gradient_tensor_invariant_ccc(i, j, k, grid, u, v, w)
+    S² = strain_rate_tensor_modulus_ccc(i, j, k, grid, u, v, w)^2
+    Ω² = vorticity_tensor_modulus_ccc(i, j, k, grid, u, v, w)^2
+    return (Ω² - S²) / 2
+end
+
+const QVelocityGradientTensorInvariant = CustomKFO{<:typeof(Q_velocity_gradient_tensor_invariant_ccc)}
+#---
+
+#+++ Stress tensor
 # Stress tensor τᵢⱼ = uᵢuⱼ components, each evaluated at its natural staggered location: the
 # velocities are interpolated to the target location and then multiplied.
 @inline stress_tensor_xx_ccc(i, j, k, grid, u)    = ℑxᶜᵃᵃ(i, j, k, grid, u)^2
@@ -524,52 +572,6 @@ function StressTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3))
 
     return (; (k => op for (k, op) in pairs(components) if op !== nothing)...)
 end
-
-@inline fψ_minus_gφ²(i, j, k, grid, f, ψ, g, φ) = (f(i, j, k, grid, ψ) - g(i, j, k, grid, φ))^2
-
-function vorticity_tensor_modulus_ccc(i, j, k, grid, u, v, w)
-    Ωˣʸ² = ℑxyᶜᶜᵃ(i, j, k, grid, fψ_minus_gφ², ∂yᶠᶠᶜ, u, ∂xᶠᶠᶜ, v) / 4
-    Ωˣᶻ² = ℑxzᶜᵃᶜ(i, j, k, grid, fψ_minus_gφ², ∂zᶠᶜᶠ, u, ∂xᶠᶜᶠ, w) / 4
-    Ωʸᶻ² = ℑyzᵃᶜᶜ(i, j, k, grid, fψ_minus_gφ², ∂zᶜᶠᶠ, v, ∂yᶜᶠᶠ, w) / 4
-
-    Ωʸˣ² = ℑxyᶜᶜᵃ(i, j, k, grid, fψ_minus_gφ², ∂xᶠᶠᶜ, v, ∂yᶠᶠᶜ, u) / 4
-    Ωᶻˣ² = ℑxzᶜᵃᶜ(i, j, k, grid, fψ_minus_gφ², ∂xᶠᶜᶠ, w, ∂zᶠᶜᶠ, u) / 4
-    Ωᶻʸ² = ℑyzᵃᶜᶜ(i, j, k, grid, fψ_minus_gφ², ∂yᶜᶠᶠ, w, ∂zᶜᶠᶠ, v) / 4
-
-    return √(Ωˣʸ² + Ωˣᶻ² + Ωʸᶻ² + Ωʸˣ² + Ωᶻˣ² + Ωᶻʸ²)
-end
-
-const VorticityTensorModulus = CustomKFO{<:typeof(vorticity_tensor_modulus_ccc)}
-
-"""
-    $(SIGNATURES)
-
-Calculate the modulus (absolute value) of the vorticity tensor `Ω`, which is defined as the
-antisymmetric part of the velocity gradient tensor:
-
-```
-    Ωᵢⱼ = ½(∂ⱼuᵢ - ∂ᵢuⱼ)
-```
-Its modulus is then defined (using Einstein summation notation) as
-
-```
-    || Ωᵢⱼ || = √(Ωᵢⱼ Ωᵢⱼ)
-```
-"""
-function VorticityTensorModulus(model; loc = (Center, Center, Center))
-    validate_location(loc, "VorticityTensorModulus", (Center, Center, Center))
-    return KernelFunctionOperation{Center, Center, Center}(vorticity_tensor_modulus_ccc, model.grid, model.velocities...)
-end
-
-
-# From doi:10.1063/1.5124245
-@inline function Q_velocity_gradient_tensor_invariant_ccc(i, j, k, grid, u, v, w)
-    S² = strain_rate_tensor_modulus_ccc(i, j, k, grid, u, v, w)^2
-    Ω² = vorticity_tensor_modulus_ccc(i, j, k, grid, u, v, w)^2
-    return (Ω² - S²) / 2
-end
-
-const QVelocityGradientTensorInvariant = CustomKFO{<:typeof(Q_velocity_gradient_tensor_invariant_ccc)}
 #---
 
 #+++ Mixed layer depth

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -361,7 +361,7 @@ function DirectionalErtelPotentialVorticity(model, direction, u, v, w, tracer, c
 end
 #---
 
-#+++ Velocity gradient and vorticity tensors
+#+++ Strain rate tensor
 @inline fψ_plus_gφ²(i, j, k, grid, f, ψ, g, φ) = (f(i, j, k, grid, ψ) + g(i, j, k, grid, φ))^2
 
 function strain_rate_tensor_modulus_ccc(i, j, k, grid, u, v, w)
@@ -460,7 +460,9 @@ function StrainRateTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3))
 
     return (; (k => op for (k, op) in pairs(components) if op !== nothing)...)
 end
+#---
 
+#+++ Vorticity tensor
 @inline fψ_minus_gφ²(i, j, k, grid, f, ψ, g, φ) = (f(i, j, k, grid, ψ) - g(i, j, k, grid, φ))^2
 
 function vorticity_tensor_modulus_ccc(i, j, k, grid, u, v, w)

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -4,6 +4,7 @@ using DocStringExtensions
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity, DirectionalErtelPotentialVorticity
 export StrainRateTensor, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
+export StressTensor
 export MixedLayerDepth, BuoyancyAnomalyCriterion, DensityAnomalyCriterion
 export BottomCellValue
 
@@ -455,6 +456,70 @@ function StrainRateTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3))
         S₁₂ = want(1, 2) ? KernelFunctionOperation{Face, Face, Center}(strain_rate_tensor_xy_ffc, grid, u, v) : nothing,
         S₁₃ = want(1, 3) ? KernelFunctionOperation{Face, Center, Face}(strain_rate_tensor_xz_fcf, grid, u, w) : nothing,
         S₂₃ = want(2, 3) ? KernelFunctionOperation{Center, Face, Face}(strain_rate_tensor_yz_cff, grid, v, w) : nothing,
+    )
+
+    return (; (k => op for (k, op) in pairs(components) if op !== nothing)...)
+end
+
+# Stress tensor τᵢⱼ = uᵢuⱼ components, each evaluated at its natural staggered location: the
+# velocities are interpolated to the target location and then multiplied.
+@inline stress_tensor_xx_ccc(i, j, k, grid, u)    = ℑxᶜᵃᵃ(i, j, k, grid, u)^2
+@inline stress_tensor_yy_ccc(i, j, k, grid, v)    = ℑyᵃᶜᵃ(i, j, k, grid, v)^2
+@inline stress_tensor_zz_ccc(i, j, k, grid, w)    = ℑzᵃᵃᶜ(i, j, k, grid, w)^2
+@inline stress_tensor_xy_ffc(i, j, k, grid, u, v) = ℑyᵃᶠᵃ(i, j, k, grid, u) * ℑxᶠᵃᵃ(i, j, k, grid, v)
+@inline stress_tensor_xz_fcf(i, j, k, grid, u, w) = ℑzᵃᵃᶠ(i, j, k, grid, u) * ℑxᶠᵃᵃ(i, j, k, grid, w)
+@inline stress_tensor_yz_cff(i, j, k, grid, v, w) = ℑzᵃᵃᶠ(i, j, k, grid, v) * ℑyᵃᶠᵃ(i, j, k, grid, w)
+
+"""
+    $(SIGNATURES)
+
+Return the components of the (kinematic) stress tensor `τ`, defined as the outer product of the
+velocity field with itself:
+
+```
+    τᵢⱼ = uᵢ uⱼ
+```
+
+The result is a `NamedTuple` with the independent components, each a `KernelFunctionOperation`
+living at its natural location on the staggered grid. The velocities are interpolated to that
+location before being multiplied:
+
+| Component | Definition | Location |
+|:---------:|:----------:|:--------:|
+| `τ₁₁`     | `u u`      | `ccc`    |
+| `τ₂₂`     | `v v`      | `ccc`    |
+| `τ₃₃`     | `w w`      | `ccc`    |
+| `τ₁₂`     | `u v`      | `ffc`    |
+| `τ₁₃`     | `u w`      | `fcf`    |
+| `τ₂₃`     | `v w`      | `cff`    |
+
+The tensor is symmetric, so the remaining components follow from `τⱼᵢ = τᵢⱼ` (i.e. `τ₂₁ = τ₁₂`,
+`τ₃₁ = τ₁₃`, `τ₃₂ = τ₂₃`).
+
+`dims` selects which spatial directions (`1 → x`, `2 → y`, `3 → z`) enter the tensor: component
+`τᵢⱼ` is included only when both `i` and `j` are in `dims`. The default `dims = (1, 2, 3)` returns
+the full tensor, while e.g. `dims = (1, 3)` returns the 2D stress tensor in the `x`–`z` plane
+(`τ₁₁`, `τ₃₃`, `τ₁₃`). Components are always ordered diagonals-first, independently of the order of
+`dims`.
+
+Each component can be wrapped in a `Field` and used with output writers, time-averaging, etc. Can
+also be called as `StressTensor(grid, u, v, w; dims)` to build the components from individual
+velocity fields. Building the tensor from perturbation velocities (e.g. via `perturbation_fields`)
+yields the kinematic Reynolds stress tensor.
+"""
+StressTensor(model; dims = (1, 2, 3)) = StressTensor(model.grid, model.velocities...; dims)
+
+function StressTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3))
+    validate_dims(dims)
+    want(ij...) = all(in(dims), ij) # keep component τᵢⱼ only if every index it needs is in `dims`
+
+    components = (
+        τ₁₁ = want(1)    ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_xx_ccc, grid, u) : nothing,
+        τ₂₂ = want(2)    ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_yy_ccc, grid, v) : nothing,
+        τ₃₃ = want(3)    ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_zz_ccc, grid, w) : nothing,
+        τ₁₂ = want(1, 2) ? KernelFunctionOperation{Face, Face, Center}(stress_tensor_xy_ffc, grid, u, v) : nothing,
+        τ₁₃ = want(1, 3) ? KernelFunctionOperation{Face, Center, Face}(stress_tensor_xz_fcf, grid, u, w) : nothing,
+        τ₂₃ = want(2, 3) ? KernelFunctionOperation{Center, Face, Face}(stress_tensor_yz_cff, grid, v, w) : nothing,
     )
 
     return (; (k => op for (k, op) in pairs(components) if op !== nothing)...)

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -54,6 +54,7 @@ export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity
 export DirectionalErtelPotentialVorticity
 export StrainRateTensor, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
+export StressTensor
 export MixedLayerDepth, BuoyancyAnomalyCriterion, DensityAnomalyCriterion
 export BottomCellValue
 #---

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -53,7 +53,9 @@ export TurbulentKineticEnergy,
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity
 export DirectionalErtelPotentialVorticity
-export StrainRateTensor, StrainRateTensorModulus, VorticityTensor, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
+export StrainRateTensor, StrainRateTensorModulus
+export VorticityTensor, VorticityTensorModulus
+export Q, QVelocityGradientTensorInvariant
 export StressTensor
 export MixedLayerDepth, BuoyancyAnomalyCriterion, DensityAnomalyCriterion
 export BottomCellValue

--- a/test/test_canonical_flows.jl
+++ b/test/test_canonical_flows.jl
@@ -172,6 +172,42 @@ function test_uniform_shear_flow(grid; model_type=NonhydrostaticModel, closure=S
         @test getindex(ε, idxs...) ≈ 2 * ν * getindex(S, idxs...)^2
     end
 end
+
+"""
+Test that StressTensor (τᵢⱼ = uᵢuⱼ) has the right values for a uniform (constant-velocity) flow,
+for which τᵢⱼ = uᵢuⱼ is itself spatially uniform.
+"""
+function test_uniform_flow(grid; model_type=NonhydrostaticModel, closure=ScalarDiffusivity(ν=1), U=2, V=-3)
+    model = model_type(grid; closure)
+    if model isa NonhydrostaticModel
+        set!(model, u=U, v=V, w=0, enforce_incompressibility=false)
+    else
+        set!(model, u=U, v=V)
+    end
+
+    τij = StressTensor(model)
+    τ₁₁ = Field(τij.τ₁₁); τ₂₂ = Field(τij.τ₂₂); τ₃₃ = Field(τij.τ₃₃)
+    τ₁₂ = Field(τij.τ₁₂); τ₁₃ = Field(τij.τ₁₃); τ₂₃ = Field(τij.τ₂₃)
+
+    idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
+
+    @allowscalar begin
+        # τᵢⱼ = uᵢuⱼ for the constant flow uⱼ = (U, V, 0)
+        @test getindex(τ₁₁, idxs...) ≈ U^2
+        @test getindex(τ₂₂, idxs...) ≈ V^2
+        @test ≈(getindex(τ₃₃, idxs...), 0, atol=10eps())
+        @test getindex(τ₁₂, idxs...) ≈ U*V
+        @test ≈(getindex(τ₁₃, idxs...), 0, atol=10eps())
+        @test ≈(getindex(τ₂₃, idxs...), 0, atol=10eps())
+
+        # The full contraction τᵢⱼτᵢⱼ = (uₖuₖ)² recovers |u|⁴
+        τᵢⱼτᵢⱼ = getindex(τ₁₁, idxs...)^2 + getindex(τ₂₂, idxs...)^2 + getindex(τ₃₃, idxs...)^2 +
+                 2 * (getindex(τ₁₂, idxs...)^2 + getindex(τ₁₃, idxs...)^2 + getindex(τ₂₃, idxs...)^2)
+        @test τᵢⱼτᵢⱼ ≈ (U^2 + V^2)^2
+    end
+
+    return nothing
+end
 #---
 
 @testset "Known flows" begin
@@ -190,6 +226,9 @@ end
 
                 @info "          Testing uniform shear flow"
                 test_uniform_shear_flow(grid; model_type, closure, σ=3)
+
+                @info "          Testing uniform flow stress tensor"
+                test_uniform_flow(grid; model_type, closure, U=2, V=-3)
             end
         end
     end

--- a/test/test_perf_invariants.jl
+++ b/test/test_perf_invariants.jl
@@ -180,6 +180,15 @@ end
         test_kfo_invariants("StrainRateTensor.S₁₂", Sij.S₁₂)
         test_kfo_invariants("StrainRateTensor.S₁₃", Sij.S₁₃)
         test_kfo_invariants("StrainRateTensor.S₂₃", Sij.S₂₃)
+
+        # Stress-tensor components interpolate the velocities to a common location before
+        # multiplying; the off-diagonals live at the edge locations (ffc/fcf/cff), the diagonals
+        # at ccc.
+        τij = StressTensor(model)
+        test_kfo_invariants("StressTensor.τ₁₁", τij.τ₁₁)
+        test_kfo_invariants("StressTensor.τ₁₂", τij.τ₁₂)
+        test_kfo_invariants("StressTensor.τ₁₃", τij.τ₁₃)
+        test_kfo_invariants("StressTensor.τ₂₃", τij.τ₂₃)
     end
     #---
 

--- a/test/test_velocity_diagnostics.jl
+++ b/test/test_velocity_diagnostics.jl
@@ -91,6 +91,40 @@ function test_velocity_only_flow_diagnostics(model)
     @test_throws ArgumentError StrainRateTensor(model; dims=())
     @test_throws ArgumentError StrainRateTensor(model; dims=1)
 
+    τij = StressTensor(model)
+    @test keys(τij) == (:τ₁₁, :τ₂₂, :τ₃₃, :τ₁₂, :τ₁₃, :τ₂₃)
+    @test location(τij.τ₁₁) == (Center, Center, Center)
+    @test location(τij.τ₂₂) == (Center, Center, Center)
+    @test location(τij.τ₃₃) == (Center, Center, Center)
+    @test location(τij.τ₁₂) == (Face, Face, Center)
+    @test location(τij.τ₁₃) == (Face, Center, Face)
+    @test location(τij.τ₂₃) == (Center, Face, Face)
+    @test τij == StressTensor(model.grid, model.velocities...) # field-based constructor agrees
+    for τᵢⱼ in τij
+        @test Field(τᵢⱼ) isa Field # every component is computable
+    end
+
+    # `dims` selects sub-dimensional stress tensors: τᵢⱼ is kept only if both i and j are in `dims`
+    @test keys(StressTensor(model; dims=(1, 2, 3))) == keys(τij)
+    @test keys(StressTensor(model; dims=(1, 2))) == (:τ₁₁, :τ₂₂, :τ₁₂)
+    @test keys(StressTensor(model; dims=(1, 3))) == (:τ₁₁, :τ₃₃, :τ₁₃)
+    @test keys(StressTensor(model; dims=(2, 3))) == (:τ₂₂, :τ₃₃, :τ₂₃)
+    @test keys(StressTensor(model; dims=(1,)))   == (:τ₁₁,)
+    @test keys(StressTensor(model; dims=(2,)))   == (:τ₂₂,)
+    @test keys(StressTensor(model; dims=(3,)))   == (:τ₃₃,)
+    @test keys(StressTensor(model; dims=(3, 1))) == (:τ₁₁, :τ₃₃, :τ₁₃) # order of `dims` doesn't matter
+
+    # selected components are the very same KFOs as in the full tensor, and `dims` is forwarded
+    τxz = StressTensor(model; dims=(1, 3))
+    @test (τxz.τ₁₁, τxz.τ₃₃, τxz.τ₁₃) == (τij.τ₁₁, τij.τ₃₃, τij.τ₁₃)
+    @test τxz == StressTensor(model.grid, model.velocities...; dims=(1, 3))
+
+    # invalid `dims` are rejected
+    @test_throws ArgumentError StressTensor(model; dims=(1, 4))
+    @test_throws ArgumentError StressTensor(model; dims=(1, 1))
+    @test_throws ArgumentError StressTensor(model; dims=())
+    @test_throws ArgumentError StressTensor(model; dims=1)
+
     op = VorticityTensorModulus(model)
     @test op isa VorticityTensorModulus
     Ω = Field(op)


### PR DESCRIPTION
## Summary

Adds a `StressTensor` diagnostic returning the components of the kinematic stress tensor

$$\tau_{ij} = u_i u_j$$

as a `NamedTuple` of `KernelFunctionOperation`s, mirroring the recently-added [`StrainRateTensor`](https://github.com/tomchor/Oceanostics.jl/pull/244).

### Behavior

- Each component lives at its natural location on the staggered grid: the diagonals `τ₁₁`, `τ₂₂`, `τ₃₃` at `(Center, Center, Center)`; the off-diagonals `τ₁₂`, `τ₁₃`, `τ₂₃` at the edge locations `ffc`, `fcf`, `cff`. The velocities are interpolated to each component's location before being multiplied.
- The tensor is symmetric (`τⱼᵢ = τᵢⱼ`), so only the 6 independent components are returned.
- The `dims` keyword selects sub-dimensional tensors — component `τᵢⱼ` is kept only when both `i` and `j` are in `dims` (e.g. `dims=(1, 3)` returns the `x`–`z` tensor `τ₁₁`, `τ₃₃`, `τ₁₃`), reusing the same `validate_dims` helper as `StrainRateTensor`.
- A field-based constructor `StressTensor(grid, u, v, w; dims)` is provided; building it from perturbation velocities yields the kinematic Reynolds stress tensor.

### Tests & docs

- **Structural tests** (`test/test_velocity_diagnostics.jl`): component keys, grid locations, `dims` selection, `dims` forwarding, field-based-constructor agreement, and rejection of invalid `dims`.
- **Value test** (`test/test_canonical_flows.jl`): a uniform (constant-velocity) flow `u = (U, V, 0)`, for which `τᵢⱼ = uᵢuⱼ` is spatially uniform, including the contraction identity `τᵢⱼτᵢⱼ = (uₖuₖ)²`.
- **Perf invariants** (`test/test_perf_invariants.jl`): zero-allocation, type-stable per-cell evaluation on a diagonal and the three off-diagonal components.
- **Docs** (`docs/src/flow_diagnostics.md`): a new "Stress tensor" section plus an intro-list entry.

### Test plan

- [x] `TEST_GROUP=vel_diagnostics` — 276/276 pass
- [x] `TEST_GROUP=canonical_flows` — 540/540 pass
- [x] `TEST_GROUP=perf_invariants` — 62/62 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)