### PR TITLE
Give tensor diagnostics a CustomKFO via kernel-functor families

### DIFF
--- a/src/FlowDiagnostics.jl
+++ b/src/FlowDiagnostics.jl
@@ -476,10 +476,20 @@ function StrainRateTensorModulus(model; loc = (Center, Center, Center))
     return KernelFunctionOperation{Center, Center, Center}(strain_rate_tensor_modulus_ccc, model.grid, model.velocities...)
 end
 
-# Off-diagonal strain rate components, each evaluated at its natural staggered location.
-@inline strain_rate_tensor_xy_ffc(i, j, k, grid, u, v) = (∂yᶠᶠᶜ(i, j, k, grid, u) + ∂xᶠᶠᶜ(i, j, k, grid, v)) / 2
-@inline strain_rate_tensor_xz_fcf(i, j, k, grid, u, w) = (∂zᶠᶜᶠ(i, j, k, grid, u) + ∂xᶠᶜᶠ(i, j, k, grid, w)) / 2
-@inline strain_rate_tensor_yz_cff(i, j, k, grid, v, w) = (∂zᶜᶠᶠ(i, j, k, grid, v) + ∂yᶜᶠᶠ(i, j, k, grid, w)) / 2
+# Strain-rate tensor components Sᵢⱼ = ½(∂ⱼuᵢ + ∂ᵢuⱼ) as a kernel-functor family parameterized by the
+# component indices (i, j), each evaluated at its natural staggered location. Bundling them under one
+# `StrainRateTensorKernel` type lets `const StrainRateTensor = CustomKFO{<:StrainRateTensorKernel}`
+# below recognize every component, mirroring the `MixedLayerDepthKernel`/`BoxFilterKernel` pattern.
+struct StrainRateTensorKernel{I, J} end
+
+@inline (::StrainRateTensorKernel{1, 1})(i, j, k, grid, u)    = ∂xᶜᶜᶜ(i, j, k, grid, u)
+@inline (::StrainRateTensorKernel{2, 2})(i, j, k, grid, v)    = ∂yᶜᶜᶜ(i, j, k, grid, v)
+@inline (::StrainRateTensorKernel{3, 3})(i, j, k, grid, w)    = ∂zᶜᶜᶜ(i, j, k, grid, w)
+@inline (::StrainRateTensorKernel{1, 2})(i, j, k, grid, u, v) = (∂yᶠᶠᶜ(i, j, k, grid, u) + ∂xᶠᶠᶜ(i, j, k, grid, v)) / 2
+@inline (::StrainRateTensorKernel{1, 3})(i, j, k, grid, u, w) = (∂zᶠᶜᶠ(i, j, k, grid, u) + ∂xᶠᶜᶠ(i, j, k, grid, w)) / 2
+@inline (::StrainRateTensorKernel{2, 3})(i, j, k, grid, v, w) = (∂zᶜᶠᶠ(i, j, k, grid, v) + ∂yᶜᶠᶠ(i, j, k, grid, w)) / 2
+
+const StrainRateTensor = CustomKFO{<:StrainRateTensorKernel}
 
 validate_dims(dims::Tuple{Vararg{Int}}) =
     (!isempty(dims) & all(d -> d in (1, 2, 3), dims) & allunique(dims)) ||
@@ -534,10 +544,11 @@ julia> keys(S)
 (:S₁₁, :S₂₂, :S₃₃, :S₁₂, :S₁₃, :S₂₃)
 
 julia> S.S₁₃
