### PR TITLE
Add per-diagnostic show methods on top of KernelFunctionOperation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,4 @@ The `perf_invariants` test group guards against performance regressions without 
 - One-line code expressions are preferred when they fit within 130 columns; only break them across lines when they exceed that width
 - Prose text (docstrings, comments, `.md` files) should wrap at around 100 columns
 - When adding a new leaf progress messenger, wrap its formatted-number string (the result of `@sprintf` / `prettytime`) in `ColoredNumber(...)` so the value participates in the configurable `NUMBER_CRAYON` coloring; prefix and unit text stay as plain `String`
+- **Code folding markers**: collapsible code sections are delimited by `#+++ <title>` to open (note the space after `#+++`) and `#---` to close — always exactly three `+`/`-`, never `#++`/`#--`. Nested sections use the same `#+++`/`#---` markers (each `#---` closes the most recent `#+++`)

--- a/docs/src/flow_diagnostics.md
+++ b/docs/src/flow_diagnostics.md
@@ -39,28 +39,32 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b, coriolis=FPlane(f=1e-4));
 
 julia> Ri = FlowDiagnostics.RichardsonNumber(model)
-KernelFunctionOperation at (Center, Center, Face)
+RichardsonNumber (KernelFunctionOperation) at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: richardson_number_ccf (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Field", "Tuple")
+└── computes: Richardson number  Ri = (∂b/∂z) / |∂u⃗ₕ/∂z|²
 
 julia> Ro = FlowDiagnostics.RossbyNumber(model)
-KernelFunctionOperation at (Face, Face, Face)
+RossbyNumber (KernelFunctionOperation) at (Face, Face, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: rossby_number_fff (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "NamedTuple")
+└── computes: Rossby number  Ro = ωᶻ/f
 
 julia> EPV = FlowDiagnostics.ErtelPotentialVorticity(model)
-KernelFunctionOperation at (Face, Face, Face)
+ErtelPotentialVorticity (KernelFunctionOperation) at (Face, Face, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ertel_potential_vorticity_fff (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Field", "Int64", "Int64", "Float64")
+└── computes: Ertel potential vorticity  q = ω⃗ₜₒₜ · ∇b
 
 julia> S = FlowDiagnostics.StrainRateTensorModulus(model)
-KernelFunctionOperation at (Center, Center, Center)
+StrainRateTensorModulus (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: strain_rate_tensor_modulus_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
+└── computes: strain-rate tensor modulus  √(SᵢⱼSᵢⱼ)
 ```
 
 ## Richardson number

--- a/docs/src/flow_diagnostics.md
+++ b/docs/src/flow_diagnostics.md
@@ -39,28 +39,28 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b, coriolis=FPlane(f=1e-4));
 
 julia> Ri = FlowDiagnostics.RichardsonNumber(model)
-RichardsonNumber (KernelFunctionOperation) at (Center, Center, Face)
+RichardsonNumber KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: richardson_number_ccf (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Field", "Tuple")
 └── computes: Richardson number  Ri = (∂b/∂z) / |∂u⃗ₕ/∂z|²
 
 julia> Ro = FlowDiagnostics.RossbyNumber(model)
-RossbyNumber (KernelFunctionOperation) at (Face, Face, Face)
+RossbyNumber KernelFunctionOperation at (Face, Face, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: rossby_number_fff (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "NamedTuple")
 └── computes: Rossby number  Ro = ωᶻ/f
 
 julia> EPV = FlowDiagnostics.ErtelPotentialVorticity(model)
-ErtelPotentialVorticity (KernelFunctionOperation) at (Face, Face, Face)
+ErtelPotentialVorticity KernelFunctionOperation at (Face, Face, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ertel_potential_vorticity_fff (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Field", "Int64", "Int64", "Float64")
 └── computes: Ertel potential vorticity  q = ω⃗ₜₒₜ · ∇b
 
 julia> S = FlowDiagnostics.StrainRateTensorModulus(model)
-StrainRateTensorModulus (KernelFunctionOperation) at (Center, Center, Center)
+StrainRateTensorModulus KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: strain_rate_tensor_modulus_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,14 +22,14 @@ julia> simulation = Simulation(model, Δt=1, stop_time=10);
 julia> simulation.callbacks[:progress] = Callback(ProgressMessengers.TimedMessenger(), IterationInterval(5));
 
 julia> ke = KineticEnergyEquation.KineticEnergy(model)
-KineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergy KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×5×6 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
 └── computes: kinetic energy  ½uᵢuᵢ
 
 julia> ε = KineticEnergyEquation.KineticEnergyDissipationRate(model)
-KineticEnergyDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyDissipationRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×5×6 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: viscous_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("NamedTuple", "NamedTuple", "NamedTuple")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,16 +22,18 @@ julia> simulation = Simulation(model, Δt=1, stop_time=10);
 julia> simulation.callbacks[:progress] = Callback(ProgressMessengers.TimedMessenger(), IterationInterval(5));
 
 julia> ke = KineticEnergyEquation.KineticEnergy(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×5×6 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
+└── computes: kinetic energy  ½uᵢuᵢ
 
 julia> ε = KineticEnergyEquation.KineticEnergyDissipationRate(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×5×6 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: viscous_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("NamedTuple", "NamedTuple", "NamedTuple")
+└── computes: kinetic energy dissipation rate  ε = ∂ⱼuᵢ·Fᵢⱼ
 
 julia> run!(simulation)
 [ Info: Initializing simulation...

--- a/docs/src/kinetic_energy_equation.md
+++ b/docs/src/kinetic_energy_equation.md
@@ -41,21 +41,21 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b, closure=ScalarDiffusivity(ν=1e-4));
 
 julia> KE = KineticEnergyEquation.KineticEnergy(model)
-KineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergy KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
 └── computes: kinetic energy  ½uᵢuᵢ
 
 julia> ε = KineticEnergyEquation.KineticEnergyIsotropicDissipationRate(model)
-KineticEnergyIsotropicDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyIsotropicDissipationRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: isotropic_viscous_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "NamedTuple")
 └── computes: isotropic kinetic energy dissipation rate  ε = 2νSᵢⱼSᵢⱼ
 
 julia> wb = KineticEnergyEquation.BuoyancyProduction(model)
-KineticEnergyBuoyancyProduction (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyBuoyancyProduction KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: uᵢbᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "BuoyancyForce", "NamedTuple")

--- a/docs/src/kinetic_energy_equation.md
+++ b/docs/src/kinetic_energy_equation.md
@@ -41,22 +41,25 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b, closure=ScalarDiffusivity(ν=1e-4));
 
 julia> KE = KineticEnergyEquation.KineticEnergy(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
+└── computes: kinetic energy  ½uᵢuᵢ
 
 julia> ε = KineticEnergyEquation.KineticEnergyIsotropicDissipationRate(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyIsotropicDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: isotropic_viscous_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "NamedTuple")
+└── computes: isotropic kinetic energy dissipation rate  ε = 2νSᵢⱼSᵢⱼ
 
 julia> wb = KineticEnergyEquation.BuoyancyProduction(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyBuoyancyProduction (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: uᵢbᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "BuoyancyForce", "NamedTuple")
+└── computes: kinetic energy buoyancy production  uᵢbᵢ
 ```
 
 ## Kinetic energy

--- a/docs/src/momentum_equation.md
+++ b/docs/src/momentum_equation.md
@@ -44,21 +44,21 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b, coriolis=FPlane(f=1e-4));
 
 julia> ADV = UMomentumEquation.Advection(model)
-UAdvection (KernelFunctionOperation) at (Face, Center, Center)
+UAdvection KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: div_𝐯u (generic function with 4 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
 └── computes: advection of u-momentum  ∂ⱼ(uⱼu)
 
 julia> BUOY = UMomentumEquation.BuoyancyAcceleration(model)
-UBuoyancyAcceleration (KernelFunctionOperation) at (Face, Center, Center)
+UBuoyancyAcceleration KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: x_dot_g_bᶠᶜᶜ (generic function with 3 methods)
 └── arguments: ("BuoyancyForce", "NamedTuple")
 └── computes: buoyancy acceleration (x)  ĝₓ b
 
 julia> COR = VMomentumEquation.CoriolisAcceleration(model)
-VCoriolisAcceleration (KernelFunctionOperation) at (Center, Face, Center)
+VCoriolisAcceleration KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: y_f_cross_U (generic function with 11 methods)
 └── arguments: ("FPlane", "NamedTuple")

--- a/docs/src/momentum_equation.md
+++ b/docs/src/momentum_equation.md
@@ -44,22 +44,25 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b, coriolis=FPlane(f=1e-4));
 
 julia> ADV = UMomentumEquation.Advection(model)
-KernelFunctionOperation at (Face, Center, Center)
+UAdvection (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: div_𝐯u (generic function with 10 methods)
+├── kernel_function: div_𝐯u (generic function with 4 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
+└── computes: advection of u-momentum  ∂ⱼ(uⱼu)
 
 julia> BUOY = UMomentumEquation.BuoyancyAcceleration(model)
-KernelFunctionOperation at (Face, Center, Center)
+UBuoyancyAcceleration (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: x_dot_g_bᶠᶜᶜ (generic function with 10 methods)
+├── kernel_function: x_dot_g_bᶠᶜᶜ (generic function with 3 methods)
 └── arguments: ("BuoyancyForce", "NamedTuple")
+└── computes: buoyancy acceleration (x)  ĝₓ b
 
 julia> COR = VMomentumEquation.CoriolisAcceleration(model)
-KernelFunctionOperation at (Center, Face, Center)
+VCoriolisAcceleration (KernelFunctionOperation) at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: y_f_cross_U (generic function with 10 methods)
+├── kernel_function: y_f_cross_U (generic function with 11 methods)
 └── arguments: ("FPlane", "NamedTuple")
+└── computes: Coriolis acceleration (y)  (f⃗ × u⃗)_y
 ```
 
 ## Budget closure

--- a/docs/src/potential_energy_equation.md
+++ b/docs/src/potential_energy_equation.md
@@ -38,10 +38,11 @@ julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Boun
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> Ep = PotentialEnergyEquation.PotentialEnergy(model)
-KernelFunctionOperation at (Center, Center, Center)
+PotentialEnergy (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: minus_bz_ccc (generic function with 3 methods)
 └── arguments: ("Field",)
+└── computes: potential energy per unit volume  Eₚ = -bz
 ```
 
 ## Potential energy

--- a/docs/src/potential_energy_equation.md
+++ b/docs/src/potential_energy_equation.md
@@ -38,7 +38,7 @@ julia> grid = RectilinearGrid(size=100, z=(-1000, 0), topology=(Flat, Flat, Boun
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> Ep = PotentialEnergyEquation.PotentialEnergy(model)
-PotentialEnergy (KernelFunctionOperation) at (Center, Center, Center)
+PotentialEnergy KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: minus_bz_ccc (generic function with 3 methods)
 └── arguments: ("Field",)

--- a/docs/src/tracer_equation.md
+++ b/docs/src/tracer_equation.md
@@ -32,16 +32,18 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:b, closure=ScalarDiffusivity(ν=1e-4, κ=1e-4));
 
 julia> adv  = TracerEquation.Advection(model, :b)
-KernelFunctionOperation at (Center, Center, Center)
+TracerAdvection (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: div_Uc (generic function with 10 methods)
+├── kernel_function: div_Uc (generic function with 12 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
+└── computes: tracer advection  ∂ⱼ(uⱼc)
 
 julia> diff = TracerEquation.Diffusion(model, :b)
-KernelFunctionOperation at (Center, Center, Center)
+TracerDiffusion (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∇_dot_qᶜ (generic function with 10 methods)
 └── arguments: ("ScalarDiffusivity", "Nothing", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: tracer diffusion (interior)  ∂ⱼqᶜⱼ
 
 julia> forc = TracerEquation.Forcing(model, :b)
 KernelFunctionOperation at (Center, Center, Center)

--- a/docs/src/tracer_equation.md
+++ b/docs/src/tracer_equation.md
@@ -32,14 +32,14 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:b, closure=ScalarDiffusivity(ν=1e-4, κ=1e-4));
 
 julia> adv  = TracerEquation.Advection(model, :b)
-TracerAdvection (KernelFunctionOperation) at (Center, Center, Center)
+TracerAdvection KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: div_Uc (generic function with 12 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
 └── computes: tracer advection  ∂ⱼ(uⱼc)
 
 julia> diff = TracerEquation.Diffusion(model, :b)
-TracerDiffusion (KernelFunctionOperation) at (Center, Center, Center)
+TracerDiffusion KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∇_dot_qᶜ (generic function with 10 methods)
 └── arguments: ("ScalarDiffusivity", "Nothing", "Val", "Field", "Clock", "NamedTuple", "Nothing")

--- a/docs/src/tracer_variance_equation.md
+++ b/docs/src/tracer_variance_equation.md
@@ -35,16 +35,18 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:b, closure=SmagorinskyLilly());
 
 julia> χ = TracerVarianceEquation.TracerVarianceDissipationRate(model, :b)
-KernelFunctionOperation at (Center, Center, Center)
+TracerVarianceDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: tracer_variance_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Oceananigans.TurbulenceClosures.Smagorinskys.Smagorinsky", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: tracer variance dissipation rate  χ = 2 ∂ⱼc·Fⱼ
 
 julia> diff = TracerVarianceEquation.TracerVarianceDiffusion(model, :b)
-KernelFunctionOperation at (Center, Center, Center)
+TracerVarianceDiffusion (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: c∇_dot_qᶜ (generic function with 1 method)
 └── arguments: ("Oceananigans.TurbulenceClosures.Smagorinskys.Smagorinsky", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: tracer variance diffusion  2c ∂ⱼFⱼ
 ```
 
 ## Tendency

--- a/docs/src/tracer_variance_equation.md
+++ b/docs/src/tracer_variance_equation.md
@@ -35,14 +35,14 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:b, closure=SmagorinskyLilly());
 
 julia> χ = TracerVarianceEquation.TracerVarianceDissipationRate(model, :b)
-TracerVarianceDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
+TracerVarianceDissipationRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: tracer_variance_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Oceananigans.TurbulenceClosures.Smagorinskys.Smagorinsky", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
 └── computes: tracer variance dissipation rate  χ = 2 ∂ⱼc·Fⱼ
 
 julia> diff = TracerVarianceEquation.TracerVarianceDiffusion(model, :b)
-TracerVarianceDiffusion (KernelFunctionOperation) at (Center, Center, Center)
+TracerVarianceDiffusion KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: c∇_dot_qᶜ (generic function with 1 method)
 └── arguments: ("Oceananigans.TurbulenceClosures.Smagorinskys.Smagorinsky", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")

--- a/docs/src/turbulent_kinetic_energy_equation.md
+++ b/docs/src/turbulent_kinetic_energy_equation.md
@@ -38,16 +38,18 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; closure=ScalarDiffusivity(ν=1e-4));
 
 julia> tke = TurbulentKineticEnergyEquation.TurbulentKineticEnergy(model)
-KernelFunctionOperation at (Center, Center, Center)
+TurbulentKineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: turbulent_kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
+└── computes: turbulent kinetic energy  ½uᵢ′uᵢ′
 
 julia> SP = TurbulentKineticEnergyEquation.ShearProductionRate(model)
-KernelFunctionOperation at (Center, Center, Center)
+TurbulentKineticEnergyShearProductionRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: shear_production_rate_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
+└── computes: total TKE shear production  -uᵢ′uⱼ′ ∂ⱼUᵢ
 ```
 
 ## Turbulent kinetic energy

--- a/docs/src/turbulent_kinetic_energy_equation.md
+++ b/docs/src/turbulent_kinetic_energy_equation.md
@@ -38,14 +38,14 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; closure=ScalarDiffusivity(ν=1e-4));
 
 julia> tke = TurbulentKineticEnergyEquation.TurbulentKineticEnergy(model)
-TurbulentKineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
+TurbulentKineticEnergy KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: turbulent_kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
 └── computes: turbulent kinetic energy  ½uᵢ′uᵢ′
 
 julia> SP = TurbulentKineticEnergyEquation.ShearProductionRate(model)
-TurbulentKineticEnergyShearProductionRate (KernelFunctionOperation) at (Center, Center, Center)
+TurbulentKineticEnergyShearProductionRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: shear_production_rate_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -87,7 +87,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> Ri = RichardsonNumber(model)
-RichardsonNumber (KernelFunctionOperation) at (Center, Center, Face)
+RichardsonNumber KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: richardson_number_ccf (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Field", "Tuple")
@@ -157,7 +157,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; coriolis=FPlane(f=1e-4));
 
 julia> Ro = RossbyNumber(model)
-RossbyNumber (KernelFunctionOperation) at (Face, Face, Face)
+RossbyNumber KernelFunctionOperation at (Face, Face, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: rossby_number_fff (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "NamedTuple")
@@ -301,7 +301,7 @@ julia> set!(model, b=stratification)
 julia> using Oceanostics: ErtelPotentialVorticity
 
 julia> EPV = ErtelPotentialVorticity(model)
-ErtelPotentialVorticity (KernelFunctionOperation) at (Face, Face, Face)
+ErtelPotentialVorticity KernelFunctionOperation at (Face, Face, Face)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: ertel_potential_vorticity_fff (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Field", "Int64", "Int64", "Float64")
@@ -399,7 +399,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; coriolis=FPlane(f=1e-4), buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> DEPV = DirectionalErtelPotentialVorticity(model, (0, 0, 1))
-DirectionalErtelPotentialVorticity (KernelFunctionOperation) at (Face, Face, Face)
+DirectionalErtelPotentialVorticity KernelFunctionOperation at (Face, Face, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: directional_ertel_potential_vorticity_fff (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Field", "NamedTuple")
@@ -464,7 +464,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> S = StrainRateTensorModulus(model)
-StrainRateTensorModulus (KernelFunctionOperation) at (Center, Center, Center)
+StrainRateTensorModulus KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: strain_rate_tensor_modulus_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
@@ -599,7 +599,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> Ω = VorticityTensorModulus(model)
-VorticityTensorModulus (KernelFunctionOperation) at (Center, Center, Center)
+VorticityTensorModulus KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: vorticity_tensor_modulus_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
@@ -853,7 +853,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> Qcrit = QVelocityGradientTensorInvariant(model)
-QVelocityGradientTensorInvariant (KernelFunctionOperation) at (Center, Center, Center)
+QVelocityGradientTensorInvariant KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: Q_velocity_gradient_tensor_invariant_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")

--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -87,10 +87,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> Ri = RichardsonNumber(model)
-KernelFunctionOperation at (Center, Center, Face)
+RichardsonNumber (KernelFunctionOperation) at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: richardson_number_ccf (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Field", "Tuple")
+└── computes: Richardson number  Ri = (∂b/∂z) / |∂u⃗ₕ/∂z|²
 ```
 """
 function RichardsonNumber(model; loc = (Center, Center, Face))
@@ -156,10 +157,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; coriolis=FPlane(f=1e-4));
 
 julia> Ro = RossbyNumber(model)
-KernelFunctionOperation at (Face, Face, Face)
+RossbyNumber (KernelFunctionOperation) at (Face, Face, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: rossby_number_fff (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "NamedTuple")
+└── computes: Rossby number  Ro = ωᶻ/f
 ```
 """
 function RossbyNumber(model; loc = (Face, Face, Face), add_background = true,
@@ -299,10 +301,11 @@ julia> set!(model, b=stratification)
 julia> using Oceanostics: ErtelPotentialVorticity
 
 julia> EPV = ErtelPotentialVorticity(model)
-KernelFunctionOperation at (Face, Face, Face)
+ErtelPotentialVorticity (KernelFunctionOperation) at (Face, Face, Face)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: ertel_potential_vorticity_fff (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Field", "Int64", "Int64", "Float64")
+└── computes: Ertel potential vorticity  q = ω⃗ₜₒₜ · ∇b
 
 julia> interior(Field(EPV))
 1×1×5 view(::Array{Float64, 3}, 1:1, 1:1, 4:8) with eltype Float64:
@@ -396,10 +399,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; coriolis=FPlane(f=1e-4), buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> DEPV = DirectionalErtelPotentialVorticity(model, (0, 0, 1))
-KernelFunctionOperation at (Face, Face, Face)
+DirectionalErtelPotentialVorticity (KernelFunctionOperation) at (Face, Face, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: directional_ertel_potential_vorticity_fff (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Field", "NamedTuple")
+└── computes: directional contribution to Ertel PV  (f̂ + ω̂)·∇b along a direction
 ```
 """
 function DirectionalErtelPotentialVorticity(model, direction; tracer_name = :b, loc = (Face, Face, Face))
@@ -460,10 +464,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> S = StrainRateTensorModulus(model)
-KernelFunctionOperation at (Center, Center, Center)
+StrainRateTensorModulus (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: strain_rate_tensor_modulus_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
+└── computes: strain-rate tensor modulus  √(SᵢⱼSᵢⱼ)
 ```
 """
 function StrainRateTensorModulus(model; loc = (Center, Center, Center))
@@ -594,10 +599,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> Ω = VorticityTensorModulus(model)
-KernelFunctionOperation at (Center, Center, Center)
+VorticityTensorModulus (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: vorticity_tensor_modulus_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
+└── computes: vorticity tensor modulus  √(ΩᵢⱼΩᵢⱼ)
 ```
 """
 function VorticityTensorModulus(model; loc = (Center, Center, Center))
@@ -847,10 +853,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> Qcrit = QVelocityGradientTensorInvariant(model)
-KernelFunctionOperation at (Center, Center, Center)
+QVelocityGradientTensorInvariant (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: Q_velocity_gradient_tensor_invariant_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
+└── computes: Q velocity-gradient invariant  Q = ½(ΩᵢⱼΩᵢⱼ - SᵢⱼSᵢⱼ)
 ```
 """
 function QVelocityGradientTensorInvariant(model; loc = (Center, Center, Center))

--- a/src/KineticEnergyEquation.jl
+++ b/src/KineticEnergyEquation.jl
@@ -53,10 +53,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> KE = KineticEnergyEquation.KineticEnergy(model, model.velocities...)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
+└── computes: kinetic energy  ½uᵢuᵢ
 ```
 """
 function KineticEnergy(model, u, v, w; location = (Center, Center, Center))
@@ -77,10 +78,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> KE = KineticEnergyEquation.KineticEnergy(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
+└── computes: kinetic energy  ½uᵢuᵢ
 ```
 """
 KineticEnergy(model; kwargs...) = KineticEnergy(model, model.velocities...; kwargs...)
@@ -132,10 +134,11 @@ julia> model = NonhydrostaticModel(grid);
 julia> using Oceanostics.KineticEnergyEquation: KineticEnergyTendency
 
 julia> ke_tendency = KineticEnergyTendency(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyTendency (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢGᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("Centered", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Oceananigans.Models.NonhydrostaticModels.BackgroundFields", "NamedTuple", "NamedTuple", "NamedTuple", "Nothing", "Nothing", "Clock", "NamedTuple")
+└── computes: kinetic energy tendency  uᵢGᵢ (excl. nonhydrostatic pressure)
 ```
 """
 function KineticEnergyTendency(model::NonhydrostaticModel; location = (Center, Center, Center))
@@ -191,10 +194,11 @@ julia> model = NonhydrostaticModel(grid);
 julia> using Oceanostics.KineticEnergyEquation: KineticEnergyAdvection
 
 julia> ADV = KineticEnergyAdvection(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyAdvection (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢ∂ⱼuⱼuᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Centered")
+└── computes: kinetic energy advection  uᵢ∂ⱼ(uᵢuⱼ)
 ```
 """
 function KineticEnergyAdvection(model::NonhydrostaticModel; velocities = model.velocities, location = (Center, Center, Center))
@@ -240,10 +244,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; closure=ScalarDiffusivity(ν=1e-4));
 
 julia> DIFF = KineticEnergyEquation.KineticEnergyStress(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyStress (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: uᵢ∂ⱼ_τᵢⱼᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("ScalarDiffusivity", "Nothing", "Clock", "NamedTuple", "Nothing")
+└── computes: kinetic energy stress/diffusion  uᵢ∂ⱼτᵢⱼ
 ```
 """
 function KineticEnergyStress(model; location = (Center, Center, Center))
@@ -297,10 +302,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> FORC = KineticEnergyEquation.KineticEnergyForcing(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyForcing (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: uᵢFᵤᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Clock", "NamedTuple")
+└── computes: kinetic energy forcing  uᵢFᵤᵢ
 ```
 """
 function KineticEnergyForcing(model::NonhydrostaticModel; location = (Center, Center, Center))
@@ -344,10 +350,11 @@ julia> model = NonhydrostaticModel(grid);
 julia> using Oceanostics.KineticEnergyEquation: KineticEnergyPressureRedistribution
 
 julia> ∇u⃗p = KineticEnergyPressureRedistribution(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyPressureRedistribution (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢ∂ᵢpᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Field")
+└── computes: kinetic energy pressure redistribution  uᵢ∂ᵢp
 ```
 
 We can also pass `velocities` and `pressure` keywords to perform more specific calculations. The
@@ -356,10 +363,11 @@ redistrubution term:
 
 ```jldoctest ∇u⃗p_example
 julia> ∇u⃗pNHS = KineticEnergyPressureRedistribution(model, pressure=model.pressures.pNHS)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyPressureRedistribution (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢ∂ᵢpᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Field")
+└── computes: kinetic energy pressure redistribution  uᵢ∂ᵢp
 ```
 """
 function KineticEnergyPressureRedistribution(model::NonhydrostaticModel; velocities = model.velocities,
@@ -405,10 +413,11 @@ julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 julia> using Oceanostics.KineticEnergyEquation: BuoyancyProduction
 
 julia> wb = BuoyancyProduction(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyBuoyancyProduction (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢbᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "BuoyancyForce", "NamedTuple")
+└── computes: kinetic energy buoyancy production  uᵢbᵢ
 ```
 
 If we want to calculate only the _turbulent_ buoyancy production rate, we can do so by passing
@@ -420,10 +429,11 @@ julia> w′ = Field(model.velocities.w - Field(Average(model.velocities.w)));
 julia> b′ = Field(model.tracers.b - Field(Average(model.tracers.b)));
 
 julia> w′b′ = BuoyancyProduction(model, velocities=(u=model.velocities.u, v=model.velocities.v, w=w′), tracers=(b=b′,))
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyBuoyancyProduction (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢbᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "BuoyancyForce", "NamedTuple")
+└── computes: kinetic energy buoyancy production  uᵢbᵢ
 ```
 """
 function BuoyancyProduction(model::NonhydrostaticModel; velocities = model.velocities, tracers = model.tracers, location = (Center, Center, Center))
@@ -482,10 +492,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; closure=ScalarDiffusivity(ν=1e-4));
 
 julia> ε = KineticEnergyEquation.DissipationRate(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: viscous_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Nothing", "NamedTuple", "NamedTuple")
+└── computes: kinetic energy dissipation rate  ε = ∂ⱼuᵢ·Fᵢⱼ
 ```
 """
 function DissipationRate(model; U=ZeroField(), V=ZeroField(), W=ZeroField(),
@@ -539,10 +550,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; closure=ScalarDiffusivity(ν=1e-4));
 
 julia> ε = KineticEnergyEquation.KineticEnergyIsotropicDissipationRate(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyIsotropicDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: isotropic_viscous_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "NamedTuple")
+└── computes: isotropic kinetic energy dissipation rate  ε = 2νSᵢⱼSᵢⱼ
 ```
 """
 function KineticEnergyIsotropicDissipationRate(u, v, w, closure, closure_fields, model_fields, clock; location = (Center, Center, Center))

--- a/src/KineticEnergyEquation.jl
+++ b/src/KineticEnergyEquation.jl
@@ -53,7 +53,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> KE = KineticEnergyEquation.KineticEnergy(model, model.velocities...)
-KineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergy KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
@@ -78,7 +78,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> KE = KineticEnergyEquation.KineticEnergy(model)
-KineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergy KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field")
@@ -134,7 +134,7 @@ julia> model = NonhydrostaticModel(grid);
 julia> using Oceanostics.KineticEnergyEquation: KineticEnergyTendency
 
 julia> ke_tendency = KineticEnergyTendency(model)
-KineticEnergyTendency (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyTendency KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢGᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("Centered", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Oceananigans.Models.NonhydrostaticModels.BackgroundFields", "NamedTuple", "NamedTuple", "NamedTuple", "Nothing", "Nothing", "Clock", "NamedTuple")
@@ -194,7 +194,7 @@ julia> model = NonhydrostaticModel(grid);
 julia> using Oceanostics.KineticEnergyEquation: KineticEnergyAdvection
 
 julia> ADV = KineticEnergyAdvection(model)
-KineticEnergyAdvection (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyAdvection KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢ∂ⱼuⱼuᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Centered")
@@ -244,7 +244,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; closure=ScalarDiffusivity(ν=1e-4));
 
 julia> DIFF = KineticEnergyEquation.KineticEnergyStress(model)
-KineticEnergyStress (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyStress KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: uᵢ∂ⱼ_τᵢⱼᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("ScalarDiffusivity", "Nothing", "Clock", "NamedTuple", "Nothing")
@@ -302,7 +302,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> FORC = KineticEnergyEquation.KineticEnergyForcing(model)
-KineticEnergyForcing (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyForcing KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: uᵢFᵤᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Clock", "NamedTuple")
@@ -350,7 +350,7 @@ julia> model = NonhydrostaticModel(grid);
 julia> using Oceanostics.KineticEnergyEquation: KineticEnergyPressureRedistribution
 
 julia> ∇u⃗p = KineticEnergyPressureRedistribution(model)
-KineticEnergyPressureRedistribution (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyPressureRedistribution KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢ∂ᵢpᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Field")
@@ -363,7 +363,7 @@ redistrubution term:
 
 ```jldoctest ∇u⃗p_example
 julia> ∇u⃗pNHS = KineticEnergyPressureRedistribution(model, pressure=model.pressures.pNHS)
-KineticEnergyPressureRedistribution (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyPressureRedistribution KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢ∂ᵢpᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Field")
@@ -413,7 +413,7 @@ julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 julia> using Oceanostics.KineticEnergyEquation: BuoyancyProduction
 
 julia> wb = BuoyancyProduction(model)
-KineticEnergyBuoyancyProduction (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyBuoyancyProduction KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢbᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "BuoyancyForce", "NamedTuple")
@@ -429,7 +429,7 @@ julia> w′ = Field(model.velocities.w - Field(Average(model.velocities.w)));
 julia> b′ = Field(model.tracers.b - Field(Average(model.tracers.b)));
 
 julia> w′b′ = BuoyancyProduction(model, velocities=(u=model.velocities.u, v=model.velocities.v, w=w′), tracers=(b=b′,))
-KineticEnergyBuoyancyProduction (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyBuoyancyProduction KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: uᵢbᵢᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("NamedTuple", "BuoyancyForce", "NamedTuple")
@@ -492,7 +492,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; closure=ScalarDiffusivity(ν=1e-4));
 
 julia> ε = KineticEnergyEquation.DissipationRate(model)
-KineticEnergyDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyDissipationRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: viscous_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Nothing", "NamedTuple", "NamedTuple")
@@ -550,7 +550,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; closure=ScalarDiffusivity(ν=1e-4));
 
 julia> ε = KineticEnergyEquation.KineticEnergyIsotropicDissipationRate(model)
-KineticEnergyIsotropicDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyIsotropicDissipationRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: isotropic_viscous_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "NamedTuple")

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -254,7 +254,7 @@ end
 Give the `CustomKFO` type alias `T` a custom display: rename its `show`/`summary` header to
 `"<name> KernelFunctionOperation"`, and (when `description` is non-empty) append a
 `└── computes: <description>` line to its multi-line `show`. On color-capable streams the leading
-`<name>` and the description are tinted with [`DESCRIPTION_CRAYON`](@ref). The header rename goes
+`<name>` and the description are tinted with `DESCRIPTION_CRAYON`. The header rename goes
 through Oceananigans' `operation_name`, so it also propagates (uncolored) to `summary(op)` and to
 `op`'s appearance inside larger operation trees and `Field` operand lines.
 """

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -203,23 +203,7 @@ import Oceananigans.AbstractOperations: operation_name
 using Crayons
 export DESCRIPTION_CRAYON, set_description_color!, Crayon, @crayon_str
 
-"""
-    DESCRIPTION_CRAYON :: Ref{Crayon}
-
-Process-global `Crayon` used to color a diagnostic's `show` output — both the leading diagnostic name
-in the header (e.g. `KineticEnergy`) and the `└── computes: …` description line. It is only applied
-when the output stream supports color (`get(io, :color, false)`), so doctests and color-less streams
-still print plain text. Reassign with [`set_description_color!`](@ref) (or `DESCRIPTION_CRAYON[] = ...`)
-to change the color at runtime.
-
-```jldoctest
-julia> using Oceanostics
-
-julia> DESCRIPTION_CRAYON[] isa Crayon
-true
-```
-"""
-const DESCRIPTION_CRAYON = Ref(crayon"cyan")
+const DESCRIPTION_CRAYON = Ref(crayon"#00FF7F")
 
 """
     set_description_color!(c::Crayon)

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -203,7 +203,7 @@ import Oceananigans.AbstractOperations: operation_name
 using Crayons
 export DESCRIPTION_CRAYON, set_description_color!, Crayon, @crayon_str
 
-const DESCRIPTION_CRAYON = Ref(crayon"#00FF7F")
+const DESCRIPTION_CRAYON = Ref(crayon"#00BFFF")
 
 """
     set_description_color!(c::Crayon)

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -192,4 +192,131 @@ using .FlowDiagnostics
 using .Filters
 using .ProgressMessengers
 
+#+++ Custom `show` for diagnostics
+# Every diagnostic is a `KernelFunctionOperation` (KFO) under the hood, so by default it prints as the
+# generic `KernelFunctionOperation at (…)`. Here we give each diagnostic alias its own header — keeping
+# the `(KernelFunctionOperation)` tag so it stays clear that the object *is* still a KFO — plus a one-line
+# description of what it computes. Everything else (grid, kernel_function, arguments) is delegated to
+# Oceananigans' KFO `show` via `invoke`, so we don't duplicate (or drift from) its tree layout.
+import Oceananigans.AbstractOperations: operation_name
+
+"Print Oceananigans' KFO tree for `op`, then a `└── computes: …` line with the diagnostic's `description`."
+function _show_diagnostic(io::IO, op, description)
+    invoke(show, Tuple{IO, KernelFunctionOperation}, io, op)
+    isempty(description) || print(io, "\n└── computes: ", description)
+    return nothing
+end
+
+"""
+    @diagnostic_show T name [description]
+
+Give the `CustomKFO` type alias `T` a custom display: rename its `show`/`summary` header to
+`"<name> (KernelFunctionOperation)"`, and (when `description` is non-empty) append a
+`└── computes: <description>` line to its multi-line `show`. The header rename goes through
+Oceananigans' `operation_name`, so it also propagates to `summary(op)` and to `op`'s appearance
+inside larger operation trees and `Field` operand lines.
+"""
+macro diagnostic_show(T, name, description="")
+    T = esc(T)
+    quote
+        # `operation_name` is escaped so the method extends the function imported from Oceananigans
+        # (hygiene would otherwise treat the unqualified name as a fresh, separate binding).
+        $(esc(:operation_name))(::$T) = $name * " (KernelFunctionOperation)"
+        Base.show(io::IO, op::$T) = _show_diagnostic(io, op, $description)
+    end
+end
+
+#++ TracerEquation
+@diagnostic_show TracerEquation.Advection         "TracerAdvection"          "tracer advection  ∂ⱼ(uⱼc)"
+@diagnostic_show TracerEquation.Diffusion         "TracerDiffusion"          "tracer diffusion (interior)  ∂ⱼqᶜⱼ"
+@diagnostic_show TracerEquation.ImmersedDiffusion "TracerImmersedDiffusion"  "tracer diffusion through immersed boundaries  ∂ⱼ𝓆ᶜⱼ"
+@diagnostic_show TracerEquation.TotalDiffusion    "TracerTotalDiffusion"     "total tracer diffusion (interior + immersed)  ∂ⱼqᶜⱼ + ∂ⱼ𝓆ᶜⱼ"
+#--
+
+#++ UMomentumEquation
+@diagnostic_show UMomentumEquation.Advection                  "UAdvection"                  "advection of u-momentum  ∂ⱼ(uⱼu)"
+@diagnostic_show UMomentumEquation.BuoyancyAcceleration       "UBuoyancyAcceleration"       "buoyancy acceleration (x)  ĝₓ b"
+@diagnostic_show UMomentumEquation.CoriolisAcceleration       "UCoriolisAcceleration"       "Coriolis acceleration (x)  (f⃗ × u⃗)ₓ"
+@diagnostic_show UMomentumEquation.PressureGradient           "UPressureGradient"           "hydrostatic pressure gradient (x)  ∂p/∂x"
+@diagnostic_show UMomentumEquation.ViscousDissipation         "UViscousDissipation"         "viscous term (interior, x)  ∂ⱼτ₁ⱼ"
+@diagnostic_show UMomentumEquation.ImmersedViscousDissipation "UImmersedViscousDissipation" "viscous term through immersed boundaries (x)  ∂ⱼτ₁ⱼ"
+@diagnostic_show UMomentumEquation.TotalViscousDissipation    "UTotalViscousDissipation"    "total viscous term (interior + immersed, x)  ∂ⱼτ₁ⱼ"
+@diagnostic_show UMomentumEquation.StokesShear                "UStokesShear"                "Stokes shear forcing (x)  ((∇ × u⃗ˢ) × u⃗)ₓ"
+@diagnostic_show UMomentumEquation.StokesTendency             "UStokesTendency"             "Stokes drift tendency (x)  ∂uˢ/∂t"
+@diagnostic_show UMomentumEquation.Tendency                   "UTendency"                   "total tendency of the u-momentum equation"
+#--
+
+#++ VMomentumEquation
+@diagnostic_show VMomentumEquation.Advection                  "VAdvection"                  "advection of v-momentum  ∂ⱼ(uⱼv)"
+@diagnostic_show VMomentumEquation.BuoyancyAcceleration       "VBuoyancyAcceleration"       "buoyancy acceleration (y)  ĝ_y b"
+@diagnostic_show VMomentumEquation.CoriolisAcceleration       "VCoriolisAcceleration"       "Coriolis acceleration (y)  (f⃗ × u⃗)_y"
+@diagnostic_show VMomentumEquation.PressureGradient           "VPressureGradient"           "hydrostatic pressure gradient (y)  ∂p/∂y"
+@diagnostic_show VMomentumEquation.ViscousDissipation         "VViscousDissipation"         "viscous term (interior, y)  ∂ⱼτ₂ⱼ"
+@diagnostic_show VMomentumEquation.ImmersedViscousDissipation "VImmersedViscousDissipation" "viscous term through immersed boundaries (y)  ∂ⱼτ₂ⱼ"
+@diagnostic_show VMomentumEquation.TotalViscousDissipation    "VTotalViscousDissipation"    "total viscous term (interior + immersed, y)  ∂ⱼτ₂ⱼ"
+@diagnostic_show VMomentumEquation.StokesShear                "VStokesShear"                "Stokes shear forcing (y)  ((∇ × u⃗ˢ) × u⃗)_y"
+@diagnostic_show VMomentumEquation.StokesTendency             "VStokesTendency"             "Stokes drift tendency (y)  ∂vˢ/∂t"
+@diagnostic_show VMomentumEquation.Tendency                   "VTendency"                   "total tendency of the v-momentum equation"
+#--
+
+#++ WMomentumEquation
+@diagnostic_show WMomentumEquation.Advection                  "WAdvection"                  "advection of w-momentum  ∂ⱼ(uⱼw)"
+@diagnostic_show WMomentumEquation.BuoyancyAcceleration       "WBuoyancyAcceleration"       "buoyancy acceleration (z)  ĝ_z b"
+@diagnostic_show WMomentumEquation.CoriolisAcceleration       "WCoriolisAcceleration"       "Coriolis acceleration (z)  (f⃗ × u⃗)_z"
+@diagnostic_show WMomentumEquation.ViscousDissipation         "WViscousDissipation"         "viscous term (interior, z)  ∂ⱼτ₃ⱼ"
+@diagnostic_show WMomentumEquation.ImmersedViscousDissipation "WImmersedViscousDissipation" "viscous term through immersed boundaries (z)  ∂ⱼτ₃ⱼ"
+@diagnostic_show WMomentumEquation.TotalViscousDissipation    "WTotalViscousDissipation"    "total viscous term (interior + immersed, z)  ∂ⱼτ₃ⱼ"
+@diagnostic_show WMomentumEquation.StokesShear                "WStokesShear"                "Stokes shear forcing (z)  ((∇ × u⃗ˢ) × u⃗)_z"
+@diagnostic_show WMomentumEquation.StokesTendency             "WStokesTendency"             "Stokes drift tendency (z)  ∂wˢ/∂t"
+@diagnostic_show WMomentumEquation.Tendency                   "WTendency"                   "total tendency of the w-momentum equation"
+#--
+
+#++ TracerVarianceEquation
+@diagnostic_show TracerVarianceEquation.Tendency        "TracerVarianceTendency"        "tracer variance tendency  2c ∂ₜc"
+@diagnostic_show TracerVarianceEquation.Diffusion       "TracerVarianceDiffusion"       "tracer variance diffusion  2c ∂ⱼFⱼ"
+@diagnostic_show TracerVarianceEquation.DissipationRate "TracerVarianceDissipationRate" "tracer variance dissipation rate  χ = 2 ∂ⱼc·Fⱼ"
+#--
+
+#++ KineticEnergyEquation
+@diagnostic_show KineticEnergyEquation.KineticEnergy                       "KineticEnergy"                       "kinetic energy  ½uᵢuᵢ"
+@diagnostic_show KineticEnergyEquation.KineticEnergyTendency               "KineticEnergyTendency"               "kinetic energy tendency  uᵢGᵢ (excl. nonhydrostatic pressure)"
+@diagnostic_show KineticEnergyEquation.KineticEnergyAdvection              "KineticEnergyAdvection"              "kinetic energy advection  uᵢ∂ⱼ(uᵢuⱼ)"
+@diagnostic_show KineticEnergyEquation.KineticEnergyStress                 "KineticEnergyStress"                 "kinetic energy stress/diffusion  uᵢ∂ⱼτᵢⱼ"
+@diagnostic_show KineticEnergyEquation.KineticEnergyForcing                "KineticEnergyForcing"                "kinetic energy forcing  uᵢFᵤᵢ"
+@diagnostic_show KineticEnergyEquation.KineticEnergyPressureRedistribution "KineticEnergyPressureRedistribution" "kinetic energy pressure redistribution  uᵢ∂ᵢp"
+@diagnostic_show KineticEnergyEquation.KineticEnergyBuoyancyProduction     "KineticEnergyBuoyancyProduction"     "kinetic energy buoyancy production  uᵢbᵢ"
+@diagnostic_show KineticEnergyEquation.KineticEnergyDissipationRate        "KineticEnergyDissipationRate"        "kinetic energy dissipation rate  ε = ∂ⱼuᵢ·Fᵢⱼ"
+@diagnostic_show KineticEnergyEquation.KineticEnergyIsotropicDissipationRate "KineticEnergyIsotropicDissipationRate" "isotropic kinetic energy dissipation rate  ε = 2νSᵢⱼSᵢⱼ"
+#--
+
+#++ TurbulentKineticEnergyEquation
+@diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergy                "TurbulentKineticEnergy"                "turbulent kinetic energy  ½uᵢ′uᵢ′"
+@diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergyXShearProductionRate "TurbulentKineticEnergyXShearProductionRate" "TKE shear production (x)  -uᵢ′u′ ∂ₓUᵢ"
+@diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergyYShearProductionRate "TurbulentKineticEnergyYShearProductionRate" "TKE shear production (y)  -uᵢ′v′ ∂_yUᵢ"
+@diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergyZShearProductionRate "TurbulentKineticEnergyZShearProductionRate" "TKE shear production (z)  -uᵢ′w′ ∂_zUᵢ"
+@diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergyShearProductionRate  "TurbulentKineticEnergyShearProductionRate"  "total TKE shear production  -uᵢ′uⱼ′ ∂ⱼUᵢ"
+#--
+
+#++ PotentialEnergyEquation
+@diagnostic_show PotentialEnergyEquation.PotentialEnergy "PotentialEnergy" "potential energy per unit volume  Eₚ = -bz"
+#--
+
+#++ FlowDiagnostics
+@diagnostic_show FlowDiagnostics.RichardsonNumber                  "RichardsonNumber"                  "Richardson number  Ri = (∂b/∂z) / |∂u⃗ₕ/∂z|²"
+@diagnostic_show FlowDiagnostics.RossbyNumber                      "RossbyNumber"                      "Rossby number  Ro = ωᶻ/f"
+@diagnostic_show FlowDiagnostics.ErtelPotentialVorticity           "ErtelPotentialVorticity"           "Ertel potential vorticity  q = ω⃗ₜₒₜ · ∇b"
+@diagnostic_show FlowDiagnostics.ThermalWindPotentialVorticity     "ThermalWindPotentialVorticity"     "Ertel PV, thermal-wind form  q = (f + ωᶻ)∂b/∂z - f((∂U/∂z)² + (∂V/∂z)²)"
+@diagnostic_show FlowDiagnostics.DirectionalErtelPotentialVorticity "DirectionalErtelPotentialVorticity" "directional contribution to Ertel PV  (f̂ + ω̂)·∇b along a direction"
+@diagnostic_show FlowDiagnostics.StrainRateTensorModulus           "StrainRateTensorModulus"           "strain-rate tensor modulus  √(SᵢⱼSᵢⱼ)"
+@diagnostic_show FlowDiagnostics.VorticityTensorModulus            "VorticityTensorModulus"            "vorticity tensor modulus  √(ΩᵢⱼΩᵢⱼ)"
+@diagnostic_show FlowDiagnostics.QVelocityGradientTensorInvariant  "QVelocityGradientTensorInvariant"  "Q velocity-gradient invariant  Q = ½(ΩᵢⱼΩᵢⱼ - SᵢⱼSᵢⱼ)"
+@diagnostic_show CustomKFO{<:FlowDiagnostics.MixedLayerDepthKernel} "MixedLayerDepth"                  "mixed layer depth (shallowest depth where the criterion is met)"
+#--
+
+#++ Filters
+@diagnostic_show Filters.BoxFilter      "BoxFilter"      "local box-average (running mean) of the operand"
+@diagnostic_show Filters.GaussianFilter "GaussianFilter" "local Gaussian-weighted average of the operand"
+#--
+#---
+
 end # module

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -194,16 +194,73 @@ using .ProgressMessengers
 
 #+++ Custom `show` for diagnostics
 # Every diagnostic is a `KernelFunctionOperation` (KFO) under the hood, so by default it prints as the
-# generic `KernelFunctionOperation at (…)`. Here we give each diagnostic alias its own header — keeping
-# the `(KernelFunctionOperation)` tag so it stays clear that the object *is* still a KFO — plus a one-line
-# description of what it computes. Everything else (grid, kernel_function, arguments) is delegated to
-# Oceananigans' KFO `show` via `invoke`, so we don't duplicate (or drift from) its tree layout.
+# generic `KernelFunctionOperation at (…)`. Here we give each diagnostic alias its own header
+# (`<Name> KernelFunctionOperation at (…)`, so it stays clear the object *is* still a KFO) plus a
+# one-line description of what it computes. On color-capable streams the leading `<Name>` and the
+# description are tinted with `DESCRIPTION_CRAYON`; everything else (grid, kernel_function, arguments)
+# is delegated to Oceananigans' KFO `show`, so we don't duplicate (or drift from) its tree layout.
 import Oceananigans.AbstractOperations: operation_name
+using Crayons
+export DESCRIPTION_CRAYON, set_description_color!, Crayon, @crayon_str
 
-"Print Oceananigans' KFO tree for `op`, then a `└── computes: …` line with the diagnostic's `description`."
-function _show_diagnostic(io::IO, op, description)
-    invoke(show, Tuple{IO, KernelFunctionOperation}, io, op)
-    isempty(description) || print(io, "\n└── computes: ", description)
+"""
+    DESCRIPTION_CRAYON :: Ref{Crayon}
+
+Process-global `Crayon` used to color a diagnostic's `show` output — both the leading diagnostic name
+in the header (e.g. `KineticEnergy`) and the `└── computes: …` description line. It is only applied
+when the output stream supports color (`get(io, :color, false)`), so doctests and color-less streams
+still print plain text. Reassign with [`set_description_color!`](@ref) (or `DESCRIPTION_CRAYON[] = ...`)
+to change the color at runtime.
+
+```jldoctest
+julia> using Oceanostics
+
+julia> DESCRIPTION_CRAYON[] isa Crayon
+true
+```
+"""
+const DESCRIPTION_CRAYON = Ref(crayon"cyan")
+
+"""
+    set_description_color!(c::Crayon)
+
+Configure the [`Crayon`](https://github.com/KristofferC/Crayons.jl) used to color a diagnostic's
+`show` output (the header's diagnostic name and the `└── computes: …` description line).
+
+```jldoctest
+julia> using Oceanostics
+
+julia> set_description_color!(crayon"magenta");
+
+julia> DESCRIPTION_CRAYON[] == crayon"magenta"
+true
+```
+"""
+set_description_color!(c::Crayon) = (DESCRIPTION_CRAYON[] = c)
+
+"""
+Print Oceananigans' KFO tree for `op`, then a `└── computes: …` line with the diagnostic's
+`description`. On color-capable streams the leading `name` in the header and the description are tinted
+with `DESCRIPTION_CRAYON`. The tree is rendered through Oceananigans' own KFO `show` (into a buffer) so
+its layout is reused verbatim; we only recolor the diagnostic name, which is the header's prefix.
+"""
+function _show_diagnostic(io::IO, op, name, description)
+    buf = IOBuffer()
+    invoke(show, Tuple{IO, KernelFunctionOperation}, IOContext(buf, :color => false), op)
+    body = String(take!(buf))
+    colored = get(io, :color, false)
+    if colored
+        c = DESCRIPTION_CRAYON[]
+        body = replace(body, name => string(c, name, inv(c)); count = 1) # header starts with `name`
+    end
+    print(io, body)
+    isempty(description) && return nothing
+    if colored
+        c = DESCRIPTION_CRAYON[]
+        print(io, "\n└── ", c, "computes: ", description, inv(c))
+    else
+        print(io, "\n└── computes: ", description)
+    end
     return nothing
 end
 
@@ -211,18 +268,19 @@ end
     @diagnostic_show T name [description]
 
 Give the `CustomKFO` type alias `T` a custom display: rename its `show`/`summary` header to
-`"<name> (KernelFunctionOperation)"`, and (when `description` is non-empty) append a
-`└── computes: <description>` line to its multi-line `show`. The header rename goes through
-Oceananigans' `operation_name`, so it also propagates to `summary(op)` and to `op`'s appearance
-inside larger operation trees and `Field` operand lines.
+`"<name> KernelFunctionOperation"`, and (when `description` is non-empty) append a
+`└── computes: <description>` line to its multi-line `show`. On color-capable streams the leading
+`<name>` and the description are tinted with [`DESCRIPTION_CRAYON`](@ref). The header rename goes
+through Oceananigans' `operation_name`, so it also propagates (uncolored) to `summary(op)` and to
+`op`'s appearance inside larger operation trees and `Field` operand lines.
 """
 macro diagnostic_show(T, name, description="")
     T = esc(T)
     quote
         # `operation_name` is escaped so the method extends the function imported from Oceananigans
         # (hygiene would otherwise treat the unqualified name as a fresh, separate binding).
-        $(esc(:operation_name))(::$T) = $name * " (KernelFunctionOperation)"
-        Base.show(io::IO, op::$T) = _show_diagnostic(io, op, $description)
+        $(esc(:operation_name))(::$T) = $name * " KernelFunctionOperation"
+        Base.show(io::IO, op::$T) = _show_diagnostic(io, op, $name, $description)
     end
 end
 

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -268,14 +268,14 @@ macro diagnostic_show(T, name, description="")
     end
 end
 
-#++ TracerEquation
+#+++ TracerEquation
 @diagnostic_show TracerEquation.Advection         "TracerAdvection"          "tracer advection  ∂ⱼ(uⱼc)"
 @diagnostic_show TracerEquation.Diffusion         "TracerDiffusion"          "tracer diffusion (interior)  ∂ⱼqᶜⱼ"
 @diagnostic_show TracerEquation.ImmersedDiffusion "TracerImmersedDiffusion"  "tracer diffusion through immersed boundaries  ∂ⱼ𝓆ᶜⱼ"
 @diagnostic_show TracerEquation.TotalDiffusion    "TracerTotalDiffusion"     "total tracer diffusion (interior + immersed)  ∂ⱼqᶜⱼ + ∂ⱼ𝓆ᶜⱼ"
-#--
+#---
 
-#++ UMomentumEquation
+#+++ UMomentumEquation
 @diagnostic_show UMomentumEquation.Advection                  "UAdvection"                  "advection of u-momentum  ∂ⱼ(uⱼu)"
 @diagnostic_show UMomentumEquation.BuoyancyAcceleration       "UBuoyancyAcceleration"       "buoyancy acceleration (x)  ĝₓ b"
 @diagnostic_show UMomentumEquation.CoriolisAcceleration       "UCoriolisAcceleration"       "Coriolis acceleration (x)  (f⃗ × u⃗)ₓ"
@@ -286,9 +286,9 @@ end
 @diagnostic_show UMomentumEquation.StokesShear                "UStokesShear"                "Stokes shear forcing (x)  ((∇ × u⃗ˢ) × u⃗)ₓ"
 @diagnostic_show UMomentumEquation.StokesTendency             "UStokesTendency"             "Stokes drift tendency (x)  ∂uˢ/∂t"
 @diagnostic_show UMomentumEquation.Tendency                   "UTendency"                   "total tendency of the u-momentum equation"
-#--
+#---
 
-#++ VMomentumEquation
+#+++ VMomentumEquation
 @diagnostic_show VMomentumEquation.Advection                  "VAdvection"                  "advection of v-momentum  ∂ⱼ(uⱼv)"
 @diagnostic_show VMomentumEquation.BuoyancyAcceleration       "VBuoyancyAcceleration"       "buoyancy acceleration (y)  ĝ_y b"
 @diagnostic_show VMomentumEquation.CoriolisAcceleration       "VCoriolisAcceleration"       "Coriolis acceleration (y)  (f⃗ × u⃗)_y"
@@ -299,9 +299,9 @@ end
 @diagnostic_show VMomentumEquation.StokesShear                "VStokesShear"                "Stokes shear forcing (y)  ((∇ × u⃗ˢ) × u⃗)_y"
 @diagnostic_show VMomentumEquation.StokesTendency             "VStokesTendency"             "Stokes drift tendency (y)  ∂vˢ/∂t"
 @diagnostic_show VMomentumEquation.Tendency                   "VTendency"                   "total tendency of the v-momentum equation"
-#--
+#---
 
-#++ WMomentumEquation
+#+++ WMomentumEquation
 @diagnostic_show WMomentumEquation.Advection                  "WAdvection"                  "advection of w-momentum  ∂ⱼ(uⱼw)"
 @diagnostic_show WMomentumEquation.BuoyancyAcceleration       "WBuoyancyAcceleration"       "buoyancy acceleration (z)  ĝ_z b"
 @diagnostic_show WMomentumEquation.CoriolisAcceleration       "WCoriolisAcceleration"       "Coriolis acceleration (z)  (f⃗ × u⃗)_z"
@@ -311,16 +311,16 @@ end
 @diagnostic_show WMomentumEquation.StokesShear                "WStokesShear"                "Stokes shear forcing (z)  ((∇ × u⃗ˢ) × u⃗)_z"
 @diagnostic_show WMomentumEquation.StokesTendency             "WStokesTendency"             "Stokes drift tendency (z)  ∂wˢ/∂t"
 @diagnostic_show WMomentumEquation.Tendency                   "WTendency"                   "total tendency of the w-momentum equation"
-#--
+#---
 
-#++ TracerVarianceEquation
+#+++ TracerVarianceEquation
 @diagnostic_show TracerVarianceEquation.Tendency        "TracerVarianceTendency"        "tracer variance tendency  2c ∂ₜc"
 @diagnostic_show TracerVarianceEquation.Diffusion       "TracerVarianceDiffusion"       "tracer variance diffusion  2c ∂ⱼFⱼ"
 @diagnostic_show TracerVarianceEquation.DissipationRate "TracerVarianceDissipationRate" "tracer variance dissipation rate  χ = 2 ∂ⱼc·Fⱼ"
-#--
+#---
 
-#++ KineticEnergyEquation
-@diagnostic_show KineticEnergyEquation.KineticEnergy                       "KineticEnergy"                       "kinetic energy  ½uᵢuᵢ"
+#+++ KineticEnergyEquation
+@diagnostic_show KineticEnergyEquation.KineticEnergy                      "KineticEnergy"                       "kinetic energy  ½uᵢuᵢ"
 @diagnostic_show KineticEnergyEquation.KineticEnergyTendency               "KineticEnergyTendency"               "kinetic energy tendency  uᵢGᵢ (excl. nonhydrostatic pressure)"
 @diagnostic_show KineticEnergyEquation.KineticEnergyAdvection              "KineticEnergyAdvection"              "kinetic energy advection  uᵢ∂ⱼ(uᵢuⱼ)"
 @diagnostic_show KineticEnergyEquation.KineticEnergyStress                 "KineticEnergyStress"                 "kinetic energy stress/diffusion  uᵢ∂ⱼτᵢⱼ"
@@ -329,21 +329,21 @@ end
 @diagnostic_show KineticEnergyEquation.KineticEnergyBuoyancyProduction     "KineticEnergyBuoyancyProduction"     "kinetic energy buoyancy production  uᵢbᵢ"
 @diagnostic_show KineticEnergyEquation.KineticEnergyDissipationRate        "KineticEnergyDissipationRate"        "kinetic energy dissipation rate  ε = ∂ⱼuᵢ·Fᵢⱼ"
 @diagnostic_show KineticEnergyEquation.KineticEnergyIsotropicDissipationRate "KineticEnergyIsotropicDissipationRate" "isotropic kinetic energy dissipation rate  ε = 2νSᵢⱼSᵢⱼ"
-#--
+#---
 
-#++ TurbulentKineticEnergyEquation
-@diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergy                "TurbulentKineticEnergy"                "turbulent kinetic energy  ½uᵢ′uᵢ′"
+#+++ TurbulentKineticEnergyEquation
+@diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergy               "TurbulentKineticEnergy"                "turbulent kinetic energy  ½uᵢ′uᵢ′"
 @diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergyXShearProductionRate "TurbulentKineticEnergyXShearProductionRate" "TKE shear production (x)  -uᵢ′u′ ∂ₓUᵢ"
 @diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergyYShearProductionRate "TurbulentKineticEnergyYShearProductionRate" "TKE shear production (y)  -uᵢ′v′ ∂_yUᵢ"
 @diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergyZShearProductionRate "TurbulentKineticEnergyZShearProductionRate" "TKE shear production (z)  -uᵢ′w′ ∂_zUᵢ"
 @diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergyShearProductionRate  "TurbulentKineticEnergyShearProductionRate"  "total TKE shear production  -uᵢ′uⱼ′ ∂ⱼUᵢ"
-#--
+#---
 
-#++ PotentialEnergyEquation
+#+++ PotentialEnergyEquation
 @diagnostic_show PotentialEnergyEquation.PotentialEnergy "PotentialEnergy" "potential energy per unit volume  Eₚ = -bz"
-#--
+#---
 
-#++ FlowDiagnostics
+#+++ FlowDiagnostics
 @diagnostic_show FlowDiagnostics.RichardsonNumber                  "RichardsonNumber"                  "Richardson number  Ri = (∂b/∂z) / |∂u⃗ₕ/∂z|²"
 @diagnostic_show FlowDiagnostics.RossbyNumber                      "RossbyNumber"                      "Rossby number  Ro = ωᶻ/f"
 @diagnostic_show FlowDiagnostics.ErtelPotentialVorticity           "ErtelPotentialVorticity"           "Ertel potential vorticity  q = ω⃗ₜₒₜ · ∇b"
@@ -353,12 +353,12 @@ end
 @diagnostic_show FlowDiagnostics.VorticityTensorModulus            "VorticityTensorModulus"            "vorticity tensor modulus  √(ΩᵢⱼΩᵢⱼ)"
 @diagnostic_show FlowDiagnostics.QVelocityGradientTensorInvariant  "QVelocityGradientTensorInvariant"  "Q velocity-gradient invariant  Q = ½(ΩᵢⱼΩᵢⱼ - SᵢⱼSᵢⱼ)"
 @diagnostic_show CustomKFO{<:FlowDiagnostics.MixedLayerDepthKernel} "MixedLayerDepth"                  "mixed layer depth (shallowest depth where the criterion is met)"
-#--
+#---
 
-#++ Filters
+#+++ Filters
 @diagnostic_show Filters.BoxFilter      "BoxFilter"      "local box-average (running mean) of the operand"
 @diagnostic_show Filters.GaussianFilter "GaussianFilter" "local Gaussian-weighted average of the operand"
-#--
+#---
 #---
 
 end # module

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -320,19 +320,19 @@ end
 #---
 
 #+++ KineticEnergyEquation
-@diagnostic_show KineticEnergyEquation.KineticEnergy                      "KineticEnergy"                       "kinetic energy  ½uᵢuᵢ"
-@diagnostic_show KineticEnergyEquation.KineticEnergyTendency               "KineticEnergyTendency"               "kinetic energy tendency  uᵢGᵢ (excl. nonhydrostatic pressure)"
-@diagnostic_show KineticEnergyEquation.KineticEnergyAdvection              "KineticEnergyAdvection"              "kinetic energy advection  uᵢ∂ⱼ(uᵢuⱼ)"
-@diagnostic_show KineticEnergyEquation.KineticEnergyStress                 "KineticEnergyStress"                 "kinetic energy stress/diffusion  uᵢ∂ⱼτᵢⱼ"
-@diagnostic_show KineticEnergyEquation.KineticEnergyForcing                "KineticEnergyForcing"                "kinetic energy forcing  uᵢFᵤᵢ"
-@diagnostic_show KineticEnergyEquation.KineticEnergyPressureRedistribution "KineticEnergyPressureRedistribution" "kinetic energy pressure redistribution  uᵢ∂ᵢp"
-@diagnostic_show KineticEnergyEquation.KineticEnergyBuoyancyProduction     "KineticEnergyBuoyancyProduction"     "kinetic energy buoyancy production  uᵢbᵢ"
-@diagnostic_show KineticEnergyEquation.KineticEnergyDissipationRate        "KineticEnergyDissipationRate"        "kinetic energy dissipation rate  ε = ∂ⱼuᵢ·Fᵢⱼ"
+@diagnostic_show KineticEnergyEquation.KineticEnergy                         "KineticEnergy"                       "kinetic energy  ½uᵢuᵢ"
+@diagnostic_show KineticEnergyEquation.KineticEnergyTendency                 "KineticEnergyTendency"               "kinetic energy tendency  uᵢGᵢ (excl. nonhydrostatic pressure)"
+@diagnostic_show KineticEnergyEquation.KineticEnergyAdvection                "KineticEnergyAdvection"              "kinetic energy advection  uᵢ∂ⱼ(uᵢuⱼ)"
+@diagnostic_show KineticEnergyEquation.KineticEnergyStress                   "KineticEnergyStress"                 "kinetic energy stress/diffusion  uᵢ∂ⱼτᵢⱼ"
+@diagnostic_show KineticEnergyEquation.KineticEnergyForcing                  "KineticEnergyForcing"                "kinetic energy forcing  uᵢFᵤᵢ"
+@diagnostic_show KineticEnergyEquation.KineticEnergyPressureRedistribution   "KineticEnergyPressureRedistribution" "kinetic energy pressure redistribution  uᵢ∂ᵢp"
+@diagnostic_show KineticEnergyEquation.KineticEnergyBuoyancyProduction       "KineticEnergyBuoyancyProduction"     "kinetic energy buoyancy production  uᵢbᵢ"
+@diagnostic_show KineticEnergyEquation.KineticEnergyDissipationRate          "KineticEnergyDissipationRate"        "kinetic energy dissipation rate  ε = ∂ⱼuᵢ·Fᵢⱼ"
 @diagnostic_show KineticEnergyEquation.KineticEnergyIsotropicDissipationRate "KineticEnergyIsotropicDissipationRate" "isotropic kinetic energy dissipation rate  ε = 2νSᵢⱼSᵢⱼ"
 #---
 
 #+++ TurbulentKineticEnergyEquation
-@diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergy               "TurbulentKineticEnergy"                "turbulent kinetic energy  ½uᵢ′uᵢ′"
+@diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergy                     "TurbulentKineticEnergy"                     "turbulent kinetic energy  ½uᵢ′uᵢ′"
 @diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergyXShearProductionRate "TurbulentKineticEnergyXShearProductionRate" "TKE shear production (x)  -uᵢ′u′ ∂ₓUᵢ"
 @diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergyYShearProductionRate "TurbulentKineticEnergyYShearProductionRate" "TKE shear production (y)  -uᵢ′v′ ∂_yUᵢ"
 @diagnostic_show TurbulentKineticEnergyEquation.TurbulentKineticEnergyZShearProductionRate "TurbulentKineticEnergyZShearProductionRate" "TKE shear production (z)  -uᵢ′w′ ∂_zUᵢ"
@@ -344,15 +344,15 @@ end
 #---
 
 #+++ FlowDiagnostics
-@diagnostic_show FlowDiagnostics.RichardsonNumber                  "RichardsonNumber"                  "Richardson number  Ri = (∂b/∂z) / |∂u⃗ₕ/∂z|²"
-@diagnostic_show FlowDiagnostics.RossbyNumber                      "RossbyNumber"                      "Rossby number  Ro = ωᶻ/f"
-@diagnostic_show FlowDiagnostics.ErtelPotentialVorticity           "ErtelPotentialVorticity"           "Ertel potential vorticity  q = ω⃗ₜₒₜ · ∇b"
-@diagnostic_show FlowDiagnostics.ThermalWindPotentialVorticity     "ThermalWindPotentialVorticity"     "Ertel PV, thermal-wind form  q = (f + ωᶻ)∂b/∂z - f((∂U/∂z)² + (∂V/∂z)²)"
+@diagnostic_show FlowDiagnostics.RichardsonNumber                   "RichardsonNumber"                   "Richardson number  Ri = (∂b/∂z) / |∂u⃗ₕ/∂z|²"
+@diagnostic_show FlowDiagnostics.RossbyNumber                       "RossbyNumber"                       "Rossby number  Ro = ωᶻ/f"
+@diagnostic_show FlowDiagnostics.ErtelPotentialVorticity            "ErtelPotentialVorticity"            "Ertel potential vorticity  q = ω⃗ₜₒₜ · ∇b"
+@diagnostic_show FlowDiagnostics.ThermalWindPotentialVorticity      "ThermalWindPotentialVorticity"      "Ertel PV, thermal-wind form  q = (f + ωᶻ)∂b/∂z - f((∂U/∂z)² + (∂V/∂z)²)"
 @diagnostic_show FlowDiagnostics.DirectionalErtelPotentialVorticity "DirectionalErtelPotentialVorticity" "directional contribution to Ertel PV  (f̂ + ω̂)·∇b along a direction"
-@diagnostic_show FlowDiagnostics.StrainRateTensorModulus           "StrainRateTensorModulus"           "strain-rate tensor modulus  √(SᵢⱼSᵢⱼ)"
-@diagnostic_show FlowDiagnostics.VorticityTensorModulus            "VorticityTensorModulus"            "vorticity tensor modulus  √(ΩᵢⱼΩᵢⱼ)"
-@diagnostic_show FlowDiagnostics.QVelocityGradientTensorInvariant  "QVelocityGradientTensorInvariant"  "Q velocity-gradient invariant  Q = ½(ΩᵢⱼΩᵢⱼ - SᵢⱼSᵢⱼ)"
-@diagnostic_show CustomKFO{<:FlowDiagnostics.MixedLayerDepthKernel} "MixedLayerDepth"                  "mixed layer depth (shallowest depth where the criterion is met)"
+@diagnostic_show FlowDiagnostics.StrainRateTensorModulus            "StrainRateTensorModulus"            "strain-rate tensor modulus  √(SᵢⱼSᵢⱼ)"
+@diagnostic_show FlowDiagnostics.VorticityTensorModulus             "VorticityTensorModulus"             "vorticity tensor modulus  √(ΩᵢⱼΩᵢⱼ)"
+@diagnostic_show FlowDiagnostics.QVelocityGradientTensorInvariant   "QVelocityGradientTensorInvariant"   "Q velocity-gradient invariant  Q = ½(ΩᵢⱼΩᵢⱼ - SᵢⱼSᵢⱼ)"
+@diagnostic_show CustomKFO{<:FlowDiagnostics.MixedLayerDepthKernel} "MixedLayerDepth"                    "mixed layer depth (shallowest depth where the criterion is met)"
 #---
 
 #+++ Filters

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -201,7 +201,7 @@ using .ProgressMessengers
 # is delegated to Oceananigans' KFO `show`, so we don't duplicate (or drift from) its tree layout.
 import Oceananigans.AbstractOperations: operation_name
 using Crayons
-export DESCRIPTION_CRAYON, set_description_color!, Crayon, @crayon_str
+export DESCRIPTION_CRAYON, set_description_color!
 
 const DESCRIPTION_CRAYON = Ref(crayon"#00BFFF")
 
@@ -209,10 +209,11 @@ const DESCRIPTION_CRAYON = Ref(crayon"#00BFFF")
     set_description_color!(c::Crayon)
 
 Configure the [`Crayon`](https://github.com/KristofferC/Crayons.jl) used to color a diagnostic's
-`show` output (the header's diagnostic name and the `└── computes: …` description line).
+`show` output (the header's diagnostic name and the `└── computes: …` description line). Build a
+`Crayon` with `Crayons.jl` (`using Crayons`), e.g. `crayon"red"` or `Crayon(foreground = :red)`.
 
 ```jldoctest
-julia> using Oceanostics
+julia> using Oceanostics, Crayons
 
 julia> set_description_color!(crayon"magenta");
 

--- a/src/PotentialEnergyEquation.jl
+++ b/src/PotentialEnergyEquation.jl
@@ -74,10 +74,11 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 └── coriolis: Nothing
 
 julia> PotentialEnergyEquation.PotentialEnergy(model)
-KernelFunctionOperation at (Center, Center, Center)
+PotentialEnergy (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: minus_bz_ccc (generic function with 3 methods)
 └── arguments: ("Field",)
+└── computes: potential energy per unit volume  Eₚ = -bz
 ```
 
 The default behaviour of `PotentialEnergy` uses the *in-situ density* in the calculation
@@ -115,10 +116,11 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 └── coriolis: Nothing
 
 julia> PotentialEnergyEquation.PotentialEnergy(model)
-KernelFunctionOperation at (Center, Center, Center)
+PotentialEnergy (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: minus_bz_ccc (generic function with 3 methods)
 └── arguments: ("KernelFunctionOperation", "NamedTuple")
+└── computes: potential energy per unit volume  Eₚ = -bz
 ```
 
 To use a reference density set a constant value for the keyword argument `geopotential_height`
@@ -139,10 +141,11 @@ julia> model = NonhydrostaticModel(grid; buoyancy, tracers);
 julia> geopotential_height = 0; # density variable will be σ₀
 
 julia> PotentialEnergyEquation.PotentialEnergy(model)
-KernelFunctionOperation at (Center, Center, Center)
+PotentialEnergy (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: minus_bz_ccc (generic function with 3 methods)
 └── arguments: ("KernelFunctionOperation", "NamedTuple")
+└── computes: potential energy per unit volume  Eₚ = -bz
 ```
 """
 @inline function PotentialEnergy(model; location = (Center, Center, Center),

--- a/src/PotentialEnergyEquation.jl
+++ b/src/PotentialEnergyEquation.jl
@@ -74,7 +74,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 └── coriolis: Nothing
 
 julia> PotentialEnergyEquation.PotentialEnergy(model)
-PotentialEnergy (KernelFunctionOperation) at (Center, Center, Center)
+PotentialEnergy KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: minus_bz_ccc (generic function with 3 methods)
 └── arguments: ("Field",)
@@ -116,7 +116,7 @@ NonhydrostaticModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 └── coriolis: Nothing
 
 julia> PotentialEnergyEquation.PotentialEnergy(model)
-PotentialEnergy (KernelFunctionOperation) at (Center, Center, Center)
+PotentialEnergy KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: minus_bz_ccc (generic function with 3 methods)
 └── arguments: ("KernelFunctionOperation", "NamedTuple")
@@ -141,7 +141,7 @@ julia> model = NonhydrostaticModel(grid; buoyancy, tracers);
 julia> geopotential_height = 0; # density variable will be σ₀
 
 julia> PotentialEnergyEquation.PotentialEnergy(model)
-PotentialEnergy (KernelFunctionOperation) at (Center, Center, Center)
+PotentialEnergy KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×100 RectilinearGrid{Float64, Flat, Flat, Bounded} on CPU with 0×0×3 halo
 ├── kernel_function: minus_bz_ccc (generic function with 3 methods)
 └── arguments: ("KernelFunctionOperation", "NamedTuple")

--- a/src/TracerEquation.jl
+++ b/src/TracerEquation.jl
@@ -46,10 +46,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:a);
 
 julia> ADV = TracerEquation.Advection(model, :a)
-KernelFunctionOperation at (Center, Center, Center)
+TracerAdvection (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: div_Uc (generic function with 10 methods)
+├── kernel_function: div_Uc (generic function with 12 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
+└── computes: tracer advection  ∂ⱼ(uⱼc)
 ```
 """
 function Advection(model, u, v, w, c, advection; location = (Center, Center, Center))
@@ -87,10 +88,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:a);
 
 julia> DIFF = TracerEquation.Diffusion(model, :a)
-KernelFunctionOperation at (Center, Center, Center)
+TracerDiffusion (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∇_dot_qᶜ (generic function with 10 methods)
 └── arguments: ("Nothing", "Nothing", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: tracer diffusion (interior)  ∂ⱼqᶜⱼ
 ```
 """
 function Diffusion(model, val_tracer_index, c, closure, closure_fields, clock, model_fields, buoyancy; location = (Center, Center, Center))
@@ -123,10 +125,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:a);
 
 julia> DIFF = TracerEquation.ImmersedDiffusion(model, :a)
-KernelFunctionOperation at (Center, Center, Center)
+TracerImmersedDiffusion (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: immersed_∇_dot_qᶜ (generic function with 2 methods)
 └── arguments: ("Field", "Nothing", "Nothing", "Nothing", "Val", "Clock", "NamedTuple")
+└── computes: tracer diffusion through immersed boundaries  ∂ⱼ𝓆ᶜⱼ
 ```
 """
 function ImmersedDiffusion(model, c, c_immersed_bc, closure, closure_fields, val_tracer_index, clock, model_fields; location = (Center, Center, Center))
@@ -159,10 +162,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:a);
 
 julia> DIFF = TracerEquation.TotalDiffusion(model, :a)
-KernelFunctionOperation at (Center, Center, Center)
+TracerTotalDiffusion (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: total_∇_dot_qᶜ (generic function with 1 method)
 └── arguments: ("Field", "Nothing", "Nothing", "Nothing", "Val", "Clock", "NamedTuple", "Nothing")
+└── computes: total tracer diffusion (interior + immersed)  ∂ⱼqᶜⱼ + ∂ⱼ𝓆ᶜⱼ
 ```
 """
 function TotalDiffusion(model, c, c_immersed_bc, closure, closure_fields, val_tracer_index, clock, model_fields, buoyancy; location = (Center, Center, Center))

--- a/src/TracerEquation.jl
+++ b/src/TracerEquation.jl
@@ -46,7 +46,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:a);
 
 julia> ADV = TracerEquation.Advection(model, :a)
-TracerAdvection (KernelFunctionOperation) at (Center, Center, Center)
+TracerAdvection KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: div_Uc (generic function with 12 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
@@ -88,7 +88,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:a);
 
 julia> DIFF = TracerEquation.Diffusion(model, :a)
-TracerDiffusion (KernelFunctionOperation) at (Center, Center, Center)
+TracerDiffusion KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∇_dot_qᶜ (generic function with 10 methods)
 └── arguments: ("Nothing", "Nothing", "Val", "Field", "Clock", "NamedTuple", "Nothing")
@@ -125,7 +125,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:a);
 
 julia> DIFF = TracerEquation.ImmersedDiffusion(model, :a)
-TracerImmersedDiffusion (KernelFunctionOperation) at (Center, Center, Center)
+TracerImmersedDiffusion KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: immersed_∇_dot_qᶜ (generic function with 2 methods)
 └── arguments: ("Field", "Nothing", "Nothing", "Nothing", "Val", "Clock", "NamedTuple")
@@ -162,7 +162,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:a);
 
 julia> DIFF = TracerEquation.TotalDiffusion(model, :a)
-TracerTotalDiffusion (KernelFunctionOperation) at (Center, Center, Center)
+TracerTotalDiffusion KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: total_∇_dot_qᶜ (generic function with 1 method)
 └── arguments: ("Field", "Nothing", "Nothing", "Nothing", "Val", "Clock", "NamedTuple", "Nothing")

--- a/src/TracerVarianceEquation.jl
+++ b/src/TracerVarianceEquation.jl
@@ -59,7 +59,7 @@ julia> grid = RectilinearGrid(size = (1, 1, 4), extent = (1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:b);
 
 julia> χ = TracerVarianceEquation.TracerVarianceTendency(model, :b)
-TracerVarianceTendency (KernelFunctionOperation) at (Center, Center, Center)
+TracerVarianceTendency KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: c∂ₜcᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("Val", "Val", "Centered", "Nothing", "Nothing", "Nothing", "Nothing", "Oceananigans.Models.NonhydrostaticModels.BackgroundFields", "NamedTuple", "NamedTuple", "NamedTuple", "Nothing", "Clock", "Returns")
@@ -119,7 +119,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:b, closure=SmagorinskyLilly());
 
 julia> DIFF = TracerVarianceEquation.TracerVarianceDiffusion(model, :b)
-TracerVarianceDiffusion (KernelFunctionOperation) at (Center, Center, Center)
+TracerVarianceDiffusion KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: c∇_dot_qᶜ (generic function with 1 method)
 └── arguments: ("Oceananigans.TurbulenceClosures.Smagorinskys.Smagorinsky", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
@@ -189,7 +189,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:b, closure=SmagorinskyLilly());
 
 julia> χ = TracerVarianceEquation.TracerVarianceDissipationRate(model, :b)
-TracerVarianceDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
+TracerVarianceDissipationRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: tracer_variance_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Oceananigans.TurbulenceClosures.Smagorinskys.Smagorinsky", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
@@ -200,7 +200,7 @@ julia> b̄ = Field(Average(model.tracers.b, dims=(1,2)));
 julia> b′ = model.tracers.b - b̄;
 
 julia> χb = TracerVarianceEquation.TracerVarianceDissipationRate(model, :b, tracer=b′)
-TracerVarianceDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
+TracerVarianceDissipationRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: tracer_variance_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Oceananigans.TurbulenceClosures.Smagorinskys.Smagorinsky", "NamedTuple", "Val", "Oceananigans.AbstractOperations.BinaryOperation", "Clock", "NamedTuple", "Nothing")

--- a/src/TracerVarianceEquation.jl
+++ b/src/TracerVarianceEquation.jl
@@ -59,10 +59,11 @@ julia> grid = RectilinearGrid(size = (1, 1, 4), extent = (1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:b);
 
 julia> χ = TracerVarianceEquation.TracerVarianceTendency(model, :b)
-KernelFunctionOperation at (Center, Center, Center)
+TracerVarianceTendency (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
 ├── kernel_function: c∂ₜcᶜᶜᶜ (generic function with 1 method)
 └── arguments: ("Val", "Val", "Centered", "Nothing", "Nothing", "Nothing", "Nothing", "Oceananigans.Models.NonhydrostaticModels.BackgroundFields", "NamedTuple", "NamedTuple", "NamedTuple", "Nothing", "Clock", "Returns")
+└── computes: tracer variance tendency  2c ∂ₜc
 ```
 """
 function TracerVarianceTendency(model::NonhydrostaticModel, tracer_name; location = (Center, Center, Center))
@@ -118,10 +119,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:b, closure=SmagorinskyLilly());
 
 julia> DIFF = TracerVarianceEquation.TracerVarianceDiffusion(model, :b)
-KernelFunctionOperation at (Center, Center, Center)
+TracerVarianceDiffusion (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: c∇_dot_qᶜ (generic function with 1 method)
 └── arguments: ("Oceananigans.TurbulenceClosures.Smagorinskys.Smagorinsky", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: tracer variance diffusion  2c ∂ⱼFⱼ
 ```
 """
 function TracerVarianceDiffusion(model, tracer_name; location = (Center, Center, Center))
@@ -187,20 +189,22 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; tracers=:b, closure=SmagorinskyLilly());
 
 julia> χ = TracerVarianceEquation.TracerVarianceDissipationRate(model, :b)
-KernelFunctionOperation at (Center, Center, Center)
+TracerVarianceDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: tracer_variance_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Oceananigans.TurbulenceClosures.Smagorinskys.Smagorinsky", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: tracer variance dissipation rate  χ = 2 ∂ⱼc·Fⱼ
 
 julia> b̄ = Field(Average(model.tracers.b, dims=(1,2)));
 
 julia> b′ = model.tracers.b - b̄;
 
 julia> χb = TracerVarianceEquation.TracerVarianceDissipationRate(model, :b, tracer=b′)
-KernelFunctionOperation at (Center, Center, Center)
+TracerVarianceDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: tracer_variance_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Oceananigans.TurbulenceClosures.Smagorinskys.Smagorinsky", "NamedTuple", "Val", "Oceananigans.AbstractOperations.BinaryOperation", "Clock", "NamedTuple", "Nothing")
+└── computes: tracer variance dissipation rate  χ = 2 ∂ⱼc·Fⱼ
 ```
 """
 function TracerVarianceDissipationRate(model, tracer_name; tracer = nothing, location = (Center, Center, Center))

--- a/src/TurbulentKineticEnergyEquation.jl
+++ b/src/TurbulentKineticEnergyEquation.jl
@@ -44,7 +44,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> TKE = TurbulentKineticEnergyEquation.TurbulentKineticEnergy(model)
-TurbulentKineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
+TurbulentKineticEnergy KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: turbulent_kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
@@ -79,7 +79,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; closure=ScalarDiffusivity(ν=1e-4));
 
 julia> TurbulentKineticEnergyEquation.IsotropicDissipationRate(model)
-KineticEnergyIsotropicDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
+KineticEnergyIsotropicDissipationRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: isotropic_viscous_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "NamedTuple")
@@ -137,7 +137,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> XSHEAR = TurbulentKineticEnergyEquation.XShearProductionRate(model)
-TurbulentKineticEnergyXShearProductionRate (KernelFunctionOperation) at (Center, Center, Center)
+TurbulentKineticEnergyXShearProductionRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: shear_production_rate_x_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
@@ -199,7 +199,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> YSHEAR = TurbulentKineticEnergyEquation.YShearProductionRate(model)
-TurbulentKineticEnergyYShearProductionRate (KernelFunctionOperation) at (Center, Center, Center)
+TurbulentKineticEnergyYShearProductionRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: shear_production_rate_y_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
@@ -260,7 +260,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> ZSHEAR = TurbulentKineticEnergyEquation.ZShearProductionRate(model)
-TurbulentKineticEnergyZShearProductionRate (KernelFunctionOperation) at (Center, Center, Center)
+TurbulentKineticEnergyZShearProductionRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: shear_production_rate_z_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
@@ -309,7 +309,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> SHEAR = TurbulentKineticEnergyEquation.ShearProductionRate(model)
-TurbulentKineticEnergyShearProductionRate (KernelFunctionOperation) at (Center, Center, Center)
+TurbulentKineticEnergyShearProductionRate KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: shear_production_rate_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")

--- a/src/TurbulentKineticEnergyEquation.jl
+++ b/src/TurbulentKineticEnergyEquation.jl
@@ -44,10 +44,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> TKE = TurbulentKineticEnergyEquation.TurbulentKineticEnergy(model)
-KernelFunctionOperation at (Center, Center, Center)
+TurbulentKineticEnergy (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: turbulent_kinetic_energy_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
+└── computes: turbulent kinetic energy  ½uᵢ′uᵢ′
 ```
 """
 function TurbulentKineticEnergy(model, u, v, w; U=ZeroField(), V=ZeroField(), W=ZeroField(), location = (Center, Center, Center))
@@ -78,10 +79,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; closure=ScalarDiffusivity(ν=1e-4));
 
 julia> TurbulentKineticEnergyEquation.IsotropicDissipationRate(model)
-KernelFunctionOperation at (Center, Center, Center)
+KineticEnergyIsotropicDissipationRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: isotropic_viscous_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "NamedTuple")
+└── computes: isotropic kinetic energy dissipation rate  ε = 2νSᵢⱼSᵢⱼ
 ```
 """
 @inline TurbulentKineticEnergyIsotropicDissipationRate(u, v, w, args...; U=ZeroField(), V=ZeroField(), W=ZeroField(), location = (Center, Center, Center)) =
@@ -135,10 +137,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> XSHEAR = TurbulentKineticEnergyEquation.XShearProductionRate(model)
-KernelFunctionOperation at (Center, Center, Center)
+TurbulentKineticEnergyXShearProductionRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: shear_production_rate_x_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
+└── computes: TKE shear production (x)  -uᵢ′u′ ∂ₓUᵢ
 ```
 """
 function TurbulentKineticEnergyXShearProductionRate(u′, v′, w′, U, V, W;
@@ -196,10 +199,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> YSHEAR = TurbulentKineticEnergyEquation.YShearProductionRate(model)
-KernelFunctionOperation at (Center, Center, Center)
+TurbulentKineticEnergyYShearProductionRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: shear_production_rate_y_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
+└── computes: TKE shear production (y)  -uᵢ′v′ ∂_yUᵢ
 ```
 """
 function TurbulentKineticEnergyYShearProductionRate(u′, v′, w′, U, V, W;
@@ -256,10 +260,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> ZSHEAR = TurbulentKineticEnergyEquation.ZShearProductionRate(model)
-KernelFunctionOperation at (Center, Center, Center)
+TurbulentKineticEnergyZShearProductionRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: shear_production_rate_z_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
+└── computes: TKE shear production (z)  -uᵢ′w′ ∂_zUᵢ
 ```
 """
 function TurbulentKineticEnergyZShearProductionRate(u′, v′, w′, U, V, W;
@@ -304,10 +309,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> SHEAR = TurbulentKineticEnergyEquation.ShearProductionRate(model)
-KernelFunctionOperation at (Center, Center, Center)
+TurbulentKineticEnergyShearProductionRate (KernelFunctionOperation) at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: shear_production_rate_ccc (generic function with 1 method)
 └── arguments: ("Field", "Field", "Field", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField", "Oceananigans.Fields.ZeroField")
+└── computes: total TKE shear production  -uᵢ′uⱼ′ ∂ⱼUᵢ
 ```
 """
 function TurbulentKineticEnergyShearProductionRate(u′, v′, w′, U, V, W;

--- a/src/UMomentumEquation.jl
+++ b/src/UMomentumEquation.jl
@@ -74,7 +74,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> ADV = UMomentumEquation.Advection(model)
-UAdvection (KernelFunctionOperation) at (Face, Center, Center)
+UAdvection KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: div_𝐯u (generic function with 4 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
@@ -109,7 +109,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> BUOY = UMomentumEquation.BuoyancyAcceleration(model)
-UBuoyancyAcceleration (KernelFunctionOperation) at (Face, Center, Center)
+UBuoyancyAcceleration KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: x_dot_g_bᶠᶜᶜ (generic function with 3 methods)
 └── arguments: ("BuoyancyForce", "NamedTuple")
@@ -142,7 +142,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; coriolis=FPlane(f=1e-4));
 
 julia> COR = UMomentumEquation.CoriolisAcceleration(model)
-UCoriolisAcceleration (KernelFunctionOperation) at (Face, Center, Center)
+UCoriolisAcceleration KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: x_f_cross_U (generic function with 11 methods)
 └── arguments: ("FPlane", "NamedTuple")
@@ -175,7 +175,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> PRES = UMomentumEquation.PressureGradient(model)
-UPressureGradient (KernelFunctionOperation) at (Face, Center, Center)
+UPressureGradient KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: hydrostatic_pressure_gradient_x (generic function with 2 methods)
 └── arguments: ("Nothing",)
@@ -220,7 +220,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = UMomentumEquation.ViscousDissipation(model)
-UViscousDissipation (KernelFunctionOperation) at (Face, Center, Center)
+UViscousDissipation KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∂ⱼ_τ₁ⱼ (generic function with 10 methods)
 └── arguments: ("Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
@@ -251,7 +251,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = UMomentumEquation.ImmersedViscousDissipation(model)
-UImmersedViscousDissipation (KernelFunctionOperation) at (Face, Center, Center)
+UImmersedViscousDissipation KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: immersed_∂ⱼ_τ₁ⱼ (generic function with 2 methods)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple")
@@ -286,7 +286,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = UMomentumEquation.TotalViscousDissipation(model)
-UTotalViscousDissipation (KernelFunctionOperation) at (Face, Center, Center)
+UTotalViscousDissipation KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: total_∂ⱼ_τ₁ⱼ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
@@ -322,7 +322,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = UMomentumEquation.StokesShear(model)
-UStokesShear (KernelFunctionOperation) at (Face, Center, Center)
+UStokesShear KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: x_curl_Uˢ_cross_U (generic function with 3 methods)
 └── arguments: ("Nothing", "NamedTuple", "Float64")
@@ -356,7 +356,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = UMomentumEquation.StokesTendency(model)
-UStokesTendency (KernelFunctionOperation) at (Face, Center, Center)
+UStokesTendency KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∂t_uˢ (generic function with 4 methods)
 └── arguments: ("Nothing", "Float64")
@@ -428,7 +428,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> TEND = UMomentumEquation.Tendency(model)
-UTendency (KernelFunctionOperation) at (Face, Center, Center)
+UTendency KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: u_velocity_tendency (generic function with 1 method)
 └── arguments: ("Centered", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Oceananigans.Models.NonhydrostaticModels.BackgroundFields", "NamedTuple", "NamedTuple", "NamedTuple", "Nothing", "Nothing", "Clock", "Returns")

--- a/src/UMomentumEquation.jl
+++ b/src/UMomentumEquation.jl
@@ -74,10 +74,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> ADV = UMomentumEquation.Advection(model)
-KernelFunctionOperation at (Face, Center, Center)
+UAdvection (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: div_𝐯u (generic function with 10 methods)
+├── kernel_function: div_𝐯u (generic function with 4 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
+└── computes: advection of u-momentum  ∂ⱼ(uⱼu)
 ```
 """
 function Advection(model, u, v, w, advection_scheme; location = (Face, Center, Center))
@@ -108,10 +109,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> BUOY = UMomentumEquation.BuoyancyAcceleration(model)
-KernelFunctionOperation at (Face, Center, Center)
+UBuoyancyAcceleration (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: x_dot_g_bᶠᶜᶜ (generic function with 10 methods)
+├── kernel_function: x_dot_g_bᶠᶜᶜ (generic function with 3 methods)
 └── arguments: ("BuoyancyForce", "NamedTuple")
+└── computes: buoyancy acceleration (x)  ĝₓ b
 ```
 """
 function BuoyancyAcceleration(model, buoyancy, tracers; location = (Face, Center, Center))
@@ -140,10 +142,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; coriolis=FPlane(f=1e-4));
 
 julia> COR = UMomentumEquation.CoriolisAcceleration(model)
-KernelFunctionOperation at (Face, Center, Center)
+UCoriolisAcceleration (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: x_f_cross_U (generic function with 10 methods)
+├── kernel_function: x_f_cross_U (generic function with 11 methods)
 └── arguments: ("FPlane", "NamedTuple")
+└── computes: Coriolis acceleration (x)  (f⃗ × u⃗)ₓ
 ```
 """
 function CoriolisAcceleration(model, coriolis, velocities; location = (Face, Center, Center))
@@ -172,10 +175,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> PRES = UMomentumEquation.PressureGradient(model)
-KernelFunctionOperation at (Face, Center, Center)
+UPressureGradient (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: hydrostatic_pressure_gradient_x (generic function with 2 methods)
 └── arguments: ("Nothing",)
+└── computes: hydrostatic pressure gradient (x)  ∂p/∂x
 ```
 """
 function PressureGradient(model, hydrostatic_pressure; location = (Face, Center, Center))
@@ -216,10 +220,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = UMomentumEquation.ViscousDissipation(model)
-KernelFunctionOperation at (Face, Center, Center)
+UViscousDissipation (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∂ⱼ_τ₁ⱼ (generic function with 10 methods)
 └── arguments: ("Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
+└── computes: viscous term (interior, x)  ∂ⱼτ₁ⱼ
 ```
 """
 function ViscousDissipation(model, closure, diffusivities, clock, model_fields, buoyancy; location = (Face, Center, Center))
@@ -246,10 +251,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = UMomentumEquation.ImmersedViscousDissipation(model)
-KernelFunctionOperation at (Face, Center, Center)
+UImmersedViscousDissipation (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: immersed_∂ⱼ_τ₁ⱼ (generic function with 2 methods)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple")
+└── computes: viscous term through immersed boundaries (x)  ∂ⱼτ₁ⱼ
 ```
 """
 function ImmersedViscousDissipation(model, velocities, u_immersed_bc, closure, diffusivities, clock, model_fields; location = (Face, Center, Center))
@@ -280,10 +286,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = UMomentumEquation.TotalViscousDissipation(model)
-KernelFunctionOperation at (Face, Center, Center)
+UTotalViscousDissipation (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: total_∂ⱼ_τ₁ⱼ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
+└── computes: total viscous term (interior + immersed, x)  ∂ⱼτ₁ⱼ
 ```
 """
 function TotalViscousDissipation(model, velocities, u_immersed_bc, closure, diffusivities, clock, model_fields, buoyancy; location = (Face, Center, Center))
@@ -315,10 +322,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = UMomentumEquation.StokesShear(model)
-KernelFunctionOperation at (Face, Center, Center)
+UStokesShear (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: x_curl_Uˢ_cross_U (generic function with 10 methods)
+├── kernel_function: x_curl_Uˢ_cross_U (generic function with 3 methods)
 └── arguments: ("Nothing", "NamedTuple", "Float64")
+└── computes: Stokes shear forcing (x)  ((∇ × u⃗ˢ) × u⃗)ₓ
 ```
 """
 function StokesShear(model, stokes_drift, velocities, time; location = (Face, Center, Center))
@@ -348,10 +356,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = UMomentumEquation.StokesTendency(model)
-KernelFunctionOperation at (Face, Center, Center)
+UStokesTendency (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: ∂t_uˢ (generic function with 10 methods)
+├── kernel_function: ∂t_uˢ (generic function with 4 methods)
 └── arguments: ("Nothing", "Float64")
+└── computes: Stokes drift tendency (x)  ∂uˢ/∂t
 ```
 """
 function StokesTendency(model, stokes_drift, time; location = (Face, Center, Center))
@@ -419,10 +428,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> TEND = UMomentumEquation.Tendency(model)
-KernelFunctionOperation at (Face, Center, Center)
+UTendency (KernelFunctionOperation) at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: u_velocity_tendency (generic function with 1 method)
 └── arguments: ("Centered", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Oceananigans.Models.NonhydrostaticModels.BackgroundFields", "NamedTuple", "NamedTuple", "NamedTuple", "Nothing", "Nothing", "Clock", "Returns")
+└── computes: total tendency of the u-momentum equation
 ```
 """
 function Tendency(model::HydrostaticFreeSurfaceModel, advection_scheme, coriolis, closure, u_immersed_bc, velocities, free_surface, tracers, buoyancy, closure_fields, hydrostatic_pressure_anomaly, auxiliary_fields, vertical_coordinate, clock, forcing_func; location = (Face, Center, Center))

--- a/src/VMomentumEquation.jl
+++ b/src/VMomentumEquation.jl
@@ -74,7 +74,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> ADV = VMomentumEquation.Advection(model)
-VAdvection (KernelFunctionOperation) at (Center, Face, Center)
+VAdvection KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: div_𝐯v (generic function with 4 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
@@ -109,7 +109,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> BUOY = VMomentumEquation.BuoyancyAcceleration(model)
-VBuoyancyAcceleration (KernelFunctionOperation) at (Center, Face, Center)
+VBuoyancyAcceleration KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: y_dot_g_bᶜᶠᶜ (generic function with 3 methods)
 └── arguments: ("BuoyancyForce", "NamedTuple")
@@ -142,7 +142,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; coriolis=FPlane(f=1e-4));
 
 julia> COR = VMomentumEquation.CoriolisAcceleration(model)
-VCoriolisAcceleration (KernelFunctionOperation) at (Center, Face, Center)
+VCoriolisAcceleration KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: y_f_cross_U (generic function with 11 methods)
 └── arguments: ("FPlane", "NamedTuple")
@@ -175,7 +175,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> PRES = VMomentumEquation.PressureGradient(model)
-VPressureGradient (KernelFunctionOperation) at (Center, Face, Center)
+VPressureGradient KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: hydrostatic_pressure_gradient_y (generic function with 2 methods)
 └── arguments: ("Nothing",)
@@ -220,7 +220,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = VMomentumEquation.ViscousDissipation(model)
-VViscousDissipation (KernelFunctionOperation) at (Center, Face, Center)
+VViscousDissipation KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∂ⱼ_τ₂ⱼ (generic function with 10 methods)
 └── arguments: ("Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
@@ -251,7 +251,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = VMomentumEquation.ImmersedViscousDissipation(model)
-VImmersedViscousDissipation (KernelFunctionOperation) at (Center, Face, Center)
+VImmersedViscousDissipation KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: immersed_∂ⱼ_τ₂ⱼ (generic function with 2 methods)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple")
@@ -286,7 +286,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = VMomentumEquation.TotalViscousDissipation(model)
-VTotalViscousDissipation (KernelFunctionOperation) at (Center, Face, Center)
+VTotalViscousDissipation KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: total_∂ⱼ_τ₂ⱼ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
@@ -322,7 +322,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = VMomentumEquation.StokesShear(model)
-VStokesShear (KernelFunctionOperation) at (Center, Face, Center)
+VStokesShear KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: y_curl_Uˢ_cross_U (generic function with 3 methods)
 └── arguments: ("Nothing", "NamedTuple", "Float64")
@@ -356,7 +356,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = VMomentumEquation.StokesTendency(model)
-VStokesTendency (KernelFunctionOperation) at (Center, Face, Center)
+VStokesTendency KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∂t_vˢ (generic function with 4 methods)
 └── arguments: ("Nothing", "Float64")
@@ -433,7 +433,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> TEND = VMomentumEquation.Tendency(model)
-VTendency (KernelFunctionOperation) at (Center, Face, Center)
+VTendency KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: v_velocity_tendency (generic function with 1 method)
 └── arguments: ("Centered", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Oceananigans.Models.NonhydrostaticModels.BackgroundFields", "NamedTuple", "NamedTuple", "NamedTuple", "Nothing", "Nothing", "Clock", "Returns")

--- a/src/VMomentumEquation.jl
+++ b/src/VMomentumEquation.jl
@@ -74,10 +74,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> ADV = VMomentumEquation.Advection(model)
-KernelFunctionOperation at (Center, Face, Center)
+VAdvection (KernelFunctionOperation) at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: div_𝐯v (generic function with 10 methods)
+├── kernel_function: div_𝐯v (generic function with 4 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
+└── computes: advection of v-momentum  ∂ⱼ(uⱼv)
 ```
 """
 function Advection(model, u, v, w, advection_scheme; location = (Center, Face, Center))
@@ -108,10 +109,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> BUOY = VMomentumEquation.BuoyancyAcceleration(model)
-KernelFunctionOperation at (Center, Face, Center)
+VBuoyancyAcceleration (KernelFunctionOperation) at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: y_dot_g_bᶜᶠᶜ (generic function with 10 methods)
+├── kernel_function: y_dot_g_bᶜᶠᶜ (generic function with 3 methods)
 └── arguments: ("BuoyancyForce", "NamedTuple")
+└── computes: buoyancy acceleration (y)  ĝ_y b
 ```
 """
 function BuoyancyAcceleration(model, buoyancy, tracers; location = (Center, Face, Center))
@@ -140,10 +142,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; coriolis=FPlane(f=1e-4));
 
 julia> COR = VMomentumEquation.CoriolisAcceleration(model)
-KernelFunctionOperation at (Center, Face, Center)
+VCoriolisAcceleration (KernelFunctionOperation) at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: y_f_cross_U (generic function with 10 methods)
+├── kernel_function: y_f_cross_U (generic function with 11 methods)
 └── arguments: ("FPlane", "NamedTuple")
+└── computes: Coriolis acceleration (y)  (f⃗ × u⃗)_y
 ```
 """
 function CoriolisAcceleration(model, coriolis, velocities; location = (Center, Face, Center))
@@ -172,10 +175,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> PRES = VMomentumEquation.PressureGradient(model)
-KernelFunctionOperation at (Center, Face, Center)
+VPressureGradient (KernelFunctionOperation) at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: hydrostatic_pressure_gradient_y (generic function with 2 methods)
 └── arguments: ("Nothing",)
+└── computes: hydrostatic pressure gradient (y)  ∂p/∂y
 ```
 """
 function PressureGradient(model, hydrostatic_pressure; location = (Center, Face, Center))
@@ -216,10 +220,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = VMomentumEquation.ViscousDissipation(model)
-KernelFunctionOperation at (Center, Face, Center)
+VViscousDissipation (KernelFunctionOperation) at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∂ⱼ_τ₂ⱼ (generic function with 10 methods)
 └── arguments: ("Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
+└── computes: viscous term (interior, y)  ∂ⱼτ₂ⱼ
 ```
 """
 function ViscousDissipation(model, closure, diffusivities, clock, model_fields, buoyancy; location = (Center, Face, Center))
@@ -246,10 +251,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = VMomentumEquation.ImmersedViscousDissipation(model)
-KernelFunctionOperation at (Center, Face, Center)
+VImmersedViscousDissipation (KernelFunctionOperation) at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: immersed_∂ⱼ_τ₂ⱼ (generic function with 2 methods)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple")
+└── computes: viscous term through immersed boundaries (y)  ∂ⱼτ₂ⱼ
 ```
 """
 function ImmersedViscousDissipation(model, velocities, v_immersed_bc, closure, diffusivities, clock, model_fields; location = (Center, Face, Center))
@@ -280,10 +286,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = VMomentumEquation.TotalViscousDissipation(model)
-KernelFunctionOperation at (Center, Face, Center)
+VTotalViscousDissipation (KernelFunctionOperation) at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: total_∂ⱼ_τ₂ⱼ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
+└── computes: total viscous term (interior + immersed, y)  ∂ⱼτ₂ⱼ
 ```
 """
 function TotalViscousDissipation(model, velocities, v_immersed_bc, closure, diffusivities, clock, model_fields, buoyancy; location = (Center, Face, Center))
@@ -315,10 +322,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = VMomentumEquation.StokesShear(model)
-KernelFunctionOperation at (Center, Face, Center)
+VStokesShear (KernelFunctionOperation) at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: y_curl_Uˢ_cross_U (generic function with 10 methods)
+├── kernel_function: y_curl_Uˢ_cross_U (generic function with 3 methods)
 └── arguments: ("Nothing", "NamedTuple", "Float64")
+└── computes: Stokes shear forcing (y)  ((∇ × u⃗ˢ) × u⃗)_y
 ```
 """
 function StokesShear(model, stokes_drift, velocities, time; location = (Center, Face, Center))
@@ -348,10 +356,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = VMomentumEquation.StokesTendency(model)
-KernelFunctionOperation at (Center, Face, Center)
+VStokesTendency (KernelFunctionOperation) at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: ∂t_vˢ (generic function with 10 methods)
+├── kernel_function: ∂t_vˢ (generic function with 4 methods)
 └── arguments: ("Nothing", "Float64")
+└── computes: Stokes drift tendency (y)  ∂vˢ/∂t
 ```
 """
 function StokesTendency(model, stokes_drift, time; location = (Center, Face, Center))
@@ -424,10 +433,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> TEND = VMomentumEquation.Tendency(model)
-KernelFunctionOperation at (Center, Face, Center)
+VTendency (KernelFunctionOperation) at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: v_velocity_tendency (generic function with 1 method)
 └── arguments: ("Centered", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Oceananigans.Models.NonhydrostaticModels.BackgroundFields", "NamedTuple", "NamedTuple", "NamedTuple", "Nothing", "Nothing", "Clock", "Returns")
+└── computes: total tendency of the v-momentum equation
 ```
 """
 function Tendency(model::HydrostaticFreeSurfaceModel, advection_scheme, coriolis, closure, v_immersed_bc, velocities, free_surface, tracers, buoyancy, closure_fields, hydrostatic_pressure_anomaly, auxiliary_fields, vertical_coordinate, clock, forcing_func; location = (Center, Face, Center))

--- a/src/WMomentumEquation.jl
+++ b/src/WMomentumEquation.jl
@@ -70,10 +70,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> ADV = WMomentumEquation.Advection(model)
-KernelFunctionOperation at (Center, Center, Face)
+WAdvection (KernelFunctionOperation) at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: div_𝐯w (generic function with 10 methods)
+├── kernel_function: div_𝐯w (generic function with 4 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
+└── computes: advection of w-momentum  ∂ⱼ(uⱼw)
 ```
 """
 function Advection(model, u, v, w, advection_scheme; location = (Center, Center, Face))
@@ -104,10 +105,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> BUOY = WMomentumEquation.BuoyancyAcceleration(model)
-KernelFunctionOperation at (Center, Center, Face)
+WBuoyancyAcceleration (KernelFunctionOperation) at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: z_dot_g_bᶜᶜᶠ (generic function with 10 methods)
+├── kernel_function: z_dot_g_bᶜᶜᶠ (generic function with 3 methods)
 └── arguments: ("BuoyancyForce", "NamedTuple")
+└── computes: buoyancy acceleration (z)  ĝ_z b
 ```
 """
 function BuoyancyAcceleration(model, buoyancy, tracers; location = (Center, Center, Face))
@@ -136,10 +138,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; coriolis=FPlane(f=1e-4));
 
 julia> COR = WMomentumEquation.CoriolisAcceleration(model)
-KernelFunctionOperation at (Center, Center, Face)
+WCoriolisAcceleration (KernelFunctionOperation) at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: z_f_cross_U (generic function with 10 methods)
+├── kernel_function: z_f_cross_U (generic function with 6 methods)
 └── arguments: ("FPlane", "NamedTuple")
+└── computes: Coriolis acceleration (z)  (f⃗ × u⃗)_z
 ```
 """
 function CoriolisAcceleration(model, coriolis, velocities; location = (Center, Center, Face))
@@ -168,10 +171,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = WMomentumEquation.ViscousDissipation(model)
-KernelFunctionOperation at (Center, Center, Face)
+WViscousDissipation (KernelFunctionOperation) at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: ∂ⱼ_τ₃ⱼ (generic function with 10 methods)
+├── kernel_function: ∂ⱼ_τ₃ⱼ (generic function with 8 methods)
 └── arguments: ("Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
+└── computes: viscous term (interior, z)  ∂ⱼτ₃ⱼ
 ```
 """
 function ViscousDissipation(model, closure, diffusivities, clock, model_fields, buoyancy; location = (Center, Center, Face))
@@ -198,10 +202,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = WMomentumEquation.ImmersedViscousDissipation(model)
-KernelFunctionOperation at (Center, Center, Face)
+WImmersedViscousDissipation (KernelFunctionOperation) at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: immersed_∂ⱼ_τ₃ⱼ (generic function with 2 methods)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple")
+└── computes: viscous term through immersed boundaries (z)  ∂ⱼτ₃ⱼ
 ```
 """
 function ImmersedViscousDissipation(model, velocities, w_immersed_bc, closure, diffusivities, clock, model_fields; location = (Center, Center, Face))
@@ -232,10 +237,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = WMomentumEquation.TotalViscousDissipation(model)
-KernelFunctionOperation at (Center, Center, Face)
+WTotalViscousDissipation (KernelFunctionOperation) at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: total_∂ⱼ_τ₃ⱼ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
+└── computes: total viscous term (interior + immersed, z)  ∂ⱼτ₃ⱼ
 ```
 """
 function TotalViscousDissipation(model, velocities, w_immersed_bc, closure, diffusivities, clock, model_fields, buoyancy; location = (Center, Center, Face))
@@ -267,10 +273,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = WMomentumEquation.StokesShear(model)
-KernelFunctionOperation at (Center, Center, Face)
+WStokesShear (KernelFunctionOperation) at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: z_curl_Uˢ_cross_U (generic function with 10 methods)
+├── kernel_function: z_curl_Uˢ_cross_U (generic function with 3 methods)
 └── arguments: ("Nothing", "NamedTuple", "Float64")
+└── computes: Stokes shear forcing (z)  ((∇ × u⃗ˢ) × u⃗)_z
 ```
 """
 function StokesShear(model, stokes_drift, velocities, time; location = (Center, Center, Face))
@@ -300,10 +307,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = WMomentumEquation.StokesTendency(model)
-KernelFunctionOperation at (Center, Center, Face)
+WStokesTendency (KernelFunctionOperation) at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: ∂t_wˢ (generic function with 10 methods)
+├── kernel_function: ∂t_wˢ (generic function with 4 methods)
 └── arguments: ("Nothing", "Float64")
+└── computes: Stokes drift tendency (z)  ∂wˢ/∂t
 ```
 """
 function StokesTendency(model, stokes_drift, time; location = (Center, Center, Face))
@@ -383,10 +391,11 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> TEND = WMomentumEquation.Tendency(model)
-KernelFunctionOperation at (Center, Center, Face)
+WTendency (KernelFunctionOperation) at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: w_velocity_tendency (generic function with 1 method)
 └── arguments: ("Centered", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Oceananigans.Models.NonhydrostaticModels.BackgroundFields", "NamedTuple", "NamedTuple", "NamedTuple", "Nothing", "Nothing", "Clock", "Returns")
+└── computes: total tendency of the w-momentum equation
 ```
 """
 function Tendency(model, advection_scheme, coriolis, stokes_drift, closure, w_immersed_bc, buoyancy, background_fields, velocities, tracers, auxiliary_fields, diffusivities, hydrostatic_pressure, clock, forcing_func; location = (Center, Center, Face))

--- a/src/WMomentumEquation.jl
+++ b/src/WMomentumEquation.jl
@@ -70,7 +70,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> ADV = WMomentumEquation.Advection(model)
-WAdvection (KernelFunctionOperation) at (Center, Center, Face)
+WAdvection KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: div_𝐯w (generic function with 4 methods)
 └── arguments: ("Centered", "NamedTuple", "Field")
@@ -105,7 +105,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b);
 
 julia> BUOY = WMomentumEquation.BuoyancyAcceleration(model)
-WBuoyancyAcceleration (KernelFunctionOperation) at (Center, Center, Face)
+WBuoyancyAcceleration KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: z_dot_g_bᶜᶜᶠ (generic function with 3 methods)
 └── arguments: ("BuoyancyForce", "NamedTuple")
@@ -138,7 +138,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid; coriolis=FPlane(f=1e-4));
 
 julia> COR = WMomentumEquation.CoriolisAcceleration(model)
-WCoriolisAcceleration (KernelFunctionOperation) at (Center, Center, Face)
+WCoriolisAcceleration KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: z_f_cross_U (generic function with 6 methods)
 └── arguments: ("FPlane", "NamedTuple")
@@ -171,7 +171,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = WMomentumEquation.ViscousDissipation(model)
-WViscousDissipation (KernelFunctionOperation) at (Center, Center, Face)
+WViscousDissipation KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∂ⱼ_τ₃ⱼ (generic function with 8 methods)
 └── arguments: ("Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
@@ -202,7 +202,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = WMomentumEquation.ImmersedViscousDissipation(model)
-WImmersedViscousDissipation (KernelFunctionOperation) at (Center, Center, Face)
+WImmersedViscousDissipation KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: immersed_∂ⱼ_τ₃ⱼ (generic function with 2 methods)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple")
@@ -237,7 +237,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> VISC = WMomentumEquation.TotalViscousDissipation(model)
-WTotalViscousDissipation (KernelFunctionOperation) at (Center, Center, Face)
+WTotalViscousDissipation KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: total_∂ⱼ_τ₃ⱼ (generic function with 1 method)
 └── arguments: ("NamedTuple", "Nothing", "Nothing", "Nothing", "Clock", "NamedTuple", "Nothing")
@@ -273,7 +273,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = WMomentumEquation.StokesShear(model)
-WStokesShear (KernelFunctionOperation) at (Center, Center, Face)
+WStokesShear KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: z_curl_Uˢ_cross_U (generic function with 3 methods)
 └── arguments: ("Nothing", "NamedTuple", "Float64")
@@ -307,7 +307,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> STOKES = WMomentumEquation.StokesTendency(model)
-WStokesTendency (KernelFunctionOperation) at (Center, Center, Face)
+WStokesTendency KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ∂t_wˢ (generic function with 4 methods)
 └── arguments: ("Nothing", "Float64")
@@ -391,7 +391,7 @@ julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 julia> model = NonhydrostaticModel(grid);
 
 julia> TEND = WMomentumEquation.Tendency(model)
-WTendency (KernelFunctionOperation) at (Center, Center, Face)
+WTendency KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: w_velocity_tendency (generic function with 1 method)
 └── arguments: ("Centered", "Nothing", "Nothing", "Nothing", "Nothing", "Nothing", "Oceananigans.Models.NonhydrostaticModels.BackgroundFields", "NamedTuple", "NamedTuple", "NamedTuple", "Nothing", "Nothing", "Clock", "Returns")


### PR DESCRIPTION
## What

Each diagnostic in Oceanostics is a `KernelFunctionOperation` (KFO) under the hood, so they all displayed as the generic `KernelFunctionOperation at (…)`. This gives every diagnostic its own `show` that **expands on** the underlying KFO's:

```
RossbyNumber KernelFunctionOperation at (Face, Face, Face)
├── grid: 4×4×4 RectilinearGrid{…} on CPU with 3×3×3 halo
├── kernel_function: rossby_number_fff (generic function with 1 method)
└── arguments: ("Field", "Field", "Field", "NamedTuple")
└── computes: Rossby number  Ro = ωᶻ/f
```

On a color-capable terminal the leading diagnostic name and the `computes:` line are tinted (configurable via `DESCRIPTION_CRAYON` / `set_description_color!`); plain/captured streams (pipes, files, doctests) print without escapes.

## How

A single `@diagnostic_show` macro (centralized in `src/Oceanostics.jl`) registers, per diagnostic:

1. an `operation_name` method renaming the header to `"<Name> KernelFunctionOperation"` — the `KernelFunctionOperation` suffix is kept so it stays clear the object is still a KFO. Because it goes through Oceananigans' `operation_name`, the rename also propagates to `summary(op)`, to operation trees, and to `Field` operand lines.
2. a `Base.show` method that delegates the grid/kernel/arguments tree to Oceananigans' KFO `show` via `invoke` and appends a `└── computes: …` description line.

**63 diagnostics** across all modules are registered.

## Notes / intentionally not covered

- Generic `*Forcing` aliases keep the default display (the kernel is a user-supplied forcing function — no fixed type to dispatch on).
- `StrainRateTensor` / `VorticityTensor` / `StressTensor` return `NamedTuple`s of raw KFOs, so their components stay generic.
- TKE's `IsotropicDissipationRate` reuses the KE kernel, so it displays as `KineticEnergyIsotropicDissipationRate`.

## Doctests

Changing `show` touches every `jldoctest` that printed the old header. All blocks in the docstrings (`src/*.jl`) and the `docs/src/*.md` pages were regenerated to match the new output (the `.md` blocks need a separate `makedocs(...; doctest=:fix)` pass). The `general_flow_diagnostics` test group also passes. Some incidental Oceananigans method-count refreshes (e.g. `10 methods → 4`) are cosmetic — normalized by the existing `doctestfilter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)