### PR TITLE
Add VorticityTensor diagnostic

### DIFF
--- a/docs/src/flow_diagnostics.md
+++ b/docs/src/flow_diagnostics.md
@@ -17,8 +17,8 @@ The module includes:
   fundamental for understanding large-scale ocean dynamics. A thermal-wind-balance
   approximation and a directional decomposition are also provided.
 - **Velocity gradient tensor diagnostics**: the full strain rate tensor ``S_{ij}``
-  and its modulus (``\|S_{ij}\|``), the vorticity tensor modulus (``\|\Omega_{ij}\|``),
-  and the ``Q``-criterion for vortex identification.
+  and its modulus (``\|S_{ij}\|``), the full vorticity tensor ``\Omega_{ij}`` and its
+  modulus (``\|\Omega_{ij}\|``), and the ``Q``-criterion for vortex identification.
 - **Mixed layer depth**: computed by scanning downward from the surface to find
   where buoyancy or density departs from the surface value by more than a
   user-specified threshold.
@@ -154,6 +154,24 @@ Oceanostics.FlowDiagnostics.StrainRateTensor
 
 ```@docs
 Oceanostics.FlowDiagnostics.StrainRateTensorModulus
+```
+
+### Vorticity tensor
+
+The (antisymmetric) vorticity tensor, returned as a `NamedTuple` of its independent off-diagonal
+components. Each component is a `KernelFunctionOperation` evaluated at its natural location on the
+staggered grid — the edge locations `(Face, Face, Center)`, `(Face, Center, Face)`, and
+`(Center, Face, Face)`. The diagonal vanishes (``\Omega_{ii} = 0``) and the lower triangle follows
+from antisymmetry (``\Omega_{ji} = -\Omega_{ij}``). The `dims` keyword selects a sub-dimensional
+tensor — component ``\Omega_{ij}`` is included only when both ``i`` and ``j`` are in `dims` — so
+`dims=(1, 3)` returns just the ``x``–``z`` component ``\Omega_{13}``.
+
+```math
+\Omega_{ij} = \tfrac{1}{2}(\partial_j u_i - \partial_i u_j)
+```
+
+```@docs
+Oceanostics.FlowDiagnostics.VorticityTensor
 ```
 
 ### Vorticity tensor modulus

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -3,7 +3,7 @@ using DocStringExtensions
 
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity, DirectionalErtelPotentialVorticity
-export StrainRateTensor, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
+export StrainRateTensor, StrainRateTensorModulus, VorticityTensor, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
 export MixedLayerDepth, BuoyancyAnomalyCriterion, DensityAnomalyCriterion
 export BottomCellValue
 
@@ -496,6 +496,60 @@ function VorticityTensorModulus(model; loc = (Center, Center, Center))
     return KernelFunctionOperation{Center, Center, Center}(vorticity_tensor_modulus_ccc, model.grid, model.velocities...)
 end
 