-KernelFunctionOperation at (Face, Center, Face)
+StrainRateTensor KernelFunctionOperation at (Face, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: strain_rate_tensor_xz_fcf (generic function with 1 method)
+├── kernel_function: Oceanostics.FlowDiagnostics.StrainRateTensorKernel{1, 3}
 └── arguments: ("Field", "Field")
+└── computes: strain-rate tensor component  Sᵢⱼ = ½(∂ⱼuᵢ + ∂ᵢuⱼ)
 ```
 """
 StrainRateTensor(model; dims = (1, 2, 3)) = StrainRateTensor(model.grid, model.velocities...; dims)
@@ -547,12 +558,12 @@ function StrainRateTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3))
     want(ij...) = all(in(dims), ij) # keep component Sᵢⱼ only if every index it needs is in `dims`
 
     components = (
-        S₁₁ = want(1)    ? KernelFunctionOperation{Center, Center, Center}(∂xᶜᶜᶜ, grid, u) : nothing,
-        S₂₂ = want(2)    ? KernelFunctionOperation{Center, Center, Center}(∂yᶜᶜᶜ, grid, v) : nothing,
-        S₃₃ = want(3)    ? KernelFunctionOperation{Center, Center, Center}(∂zᶜᶜᶜ, grid, w) : nothing,
-        S₁₂ = want(1, 2) ? KernelFunctionOperation{Face, Face, Center}(strain_rate_tensor_xy_ffc, grid, u, v) : nothing,
-        S₁₃ = want(1, 3) ? KernelFunctionOperation{Face, Center, Face}(strain_rate_tensor_xz_fcf, grid, u, w) : nothing,
-        S₂₃ = want(2, 3) ? KernelFunctionOperation{Center, Face, Face}(strain_rate_tensor_yz_cff, grid, v, w) : nothing,
+        S₁₁ = want(1)    ? KernelFunctionOperation{Center, Center, Center}(StrainRateTensorKernel{1, 1}(), grid, u) : nothing,
+        S₂₂ = want(2)    ? KernelFunctionOperation{Center, Center, Center}(StrainRateTensorKernel{2, 2}(), grid, v) : nothing,
+        S₃₃ = want(3)    ? KernelFunctionOperation{Center, Center, Center}(StrainRateTensorKernel{3, 3}(), grid, w) : nothing,
+        S₁₂ = want(1, 2) ? KernelFunctionOperation{Face, Face, Center}(StrainRateTensorKernel{1, 2}(), grid, u, v) : nothing,
+        S₁₃ = want(1, 3) ? KernelFunctionOperation{Face, Center, Face}(StrainRateTensorKernel{1, 3}(), grid, u, w) : nothing,
+        S₂₃ = want(2, 3) ? KernelFunctionOperation{Center, Face, Face}(StrainRateTensorKernel{2, 3}(), grid, v, w) : nothing,
     )
 
     return (; (k => op for (k, op) in pairs(components) if op !== nothing)...)
@@ -611,11 +622,17 @@ function VorticityTensorModulus(model; loc = (Center, Center, Center))
     return KernelFunctionOperation{Center, Center, Center}(vorticity_tensor_modulus_ccc, model.grid, model.velocities...)
 end
 
-# Off-diagonal vorticity components, each evaluated at its natural staggered location. The diagonal
-# components vanish identically (Ωᵢᵢ = 0), so they are not built.
-@inline vorticity_tensor_xy_ffc(i, j, k, grid, u, v) = (∂yᶠᶠᶜ(i, j, k, grid, u) - ∂xᶠᶠᶜ(i, j, k, grid, v)) / 2
-@inline vorticity_tensor_xz_fcf(i, j, k, grid, u, w) = (∂zᶠᶜᶠ(i, j, k, grid, u) - ∂xᶠᶜᶠ(i, j, k, grid, w)) / 2
-@inline vorticity_tensor_yz_cff(i, j, k, grid, v, w) = (∂zᶜᶠᶠ(i, j, k, grid, v) - ∂yᶜᶠᶠ(i, j, k, grid, w)) / 2
+# Vorticity tensor components Ωᵢⱼ = ½(∂ⱼuᵢ - ∂ᵢuⱼ) as a kernel-functor family parameterized by the
+# component indices (i, j), each evaluated at its natural staggered location. The diagonal components
+# vanish identically (Ωᵢᵢ = 0), so they are not built. Bundling them under one `VorticityTensorKernel`
+# type lets `const VorticityTensor = CustomKFO{<:VorticityTensorKernel}` below recognize every component.
+struct VorticityTensorKernel{I, J} end
+
+@inline (::VorticityTensorKernel{1, 2})(i, j, k, grid, u, v) = (∂yᶠᶠᶜ(i, j, k, grid, u) - ∂xᶠᶠᶜ(i, j, k, grid, v)) / 2
+@inline (::VorticityTensorKernel{1, 3})(i, j, k, grid, u, w) = (∂zᶠᶜᶠ(i, j, k, grid, u) - ∂xᶠᶜᶠ(i, j, k, grid, w)) / 2
+@inline (::VorticityTensorKernel{2, 3})(i, j, k, grid, v, w) = (∂zᶜᶠᶠ(i, j, k, grid, v) - ∂yᶜᶠᶠ(i, j, k, grid, w)) / 2
+
+const VorticityTensor = CustomKFO{<:VorticityTensorKernel}
 
 """
     $(SIGNATURES)
@@ -664,10 +681,11 @@ julia> keys(Ω)
 (:Ω₁₂, :Ω₁₃, :Ω₂₃)
 
 julia> Ω.Ω₁₃
-KernelFunctionOperation at (Face, Center, Face)
+VorticityTensor KernelFunctionOperation at (Face, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: vorticity_tensor_xz_fcf (generic function with 1 method)
+├── kernel_function: Oceanostics.FlowDiagnostics.VorticityTensorKernel{1, 3}
 └── arguments: ("Field", "Field")
+└── computes: vorticity tensor component  Ωᵢⱼ = ½(∂ⱼuᵢ - ∂ᵢuⱼ)
 ```
 """
 VorticityTensor(model; dims = (1, 2, 3)) = VorticityTensor(model.grid, model.velocities...; dims)
@@ -677,9 +695,9 @@ function VorticityTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3))
     want(ij...) = all(in(dims), ij) # keep component Ωᵢⱼ only if every index it needs is in `dims`
 
     components = (
-        Ω₁₂ = want(1, 2) ? KernelFunctionOperation{Face, Face, Center}(vorticity_tensor_xy_ffc, grid, u, v) : nothing,
-        Ω₁₃ = want(1, 3) ? KernelFunctionOperation{Face, Center, Face}(vorticity_tensor_xz_fcf, grid, u, w) : nothing,
-        Ω₂₃ = want(2, 3) ? KernelFunctionOperation{Center, Face, Face}(vorticity_tensor_yz_cff, grid, v, w) : nothing,
+        Ω₁₂ = want(1, 2) ? KernelFunctionOperation{Face, Face, Center}(VorticityTensorKernel{1, 2}(), grid, u, v) : nothing,
+        Ω₁₃ = want(1, 3) ? KernelFunctionOperation{Face, Center, Face}(VorticityTensorKernel{1, 3}(), grid, u, w) : nothing,
+        Ω₂₃ = want(2, 3) ? KernelFunctionOperation{Center, Face, Face}(VorticityTensorKernel{2, 3}(), grid, v, w) : nothing,
     )
 
     return (; (k => op for (k, op) in pairs(components) if op !== nothing)...)
@@ -696,17 +714,24 @@ const QVelocityGradientTensorInvariant = CustomKFO{<:typeof(Q_velocity_gradient_
 #---
 
 #+++ Stress tensor
-# Stress tensor τᵢⱼ = uᵢuⱼ kernels. Diagonals come in two flavors (see `collocate_diagonals` in
-# `StressTensor`): collocated `_ccc` = (ℑ uᵢ)² at ccc, or interpolation-free at uᵢ's own location.
-@inline stress_tensor_xx_ccc(i, j, k, grid, u)    = ℑxᶜᵃᵃ(i, j, k, grid, u)^2
-@inline stress_tensor_yy_ccc(i, j, k, grid, v)    = ℑyᵃᶜᵃ(i, j, k, grid, v)^2
-@inline stress_tensor_zz_ccc(i, j, k, grid, w)    = ℑzᵃᵃᶜ(i, j, k, grid, w)^2
-@inline stress_tensor_xx_fcc(i, j, k, grid, u)    = @inbounds u[i, j, k]^2
-@inline stress_tensor_yy_cfc(i, j, k, grid, v)    = @inbounds v[i, j, k]^2
-@inline stress_tensor_zz_ccf(i, j, k, grid, w)    = @inbounds w[i, j, k]^2
-@inline stress_tensor_xy_ffc(i, j, k, grid, u, v) = ℑyᵃᶠᵃ(i, j, k, grid, u) * ℑxᶠᵃᵃ(i, j, k, grid, v)
-@inline stress_tensor_xz_fcf(i, j, k, grid, u, w) = ℑzᵃᵃᶠ(i, j, k, grid, u) * ℑxᶠᵃᵃ(i, j, k, grid, w)
-@inline stress_tensor_yz_cff(i, j, k, grid, v, w) = ℑzᵃᵃᶠ(i, j, k, grid, v) * ℑyᵃᶠᵃ(i, j, k, grid, w)
+# Stress tensor τᵢⱼ = uᵢuⱼ as a kernel-functor family parameterized by the component indices (i, j) and,
+# for the diagonals, a `Collocated` flag (see `collocate_diagonals` in `StressTensor`): collocated
+# `(ℑ uᵢ)²` at ccc, or interpolation-free `uᵢ²` at uᵢ's own location. Off-diagonals carry the flag too
+# (always `false`) so the whole tensor shares one `StressTensorKernel` type, which lets
+# `const StressTensor = CustomKFO{<:StressTensorKernel}` below recognize every component.
+struct StressTensorKernel{I, J, Collocated} end
+
+@inline (::StressTensorKernel{1, 1, true})(i, j, k, grid, u)     = ℑxᶜᵃᵃ(i, j, k, grid, u)^2
+@inline (::StressTensorKernel{2, 2, true})(i, j, k, grid, v)     = ℑyᵃᶜᵃ(i, j, k, grid, v)^2
+@inline (::StressTensorKernel{3, 3, true})(i, j, k, grid, w)     = ℑzᵃᵃᶜ(i, j, k, grid, w)^2
+@inline (::StressTensorKernel{1, 1, false})(i, j, k, grid, u)    = @inbounds u[i, j, k]^2
+@inline (::StressTensorKernel{2, 2, false})(i, j, k, grid, v)    = @inbounds v[i, j, k]^2
+@inline (::StressTensorKernel{3, 3, false})(i, j, k, grid, w)    = @inbounds w[i, j, k]^2
+@inline (::StressTensorKernel{1, 2, false})(i, j, k, grid, u, v) = ℑyᵃᶠᵃ(i, j, k, grid, u) * ℑxᶠᵃᵃ(i, j, k, grid, v)
+@inline (::StressTensorKernel{1, 3, false})(i, j, k, grid, u, w) = ℑzᵃᵃᶠ(i, j, k, grid, u) * ℑxᶠᵃᵃ(i, j, k, grid, w)
+@inline (::StressTensorKernel{2, 3, false})(i, j, k, grid, v, w) = ℑzᵃᵃᶠ(i, j, k, grid, v) * ℑyᵃᶠᵃ(i, j, k, grid, w)
+
+const StressTensor = CustomKFO{<:StressTensorKernel}
 
 """
     $(SIGNATURES)
@@ -790,10 +815,11 @@ julia> keys(τ)
 (:τ₁₁, :τ₂₂, :τ₃₃, :τ₁₂, :τ₁₃, :τ₂₃)
 
 julia> τ.τ₁₁
-KernelFunctionOperation at (Face, Center, Center)
+StressTensor KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
-├── kernel_function: stress_tensor_xx_fcc (generic function with 1 method)
+├── kernel_function: Oceanostics.FlowDiagnostics.StressTensorKernel{1, 1, false}
 └── arguments: ("Field",)
+└── computes: stress tensor component  τᵢⱼ = uᵢuⱼ
 ```
 """
 StressTensor(model; dims = (1, 2, 3), collocate_diagonals = false) =
@@ -804,20 +830,20 @@ function StressTensor(grid::AbstractGrid, u, v, w; dims = (1, 2, 3), collocate_d
     want(ij...) = all(in(dims), ij) # keep component τᵢⱼ only if every index it needs is in `dims`
 
     if collocate_diagonals # τᵢᵢ = (ℑ uᵢ)² interpolated to a shared ccc location (one interpolation each)
-        τ₁₁ = want(1) ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_xx_ccc, grid, u) : nothing
-        τ₂₂ = want(2) ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_yy_ccc, grid, v) : nothing
-        τ₃₃ = want(3) ? KernelFunctionOperation{Center, Center, Center}(stress_tensor_zz_ccc, grid, w) : nothing
+        τ₁₁ = want(1) ? KernelFunctionOperation{Center, Center, Center}(StressTensorKernel{1, 1, true}(), grid, u) : nothing
+        τ₂₂ = want(2) ? KernelFunctionOperation{Center, Center, Center}(StressTensorKernel{2, 2, true}(), grid, v) : nothing
+        τ₃₃ = want(3) ? KernelFunctionOperation{Center, Center, Center}(StressTensorKernel{3, 3, true}(), grid, w) : nothing
     else # τᵢᵢ = uᵢ² read at each velocity's own location (no interpolation)
-        τ₁₁ = want(1) ? KernelFunctionOperation{Face, Center, Center}(stress_tensor_xx_fcc, grid, u) : nothing
-        τ₂₂ = want(2) ? KernelFunctionOperation{Center, Face, Center}(stress_tensor_yy_cfc, grid, v) : nothing
-        τ₃₃ = want(3) ? KernelFunctionOperation{Center, Center, Face}(stress_tensor_zz_ccf, grid, w) : nothing
+        τ₁₁ = want(1) ? KernelFunctionOperation{Face, Center, Center}(StressTensorKernel{1, 1, false}(), grid, u) : nothing
+        τ₂₂ = want(2) ? KernelFunctionOperation{Center, Face, Center}(StressTensorKernel{2, 2, false}(), grid, v) : nothing
+        τ₃₃ = want(3) ? KernelFunctionOperation{Center, Center, Face}(StressTensorKernel{3, 3, false}(), grid, w) : nothing
     end
 
     components = (;
         τ₁₁, τ₂₂, τ₃₃,
-        τ₁₂ = want(1, 2) ? KernelFunctionOperation{Face, Face, Center}(stress_tensor_xy_ffc, grid, u, v) : nothing,
-        τ₁₃ = want(1, 3) ? KernelFunctionOperation{Face, Center, Face}(stress_tensor_xz_fcf, grid, u, w) : nothing,
-        τ₂₃ = want(2, 3) ? KernelFunctionOperation{Center, Face, Face}(stress_tensor_yz_cff, grid, v, w) : nothing,
+        τ₁₂ = want(1, 2) ? KernelFunctionOperation{Face, Face, Center}(StressTensorKernel{1, 2, false}(), grid, u, v) : nothing,
+        τ₁₃ = want(1, 3) ? KernelFunctionOperation{Face, Center, Face}(StressTensorKernel{1, 3, false}(), grid, u, w) : nothing,
+        τ₂₃ = want(2, 3) ? KernelFunctionOperation{Center, Face, Face}(StressTensorKernel{2, 3, false}(), grid, v, w) : nothing,
     )
 
     return (; (k => op for (k, op) in pairs(components) if op !== nothing)...)

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -250,6 +250,23 @@ function _show_diagnostic(io::IO, op, name, description)
 end
 
 """
+Print the compact `summary(op)` one-liner (used when a diagnostic appears nested in a container, e.g.
+the `NamedTuple` of components a tensor returns), tinting the leading `name` with `DESCRIPTION_CRAYON`
+on color-capable streams — so the name matches the colored header of the multi-line `show`. The
+summary starts with `name`, so we recolor only that prefix and leave the rest (` KernelFunctionOperation
+at …`) untinted, exactly as the tree does.
+"""
+function _show_diagnostic_summary(io::IO, op, name)
+    s = summary(op)
+    if get(io, :color, false)
+        c = DESCRIPTION_CRAYON[]
+        s = replace(s, name => string(c, name, inv(c)); count = 1)
+    end
+    print(io, s)
+    return nothing
+end
+
+"""
     @diagnostic_show T name [description]
 
 Give the `CustomKFO` type alias `T` a custom display: rename its `show`/`summary` header to
@@ -258,6 +275,12 @@ Give the `CustomKFO` type alias `T` a custom display: rename its `show`/`summary
 `<name>` and the description are tinted with `DESCRIPTION_CRAYON`. The header rename goes
 through Oceananigans' `operation_name`, so it also propagates (uncolored) to `summary(op)` and to
 `op`'s appearance inside larger operation trees and `Field` operand lines.
+
+Following the Julia convention, the full multi-line tree is the *three-arg* `show` (used by the
+REPL/`display` for a standalone object), while the *two-arg* `show` is the compact `summary(op)`
+one-liner with the leading `<name>` tinted the same `DESCRIPTION_CRAYON` as the tree's header. This
+keeps a diagnostic readable when it appears nested in a container — e.g. inside the `NamedTuple` of
+components a tensor diagnostic returns, which would otherwise print one full tree per component.
 """
 macro diagnostic_show(T, name, description="")
     T = esc(T)
@@ -265,7 +288,8 @@ macro diagnostic_show(T, name, description="")
         # `operation_name` is escaped so the method extends the function imported from Oceananigans
         # (hygiene would otherwise treat the unqualified name as a fresh, separate binding).
         $(esc(:operation_name))(::$T) = $name * " KernelFunctionOperation"
-        Base.show(io::IO, op::$T) = _show_diagnostic(io, op, $name, $description)
+        Base.show(io::IO, ::MIME"text/plain", op::$T) = _show_diagnostic(io, op, $name, $description)
+        Base.show(io::IO, op::$T) = _show_diagnostic_summary(io, op, $name)
     end
 end
 

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -355,6 +355,9 @@ end
 @diagnostic_show FlowDiagnostics.StrainRateTensorModulus            "StrainRateTensorModulus"            "strain-rate tensor modulus  √(SᵢⱼSᵢⱼ)"
 @diagnostic_show FlowDiagnostics.VorticityTensorModulus             "VorticityTensorModulus"             "vorticity tensor modulus  √(ΩᵢⱼΩᵢⱼ)"
 @diagnostic_show FlowDiagnostics.QVelocityGradientTensorInvariant   "QVelocityGradientTensorInvariant"   "Q velocity-gradient invariant  Q = ½(ΩᵢⱼΩᵢⱼ - SᵢⱼSᵢⱼ)"
+@diagnostic_show FlowDiagnostics.StrainRateTensor                   "StrainRateTensor"                   "strain-rate tensor component  Sᵢⱼ = ½(∂ⱼuᵢ + ∂ᵢuⱼ)"
+@diagnostic_show FlowDiagnostics.VorticityTensor                    "VorticityTensor"                    "vorticity tensor component  Ωᵢⱼ = ½(∂ⱼuᵢ - ∂ᵢuⱼ)"
+@diagnostic_show FlowDiagnostics.StressTensor                       "StressTensor"                       "stress tensor component  τᵢⱼ = uᵢuⱼ"
 @diagnostic_show CustomKFO{<:FlowDiagnostics.MixedLayerDepthKernel} "MixedLayerDepth"                    "mixed layer depth (shallowest depth where the criterion is met)"
 #---
 

--- a/test/test_velocity_diagnostics.jl
+++ b/test/test_velocity_diagnostics.jl
@@ -61,6 +61,7 @@ function test_velocity_only_flow_diagnostics(model)
 
     Sij = StrainRateTensor(model)
     @test keys(Sij) == (:S₁₁, :S₂₂, :S₃₃, :S₁₂, :S₁₃, :S₂₃)
+    @test all(Sᵢⱼ -> Sᵢⱼ isa StrainRateTensor, Sij) # every component is recognized by the type alias
     @test location(Sij.S₁₁) == (Center, Center, Center)
     @test location(Sij.S₁₂) == (Face, Face, Center)
     @test location(Sij.S₁₃) == (Face, Center, Face)
@@ -93,6 +94,7 @@ function test_velocity_only_flow_diagnostics(model)
 
     τij = StressTensor(model)
     @test keys(τij) == (:τ₁₁, :τ₂₂, :τ₃₃, :τ₁₂, :τ₁₃, :τ₂₃)
+    @test all(τᵢⱼ -> τᵢⱼ isa StressTensor, τij) # every component is recognized by the type alias
     # default `collocate_diagonals = false`: diagonals are interpolation-free, at each velocity's location
     @test location(τij.τ₁₁) == (Face, Center, Center)
     @test location(τij.τ₂₂) == (Center, Face, Center)
@@ -109,6 +111,7 @@ function test_velocity_only_flow_diagnostics(model)
     # `collocate_diagonals = true`: diagonals are interpolated to a shared ccc location instead
     τij_c = StressTensor(model; collocate_diagonals=true)
     @test keys(τij_c) == keys(τij)
+    @test all(τᵢⱼ -> τᵢⱼ isa StressTensor, τij_c) # collocated diagonals are recognized too
     @test location(τij_c.τ₁₁) == (Center, Center, Center)
     @test location(τij_c.τ₂₂) == (Center, Center, Center)
     @test location(τij_c.τ₃₃) == (Center, Center, Center)
@@ -157,6 +160,7 @@ function test_velocity_only_flow_diagnostics(model)
 
     Ωij = VorticityTensor(model)
     @test keys(Ωij) == (:Ω₁₂, :Ω₁₃, :Ω₂₃) # antisymmetric tensor: only off-diagonals, no diagonals
+    @test all(Ωᵢⱼ -> Ωᵢⱼ isa VorticityTensor, Ωij) # every component is recognized by the type alias
     @test location(Ωij.Ω₁₂) == (Face, Face, Center)
     @test location(Ωij.Ω₁₃) == (Face, Center, Face)
     @test location(Ωij.Ω₂₃) == (Center, Face, Face)


### PR DESCRIPTION
`StrainRateTensor`, `VorticityTensor`, and `StressTensor` each return a `NamedTuple` of bare `KernelFunctionOperation`s, so — unlike every other diagnostic — they had no `CustomKFO` type alias and displayed with the generic KFO `show`.

This rewrites each tensor's component kernels as a singleton **functor family** parameterized by the component indices (plus the `collocate_diagonals` flag for stress diagonals), following the existing `MixedLayerDepthKernel` / `BoxFilterKernel` pattern. Each tensor then gets one alias matching all its components:

```julia
const StrainRateTensor = CustomKFO{<:StrainRateTensorKernel}
```

plus a `@diagnostic_show` registration, so components now print with a named header and a `computes:` line:

```
julia> S.S₁₃
StrainRateTensor KernelFunctionOperation at (Face, Center, Face)
├── grid: ...
├── kernel_function: Oceanostics.FlowDiagnostics.StrainRateTensorKernel{1, 3}
└── arguments: ("Field", "Field")
└── computes: strain-rate tensor component  Sᵢⱼ = ½(∂ⱼuᵢ + ∂ᵢuⱼ)
```

Notes:
- Constructors still return a `NamedTuple`; what gains a type is each component (`S.S₁₂ isa StrainRateTensor`).
- Also removes `StrainRateTensor`'s reliance on Oceananigans' generic `∂xᶜᶜᶜ` operators for its diagonals — those can't be aliased without intercepting every `∂x` KFO.
- Functors stay zero-alloc and type-stable.

Tests: `vel_diagnostics`, `canonical_flows`, `perf_invariants` and the doctests all pass; added `isa` assertions for every component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)