### PR TITLE
(0.17.0) Add collocate_diagonals option to StressTensor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
-version = "0.16.17"
+version = "0.17.0"
 authors = ["tomchor <tomaschor@gmail.com>"]
 
 [deps]

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -565,11 +565,8 @@ const QVelocityGradientTensorInvariant = CustomKFO{<:typeof(Q_velocity_gradient_
 #---
 
 #+++ Stress tensor
-# Stress tensor τᵢⱼ = uᵢuⱼ components. Off-diagonals live at their natural edge location (ffc/fcf/cff):
-# the two velocities are interpolated there and then multiplied. The diagonals come in two flavors,
-# selected by the `collocate_diagonals` keyword of `StressTensor`:
-#   • interpolation-free (default): τᵢᵢ = uᵢ² read at uᵢ's own location (fcc/cfc/ccf), no interpolation
-#   • collocated: τᵢᵢ = (ℑ uᵢ)² interpolated to ccc, so all three diagonals share one location
+# Stress tensor τᵢⱼ = uᵢuⱼ kernels. Diagonals come in two flavors (see `collocate_diagonals` in
+# `StressTensor`): collocated `_ccc` = (ℑ uᵢ)² at ccc, or interpolation-free at uᵢ's own location.
 @inline stress_tensor_xx_ccc(i, j, k, grid, u)    = ℑxᶜᵃᵃ(i, j, k, grid, u)^2
 @inline stress_tensor_yy_ccc(i, j, k, grid, v)    = ℑyᵃᶜᵃ(i, j, k, grid, v)^2
 @inline stress_tensor_zz_ccc(i, j, k, grid, w)    = ℑzᵃᵃᶜ(i, j, k, grid, w)^2

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -565,11 +565,17 @@ const QVelocityGradientTensorInvariant = CustomKFO{<:typeof(Q_velocity_gradient_
 #---
 
 #+++ Stress tensor
-# Stress tensor τᵢⱼ = uᵢuⱼ components, each evaluated at its natural staggered location: the
-# velocities are interpolated to the target location and then multiplied.
+# Stress tensor τᵢⱼ = uᵢuⱼ components. Off-diagonals live at their natural edge location (ffc/fcf/cff):
+# the two velocities are interpolated there and then multiplied. The diagonals come in two flavors,
+# selected by the `collocate_diagonals` keyword of `StressTensor`:
+#   • interpolation-free (default): τᵢᵢ = uᵢ² read at uᵢ's own location (fcc/cfc/ccf), no interpolation
+#   • collocated: τᵢᵢ = (ℑ uᵢ)² interpolated to ccc, so all three diagonals share one location
 @inline stress_tensor_xx_ccc(i, j, k, grid, u)    = ℑxᶜᵃᵃ(i, j, k, grid, u)^2
 @inline stress_tensor_yy_ccc(i, j, k, grid, v)    = ℑyᵃᶜᵃ(i, j, k, grid, v)^2
 @inline stress_tensor_zz_ccc(i, j, k, grid, w)    = ℑzᵃᵃᶜ(i, j, k, grid, w)^2
+@inline stress_tensor_xx_fcc(i, j, k, grid, u)    = @inbounds u[i, j, k]^2
+@inline stress_tensor_yy_cfc(i, j, k, grid, v)    = @inbounds v[i, j, k]^2
+@inline stress_tensor_zz_ccf(i, j, k, grid, w)    = @inbounds w[i, j, k]^2
 @inline stress_tensor_xy_ffc(i, j, k, grid, u, v) = ℑyᵃᶠᵃ(i, j, k, grid, u) * ℑxᶠᵃᵃ(i, j, k, grid, v)
 @inline stress_tensor_xz_fcf(i, j, k, grid, u, w) = ℑzᵃᵃᶠ(i, j, k, grid, u) * ℑxᶠᵃᵃ(i, j, k, grid, w)
 @inline stress_tensor_yz_cff(i, j, k, grid, v, w) = ℑzᵃᵃᶠ(i, j, k, grid, v) * ℑyᵃᶠᵃ(i, j, k, grid, w)
@@ -584,18 +590,50 @@ velocity field with itself:
     τᵢⱼ = uᵢ uⱼ
 ```
 
-The result is a `NamedTuple` with the independent components, each a `KernelFunctionOperation`
-living at its natural location on the staggered grid. The velocities are interpolated to that
-location before being multiplied:
+The result is a `NamedTuple` of the independent components, each a `KernelFunctionOperation` living
+at a location on the staggered grid.
+
+The **off-diagonal** components are always evaluated at their natural edge location. Because each
+couples two *different*, mutually-staggered velocities, the two factors must be interpolated to a
+common point before multiplying — this is unavoidable, and the edge locations below are the
+interpolation-minimal choice (one interpolation per factor):
 
 | Component | Definition | Location |
 |:---------:|:----------:|:--------:|
-| `τ₁₁`     | `u u`      | `ccc`    |
-| `τ₂₂`     | `v v`      | `ccc`    |
-| `τ₃₃`     | `w w`      | `ccc`    |
 | `τ₁₂`     | `u v`      | `ffc`    |
 | `τ₁₃`     | `u w`      | `fcf`    |
 | `τ₂₃`     | `v w`      | `cff`    |
+
+The **`collocate_diagonals`** keyword controls *only* where the diagonal components `τ₁₁, τ₂₂, τ₃₃`
+live. It trades interpolation against collocation, and **defaults to `false`** (minimal
+interpolation):
+
+- `collocate_diagonals = false` (**default**): each diagonal is computed as `τᵢᵢ = uᵢ²` read
+  *directly at `uᵢ`'s own location*, performing **no interpolation at all**. This is the cheapest
+  and most accurate option. The trade-off is that the three diagonals end up at three *different*
+  locations, so they are not collocated with each other or with the off-diagonals:
+
+  | Component | Definition | Location |
+  |:---------:|:----------:|:--------:|
+  | `τ₁₁`     | `u u`      | `fcc`    |
+  | `τ₂₂`     | `v v`      | `cfc`    |
+  | `τ₃₃`     | `w w`      | `ccf`    |
+
+- `collocate_diagonals = true`: each velocity is first interpolated to `ccc` and *then* squared,
+  `τᵢᵢ = (ℑ uᵢ)²`, so all three diagonals share the single location `ccc`. Choose this when you need
+  the diagonals collocated — e.g. to form the trace `τ₁₁ + τ₂₂ + τ₃₃` (twice the kinetic energy) or
+  to treat `τ` as a single collocated tensor. The cost is one interpolation per diagonal:
+
+  | Component | Definition | Location |
+  |:---------:|:----------:|:--------:|
+  | `τ₁₁`     | `u u`      | `ccc`    |
+  | `τ₂₂`     | `v v`      | `ccc`    |
+  | `τ₃₃`     | `w w`      | `ccc`    |
+
+!!! warning "The two diagonal modes return different numbers"
+    Interpolation and squaring do not commute, `(ℑ uᵢ)² ≠ ℑ(uᵢ²)`. The diagonals obtained with
+    `collocate_diagonals = true` are therefore *not* the `false` values resampled at another point —
+    they differ by an interpolation error. Pick the mode deliberately.
 
 The tensor is symmetric, so the remaining components follow from `τⱼᵢ = τᵢⱼ` (i.e. `τ₂₁ = τ₁₂`,
 `τ₃₁ = τ₁₃`, `τ₃₂ = τ₂₃`).
@@ -607,20 +645,29 @@ the full tensor, while e.g. `dims = (1, 3)` returns the 2D stress tensor in the 
 `dims`.
 
 Each component can be wrapped in a `Field` and used with output writers, time-averaging, etc. Can
-also be called as `StressTensor(grid, u, v, w; dims)` to build the components from individual
-velocity fields. Building the tensor from perturbation velocities (e.g. via `perturbation_fields`)
-yields the kinematic Reynolds stress tensor.
+also be called as `StressTensor(grid, u, v, w; dims, collocate_diagonals)` to build the components
+from individual velocity fields. Building the tensor from perturbation velocities (e.g. via
+`perturbation_fields`) yields the kinematic Reynolds stress tensor.
 """
-StressTensor(model; dims = (1, 2, 3)) = StressTensor(model.grid, model.velocities...; dims)
+StressTensor(model; dims = (1, 2, 3), collocate_diagonals = false) =
+    StressTensor(model.grid, model.velocities...; dims, collocate_diagonals)
 
-function StressTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3))
+function StressTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3), collocate_diagonals = false)
     validate_dims(dims)
     want(ij...) = all(in(dims), ij) # keep component τᵢⱼ only if every index it needs is in `dims`
 
-    components = (
-        τ₁₁ = want(1)    ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_xx_ccc, grid, u) : nothing,
-        τ₂₂ = want(2)    ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_yy_ccc, grid, v) : nothing,
-        τ₃₃ = want(3)    ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_zz_ccc, grid, w) : nothing,
+    if collocate_diagonals # τᵢᵢ = (ℑ uᵢ)² interpolated to a shared ccc location (one interpolation each)
+        τ₁₁ = want(1) ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_xx_ccc, grid, u) : nothing
+        τ₂₂ = want(2) ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_yy_ccc, grid, v) : nothing
+        τ₃₃ = want(3) ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_zz_ccc, grid, w) : nothing
+    else # τᵢᵢ = uᵢ² read at each velocity's own location (no interpolation)
+        τ₁₁ = want(1) ? KernelFunctionOperation{Face, Center, Center}(stress_tensor_xx_fcc, grid, u) : nothing
+        τ₂₂ = want(2) ? KernelFunctionOperation{Center, Face, Center}(stress_tensor_yy_cfc, grid, v) : nothing
+        τ₃₃ = want(3) ? KernelFunctionOperation{Center, Center, Face}(stress_tensor_zz_ccf, grid, w) : nothing
+    end
+
+    components = (;
+        τ₁₁, τ₂₂, τ₃₃,
         τ₁₂ = want(1, 2) ? KernelFunctionOperation{Face, Face, Center}(stress_tensor_xy_ffc, grid, u, v) : nothing,
         τ₁₃ = want(1, 3) ? KernelFunctionOperation{Face, Center, Face}(stress_tensor_xz_fcf, grid, u, w) : nothing,
         τ₂₃ = want(2, 3) ? KernelFunctionOperation{Center, Face, Face}(stress_tensor_yz_cff, grid, v, w) : nothing,

--- a/test/test_perf_invariants.jl
+++ b/test/test_perf_invariants.jl
@@ -188,14 +188,19 @@ end
         test_kfo_invariants("VorticityTensor.Ω₁₃", Ωij.Ω₁₃)
         test_kfo_invariants("VorticityTensor.Ω₂₃", Ωij.Ω₂₃)
 
-        # Stress-tensor components interpolate the velocities to a common location before
-        # multiplying; the off-diagonals live at the edge locations (ffc/fcf/cff), the diagonals
-        # at ccc.
+        # Off-diagonal stress components interpolate the two velocities to a common edge location
+        # (ffc/fcf/cff) before multiplying. The default diagonals (collocate_diagonals = false) read
+        # the velocity at its own location and square it — no interpolation.
         τij = StressTensor(model)
         test_kfo_invariants("StressTensor.τ₁₁", τij.τ₁₁)
         test_kfo_invariants("StressTensor.τ₁₂", τij.τ₁₂)
         test_kfo_invariants("StressTensor.τ₁₃", τij.τ₁₃)
         test_kfo_invariants("StressTensor.τ₂₃", τij.τ₂₃)
+
+        # The collocated diagonal (collocate_diagonals = true) interpolates to ccc and squares; it
+        # must remain allocation-free and type-stable too.
+        τij_c = StressTensor(model; collocate_diagonals=true)
+        test_kfo_invariants("StressTensor.τ₁₁ (collocated)", τij_c.τ₁₁)
     end
     #---
 

--- a/test/test_velocity_diagnostics.jl
+++ b/test/test_velocity_diagnostics.jl
@@ -93,16 +93,41 @@ function test_velocity_only_flow_diagnostics(model)
 
     τij = StressTensor(model)
     @test keys(τij) == (:τ₁₁, :τ₂₂, :τ₃₃, :τ₁₂, :τ₁₃, :τ₂₃)
-    @test location(τij.τ₁₁) == (Center, Center, Center)
-    @test location(τij.τ₂₂) == (Center, Center, Center)
-    @test location(τij.τ₃₃) == (Center, Center, Center)
+    # default `collocate_diagonals = false`: diagonals are interpolation-free, at each velocity's location
+    @test location(τij.τ₁₁) == (Face, Center, Center)
+    @test location(τij.τ₂₂) == (Center, Face, Center)
+    @test location(τij.τ₃₃) == (Center, Center, Face)
     @test location(τij.τ₁₂) == (Face, Face, Center)
     @test location(τij.τ₁₃) == (Face, Center, Face)
     @test location(τij.τ₂₃) == (Center, Face, Face)
     @test τij == StressTensor(model.grid, model.velocities...) # field-based constructor agrees
+    @test τij == StressTensor(model; collocate_diagonals=false) # the default
     for τᵢⱼ in τij
         @test Field(τᵢⱼ) isa Field # every component is computable
     end
+
+    # `collocate_diagonals = true`: diagonals are interpolated to a shared ccc location instead
+    τij_c = StressTensor(model; collocate_diagonals=true)
+    @test keys(τij_c) == keys(τij)
+    @test location(τij_c.τ₁₁) == (Center, Center, Center)
+    @test location(τij_c.τ₂₂) == (Center, Center, Center)
+    @test location(τij_c.τ₃₃) == (Center, Center, Center)
+    # off-diagonals are unaffected by `collocate_diagonals`
+    @test (location(τij_c.τ₁₂), location(τij_c.τ₁₃), location(τij_c.τ₂₃)) ==
+          (location(τij.τ₁₂),   location(τij.τ₁₃),   location(τij.τ₂₃))
+    @test τij_c == StressTensor(model.grid, model.velocities...; collocate_diagonals=true) # field-based agrees
+    for τᵢⱼ in τij_c
+        @test Field(τᵢⱼ) isa Field # every component is computable
+    end
+    # (ℑu)² ≠ ℑ(u²): collocating a diagonal is a genuinely different computation, not a relocation.
+    # The model's velocities here are zero, so verify on a noise-filled field instead.
+    uₙ = XFaceField(model.grid); set!(uₙ, grid_noise)
+    vₙ = YFaceField(model.grid); set!(vₙ, grid_noise)
+    wₙ = ZFaceField(model.grid); set!(wₙ, grid_noise)
+    τ_min = StressTensor(model.grid, uₙ, vₙ, wₙ; collocate_diagonals=false) # τ₁₁ = u²    at fcc
+    τ_col = StressTensor(model.grid, uₙ, vₙ, wₙ; collocate_diagonals=true)  # τ₁₁ = (ℑu)² at ccc
+    τ₁₁_min_at_ccc = Field(@at (Center, Center, Center) τ_min.τ₁₁)          # ℑ(u²)      at ccc
+    @test interior(Field(τ_col.τ₁₁)) != interior(τ₁₁_min_at_ccc)
 
     # `dims` selects sub-dimensional stress tensors: τᵢⱼ is kept only if both i and j are in `dims`
     @test keys(StressTensor(model; dims=(1, 2, 3))) == keys(τij)


### PR DESCRIPTION
## Summary

Adds a `collocate_diagonals` keyword to `StressTensor` that lets users choose where the diagonal components `τ₁₁, τ₂₂, τ₃₃` live, trading interpolation against collocation. The off-diagonals (`ffc`/`fcf`/`cff`) are already interpolation-minimal and are unchanged in both modes.

- **`collocate_diagonals = false` (new default):** each diagonal is computed as `τᵢᵢ = uᵢ²` read directly at `uᵢ`'s own location (`fcc`/`cfc`/`ccf`), with **no interpolation**. Cheapest and most accurate; the three diagonals end up at three different locations.
- **`collocate_diagonals = true`:** each velocity is first interpolated to `ccc` and then squared (`τᵢᵢ = (ℑ uᵢ)²`), so all three diagonals share `ccc` — useful for forming the trace `τ₁₁ + τ₂₂ + τ₃₃` (twice the KE) or treating `τ` as a collocated tensor. This is what the tensor did before.
## Changes

- **`src/FlowDiagnostics.jl`**: new interpolation-free diagonal kernels (`stress_tensor_xx_fcc`, `_yy_cfc`, `_zz_ccf`); `collocate_diagonals = false` keyword on both the `model` and field-based constructors; rewritten docstring with per-mode location tables and a warning that the two modes differ numerically.
- **`test/test_velocity_diagnostics.jl`**: updated default-location assertions to `fcc`/`cfc`/`ccf`; added a `collocate_diagonals=true` block (diagonals at `ccc`, off-diagonals unchanged); checked the kwarg forwards through the field-based constructor; added a numerical check that `(ℑu)² ≠ ℑ(u²)`.
- **`test/test_perf_invariants.jl`**: added a zero-allocation / type-stability check for the collocated diagonal.