+# Off-diagonal vorticity components, each evaluated at its natural staggered location. The diagonal
+# components vanish identically (Ωᵢᵢ = 0), so they are not built.
+@inline vorticity_tensor_xy_ffc(i, j, k, grid, u, v) = (∂yᶠᶠᶜ(i, j, k, grid, u) - ∂xᶠᶠᶜ(i, j, k, grid, v)) / 2
+@inline vorticity_tensor_xz_fcf(i, j, k, grid, u, w) = (∂zᶠᶜᶠ(i, j, k, grid, u) - ∂xᶠᶜᶠ(i, j, k, grid, w)) / 2
+@inline vorticity_tensor_yz_cff(i, j, k, grid, v, w) = (∂zᶜᶠᶠ(i, j, k, grid, v) - ∂yᶜᶠᶠ(i, j, k, grid, w)) / 2
+
+"""
+    $(SIGNATURES)
+
+Return the components of the vorticity tensor `Ω`, defined as the antisymmetric part of the velocity
+gradient tensor:
+
+```
+    Ωᵢⱼ = ½(∂ⱼuᵢ - ∂ᵢuⱼ)
+```
+
+The tensor is antisymmetric, so its diagonal vanishes (`Ω₁₁ = Ω₂₂ = Ω₃₃ = 0`) and only the
+independent off-diagonal components are returned, as a `NamedTuple` of `KernelFunctionOperation`s,
+each living at its natural location on the staggered grid:
+
+| Component | Definition         | Location |
+|:---------:|:------------------:|:--------:|
+| `Ω₁₂`     | `½(∂u/∂y - ∂v/∂x)` | `ffc`    |
+| `Ω₁₃`     | `½(∂u/∂z - ∂w/∂x)` | `fcf`    |
+| `Ω₂₃`     | `½(∂v/∂z - ∂w/∂y)` | `cff`    |
+
+The remaining off-diagonal components follow from antisymmetry, `Ωⱼᵢ = -Ωᵢⱼ` (i.e. `Ω₂₁ = -Ω₁₂`,
+`Ω₃₁ = -Ω₁₃`, `Ω₃₂ = -Ω₂₃`).
+
+`dims` selects which spatial directions (`1 → x`, `2 → y`, `3 → z`) enter the tensor: component
+`Ωᵢⱼ` is included only when both `i` and `j` are in `dims`. The default `dims = (1, 2, 3)` returns
+all three off-diagonal components, while e.g. `dims = (1, 3)` returns the single component in the
+`x`–`z` plane (`Ω₁₃`). Because every component couples two distinct directions, a single-direction
+`dims` (e.g. `dims = (1,)`) yields an empty tensor. Components are always ordered `Ω₁₂`, `Ω₁₃`,
+`Ω₂₃`, independently of the order of `dims`.
+
+Each component can be wrapped in a `Field` and used with output writers, time-averaging, etc. Can
+also be called as `VorticityTensor(grid, u, v, w; dims)` to build the components from individual
+velocity fields. See also [`VorticityTensorModulus`](@ref) for the scalar modulus `√(ΩᵢⱼΩᵢⱼ)`.
+"""
+VorticityTensor(model; dims = (1, 2, 3)) = VorticityTensor(model.grid, model.velocities...; dims)
+
+function VorticityTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3))
+    validate_dims(dims)
+    want(ij...) = all(in(dims), ij) # keep component Ωᵢⱼ only if every index it needs is in `dims`
+
+    components = (
+        Ω₁₂ = want(1, 2) ? KernelFunctionOperation{Face, Face, Center}(vorticity_tensor_xy_ffc, grid, u, v) : nothing,
+        Ω₁₃ = want(1, 3) ? KernelFunctionOperation{Face, Center, Face}(vorticity_tensor_xz_fcf, grid, u, w) : nothing,
+        Ω₂₃ = want(2, 3) ? KernelFunctionOperation{Center, Face, Face}(vorticity_tensor_yz_cff, grid, v, w) : nothing,
+    )
+
+    return (; (k => op for (k, op) in pairs(components) if op !== nothing)...)
+end
 
 # From doi:10.1063/1.5124245
 @inline function Q_velocity_gradient_tensor_invariant_ccc(i, j, k, grid, u, v, w)

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -53,7 +53,7 @@ export TurbulentKineticEnergy,
 export RichardsonNumber, RossbyNumber
 export ErtelPotentialVorticity, ThermalWindPotentialVorticity
 export DirectionalErtelPotentialVorticity
-export StrainRateTensor, StrainRateTensorModulus, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
+export StrainRateTensor, StrainRateTensorModulus, VorticityTensor, VorticityTensorModulus, Q, QVelocityGradientTensorInvariant
 export MixedLayerDepth, BuoyancyAnomalyCriterion, DensityAnomalyCriterion
 export BottomCellValue
 #---

--- a/test/test_canonical_flows.jl
+++ b/test/test_canonical_flows.jl
@@ -116,6 +116,9 @@ function test_solid_body_rotation_flow(grid; model_type=NonhydrostaticModel, clo
     Ω = Field(VorticityTensorModulus(model))
     q = Field(QVelocityGradientTensorInvariant(model))
 
+    Ωij = VorticityTensor(model)
+    Ω₁₂ = Field(Ωij.Ω₁₂); Ω₁₃ = Field(Ωij.Ω₁₃); Ω₂₃ = Field(Ωij.Ω₂₃)
+
     idxs = (model.grid.Nx÷2, model.grid.Ny÷2, model.grid.Nz÷2) # Get a value far from boundaries
 
     if model.closure isa Tuple
@@ -131,6 +134,15 @@ function test_solid_body_rotation_flow(grid; model_type=NonhydrostaticModel, clo
         @test getindex(Ω, idxs...) ≈ ζ/√2
         @test getindex(q, idxs...) ≈ (getindex(Ω, idxs...)^2 - getindex(S, idxs...)^2)/2 ≈ ζ^2/4
         @test getindex(ε, idxs...) ≈ 0
+
+        # Vorticity tensor for uⱼ = (ζy/2, -ζx/2, 0) has only Ω₁₂ = ½(∂u/∂y - ∂v/∂x) = ζ/2 nonzero
+        @test getindex(Ω₁₂, idxs...) ≈ +ζ/2
+        @test ≈(getindex(Ω₁₃, idxs...), 0, atol=10eps())
+        @test ≈(getindex(Ω₂₃, idxs...), 0, atol=10eps())
+
+        # The modulus is recovered from the components: ‖Ω‖ = √(Ωᵢⱼ Ωᵢⱼ) = √(2(Ω₁₂² + Ω₁₃² + Ω₂₃²))
+        ΩᵢⱼΩᵢⱼ = 2 * (getindex(Ω₁₂, idxs...)^2 + getindex(Ω₁₃, idxs...)^2 + getindex(Ω₂₃, idxs...)^2)
+        @test √(ΩᵢⱼΩᵢⱼ) ≈ getindex(Ω, idxs...)
     end
 end
 """

--- a/test/test_perf_invariants.jl
+++ b/test/test_perf_invariants.jl
@@ -180,6 +180,13 @@ end
         test_kfo_invariants("StrainRateTensor.S₁₂", Sij.S₁₂)
         test_kfo_invariants("StrainRateTensor.S₁₃", Sij.S₁₃)
         test_kfo_invariants("StrainRateTensor.S₂₃", Sij.S₂₃)
+
+        # The vorticity tensor is antisymmetric, so all its components are off-diagonal edge kernels
+        # (ffc/fcf/cff); there are no diagonal components to check.
+        Ωij = VorticityTensor(model)
+        test_kfo_invariants("VorticityTensor.Ω₁₂", Ωij.Ω₁₂)
+        test_kfo_invariants("VorticityTensor.Ω₁₃", Ωij.Ω₁₃)
+        test_kfo_invariants("VorticityTensor.Ω₂₃", Ωij.Ω₂₃)
     end
     #---
 

--- a/test/test_velocity_diagnostics.jl
+++ b/test/test_velocity_diagnostics.jl
@@ -96,6 +96,38 @@ function test_velocity_only_flow_diagnostics(model)
     Ω = Field(op)
     @test all(interior(Ω) .≈ 0)
 
+    Ωij = VorticityTensor(model)
+    @test keys(Ωij) == (:Ω₁₂, :Ω₁₃, :Ω₂₃) # antisymmetric tensor: only off-diagonals, no diagonals
+    @test location(Ωij.Ω₁₂) == (Face, Face, Center)
+    @test location(Ωij.Ω₁₃) == (Face, Center, Face)
+    @test location(Ωij.Ω₂₃) == (Center, Face, Face)
+    @test Ωij == VorticityTensor(model.grid, model.velocities...) # field-based constructor agrees
+    for Ωᵢⱼ in Ωij
+        @test all(interior(Field(Ωᵢⱼ)) .≈ 0)
+    end
+
+    # `dims` selects sub-dimensional vorticity tensors: Ωᵢⱼ is kept only if both i and j are in `dims`
+    @test keys(VorticityTensor(model; dims=(1, 2, 3))) == keys(Ωij)
+    @test keys(VorticityTensor(model; dims=(1, 2))) == (:Ω₁₂,)
+    @test keys(VorticityTensor(model; dims=(1, 3))) == (:Ω₁₃,)
+    @test keys(VorticityTensor(model; dims=(2, 3))) == (:Ω₂₃,)
+    @test keys(VorticityTensor(model; dims=(3, 1))) == (:Ω₁₃,) # order of `dims` doesn't matter
+    # every component couples two distinct directions, so a single-direction `dims` is empty
+    @test keys(VorticityTensor(model; dims=(1,))) == ()
+    @test keys(VorticityTensor(model; dims=(2,))) == ()
+    @test keys(VorticityTensor(model; dims=(3,))) == ()
+
+    # selected components are the very same KFOs as in the full tensor, and `dims` is forwarded
+    Ωxz = VorticityTensor(model; dims=(1, 3))
+    @test Ωxz.Ω₁₃ == Ωij.Ω₁₃
+    @test Ωxz == VorticityTensor(model.grid, model.velocities...; dims=(1, 3))
+
+    # invalid `dims` are rejected
+    @test_throws ArgumentError VorticityTensor(model; dims=(1, 4))
+    @test_throws ArgumentError VorticityTensor(model; dims=(1, 1))
+    @test_throws ArgumentError VorticityTensor(model; dims=())
+    @test_throws ArgumentError VorticityTensor(model; dims=1)
+
     op = QVelocityGradientTensorInvariant(model)
     @allowscalar @test op == Oceanostics.Q(model)
     @test op isa QVelocityGradientTensorInvariant


### PR DESCRIPTION
Adds `VorticityTensor`, the antisymmetric counterpart to `StrainRateTensor` (#244). It returns the independent off-diagonal components of the vorticity tensor

```
Ωᵢⱼ = ½(∂ⱼuᵢ - ∂ᵢuⱼ)
```

as a `NamedTuple` of `KernelFunctionOperation`s, each at its natural staggered location:

| Component | Definition         | Location |
|:---------:|:------------------:|:--------:|
| `Ω₁₂`     | `½(∂u/∂y - ∂v/∂x)` | `ffc`    |
| `Ω₁₃`     | `½(∂u/∂z - ∂w/∂x)` | `fcf`    |
| `Ω₂₃`     | `½(∂v/∂z - ∂w/∂y)` | `cff`    |

The tensor is antisymmetric, so its diagonal vanishes (`Ω₁₁ = Ω₂₂ = Ω₃₃ = 0`) and the lower triangle follows from `Ωⱼᵢ = -Ωᵢⱼ`; only the three off-diagonal components are built.

A `dims` kwarg (default `(1, 2, 3)`) selects sub-dimensional tensors — component `Ωᵢⱼ` is kept only when both `i` and `j` are in `dims`. Since every component couples two distinct directions, `dims=(1, 3)` returns just `Ω₁₃`, and a single-direction `dims` (e.g. `dims=(1,)`) yields an empty tensor. The field-based constructor `VorticityTensor(grid, u, v, w; dims)` is also available. Reuses the `validate_dims` helper introduced in #244. Complements `VorticityTensorModulus`.

## Tests
Mirrors the `StrainRateTensor` coverage:
- **`vel_diagnostics`** — keys, component locations, model-vs-field constructor agreement, `dims` selection (including the empty single-direction case), KFO sharing, and rejection of invalid `dims`.
- **`canonical_flows`** — solid-body rotation `uⱼ = (ζy/2, -ζx/2, 0)`: checks `Ω₁₂ = ζ/2`, `Ω₁₃ = Ω₂₃ = 0`, and that the modulus is recovered as `√(ΩᵢⱼΩᵢⱼ) = √(2(Ω₁₂² + Ω₁₃² + Ω₂₃²))`.
- **`perf_invariants`** — zero-allocation / type-stable per-cell evaluation of the three off-diagonal edge kernels.

All three groups pass locally (252, 480, 60 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)