### PR TITLE
Subgrid diffusive fluxes for from closure for tracers

### DIFF
--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -11,7 +11,7 @@ export TracerEquation, KineticEnergyEquation, FilteredKineticEnergyEquation, Sub
 
 #+++ TracerEquation exports
 export TracerAdvection, TracerDiffusion, TracerImmersedDiffusion, TracerTotalDiffusion, TracerForcing,
-       TracerDiffusiveFluxX, TracerDiffusiveFluxY,TracerDiffusiveFluxZ
+       TracerXDiffusiveFlux, TracerYDiffusiveFlux,TracerZDiffusiveFlux
 #---
 
 #+++ UMomentumEquation exports
@@ -312,9 +312,9 @@ end
 @diagnostic_show TracerEquation.Diffusion         "TracerDiffusion"          "tracer diffusion (interior)  ∂ⱼqᶜⱼ"
 @diagnostic_show TracerEquation.ImmersedDiffusion "TracerImmersedDiffusion"  "tracer diffusion through immersed boundaries  ∂ⱼ𝓆ᶜⱼ"
 @diagnostic_show TracerEquation.TotalDiffusion    "TracerTotalDiffusion"     "total tracer diffusion (interior + immersed)  ∂ⱼqᶜⱼ + ∂ⱼ𝓆ᶜⱼ"
-@diagnostic_show TracerEquation.DiffusiveFluxX    "TracerDiffusiveFluxX"     "subgrid tracer diffusion in x determined by the configured closure"
-@diagnostic_show TracerEquation.DiffusiveFluxY    "TracerDiffusiveFluxY"     "subgrid tracer diffusion in y determined by the configured closure"
-@diagnostic_show TracerEquation.DiffusiveFluxZ    "TracerDiffusiveFluxZ"     "subgrid tracer diffusion in z determined by the configured closure"
+@diagnostic_show TracerEquation.XDiffusiveFlux    "TracerXDiffusiveFlux"     "subgrid tracer diffusion in x determined by the configured closure"
+@diagnostic_show TracerEquation.YDiffusiveFlux    "TracerYDiffusiveFlux"     "subgrid tracer diffusion in y determined by the configured closure"
+@diagnostic_show TracerEquation.ZDiffusiveFlux    "TracerZDiffusiveFlux"     "subgrid tracer diffusion in z determined by the configured closure"
 #---
 
 #+++ UMomentumEquation

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -10,7 +10,8 @@ export TracerEquation, KineticEnergyEquation, FilteredKineticEnergyEquation, Sub
 #---
 
 #+++ TracerEquation exports
-export TracerAdvection, TracerDiffusion, TracerImmersedDiffusion, TracerTotalDiffusion, TracerForcing
+export TracerAdvection, TracerDiffusion, TracerImmersedDiffusion, TracerTotalDiffusion, TracerForcing,
+       TracerDiffusiveFluxX, TracerDiffusiveFluxY,TracerDiffusiveFluxZ
 #---
 
 #+++ UMomentumEquation exports
@@ -311,6 +312,9 @@ end
 @diagnostic_show TracerEquation.Diffusion         "TracerDiffusion"          "tracer diffusion (interior)  ∂ⱼqᶜⱼ"
 @diagnostic_show TracerEquation.ImmersedDiffusion "TracerImmersedDiffusion"  "tracer diffusion through immersed boundaries  ∂ⱼ𝓆ᶜⱼ"
 @diagnostic_show TracerEquation.TotalDiffusion    "TracerTotalDiffusion"     "total tracer diffusion (interior + immersed)  ∂ⱼqᶜⱼ + ∂ⱼ𝓆ᶜⱼ"
+@diagnostic_show TracerEquation.DiffusiveFluxX    "TracerDiffusiveFluxX"     "subgrid tracer diffusion in x determined by the configured closure"
+@diagnostic_show TracerEquation.DiffusiveFluxY    "TracerDiffusiveFluxY"     "subgrid tracer diffusion in y determined by the configured closure"
+@diagnostic_show TracerEquation.DiffusiveFluxZ    "TracerDiffusiveFluxZ"     "subgrid tracer diffusion in z determined by the configured closure"
 #---
 
 #+++ UMomentumEquation

--- a/src/TracerEquation.jl
+++ b/src/TracerEquation.jl
@@ -212,15 +212,15 @@ TracerXDiffusiveFlux KernelFunctionOperation at (Face, Center, Center)
 └── computes: sub-grid diffusive flux given by the configured closure
 ```
 """
-function XDiffusiveFlux(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Face, Center, Center))
+function XDiffusiveFlux(model, val_tracer_index, tracer; location = (Face, Center, Center))
     validate_location(location, "XDiffusiveFlux", (Face, Center, Center))
-    return KernelFunctionOperation{Face, Center, Center}(diffusive_flux_x, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy)
+    return KernelFunctionOperation{Face, Center, Center}(diffusive_flux_x, model.grid, model.closure, model.closure_fields, val_tracer_index, tracer, model.clock, fields(model), model.buoyancy)
 end
 
 function XDiffusiveFlux(model, tracer_name; kwargs...)
     tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
     @inbounds tracer = model.tracers[tracer_name]
-    return XDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
+    return XDiffusiveFlux(model, Val(tracer_index), tracer; kwargs...)
 end
 
 """
@@ -246,15 +246,15 @@ TracerYDiffusiveFlux KernelFunctionOperation at (Center, Face, Center)
 └── computes: sub-grid diffusive flux given by the configured closure
 ```
 """
-function YDiffusiveFlux(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Center, Face, Center))
+function YDiffusiveFlux(model, val_tracer_index, tracer; location = (Center, Face, Center))
     validate_location(location, "YDiffusiveFlux", (Center, Face, Center))
-    return KernelFunctionOperation{Center, Face, Center}(diffusive_flux_y, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy)
+    return KernelFunctionOperation{Center, Face, Center}(diffusive_flux_y, model.grid, model.closure, model.closure_fields, val_tracer_index, tracer, model.clock, fields(model), model.buoyancy)
 end
 
 function YDiffusiveFlux(model, tracer_name; kwargs...)
     tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
     @inbounds tracer = model.tracers[tracer_name]
-    return YDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
+    return YDiffusiveFlux(model, Val(tracer_index), tracer; kwargs...)
 end
 
 """
@@ -280,15 +280,15 @@ TracerZDiffusiveFlux KernelFunctionOperation at (Center, Center, Face)
 └── computes: sub-grid diffusive flux given by the configured closure
 ```
 """
-function ZDiffusiveFlux(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Center, Center, Face))
+function ZDiffusiveFlux(model, val_tracer_index, tracer; location = (Center, Center, Face))
     validate_location(location, "ZDiffusiveFlux", (Center, Center, Face))
-    return KernelFunctionOperation{Center, Center, Face}(diffusive_flux_z, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy)
+    return KernelFunctionOperation{Center, Center, Face}(diffusive_flux_z, model.grid, model.closure, model.closure_fields, val_tracer_index, tracer, model.clock, fields(model), model.buoyancy)
 end
 
 function ZDiffusiveFlux(model, tracer_name; kwargs...)
     tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
     @inbounds tracer = model.tracers[tracer_name]
-    return ZDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
+    return ZDiffusiveFlux(model, Val(tracer_index), tracer; kwargs...)
 end
 #---
 

--- a/src/TracerEquation.jl
+++ b/src/TracerEquation.jl
@@ -1,14 +1,16 @@
 module TracerEquation
 using DocStringExtensions
 
-using Oceananigans: fields, Center, KernelFunctionOperation
+using Oceananigans: fields, Center, Face, KernelFunctionOperation
 using Oceananigans.Models: HydrostaticFreeSurfaceModel
 using Oceananigans.Models.NonhydrostaticModels: div_Uc, ∇_dot_qᶜ, immersed_∇_dot_qᶜ, biogeochemical_transition
+using Oceananigans.TurbulenceClosures: diffusive_flux_x, diffusive_flux_y, diffusive_flux_z
 
 using Oceanostics: validate_location, CustomKFO
 
 export Advection, Diffusion, ImmersedDiffusion, TotalDiffusion, Forcing,
-       TracerAdvection, TracerDiffusion, TracerImmersedDiffusion, TracerTotalDiffusion, TracerForcing
+       TracerAdvection, TracerDiffusion, TracerImmersedDiffusion, TracerTotalDiffusion, 
+       TracerDiffusiveFluxX, TracerDiffusiveFluxY, TracerDiffusiveFluxZ, TracerForcing
 
 # Inline function for total diffusion
 @inline total_∇_dot_qᶜ(i, j, k, grid, c, c_immersed_bc, closure, closure_fields, val_tracer_index, clock, model_fields, buoyancy) =
@@ -20,12 +22,18 @@ const Advection = CustomKFO{<:typeof(div_Uc)}
 const Diffusion = CustomKFO{<:typeof(∇_dot_qᶜ)}
 const ImmersedDiffusion = CustomKFO{<:typeof(immersed_∇_dot_qᶜ)}
 const TotalDiffusion = CustomKFO{<:typeof(total_∇_dot_qᶜ)}
+const DiffusiveFluxX = CustomKFO{<:typeof(diffusive_flux_x)}
+const DiffusiveFluxY = CustomKFO{<:typeof(diffusive_flux_y)}
+const DiffusiveFluxZ = CustomKFO{<:typeof(diffusive_flux_z)}
 const Forcing = KernelFunctionOperation{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any}
 
 const TracerAdvection = Advection
 const TracerDiffusion = Diffusion
 const TracerImmersedDiffusion = ImmersedDiffusion
 const TracerTotalDiffusion = TotalDiffusion
+const TracerDiffusiveFluxX = DiffusiveFluxX
+const TracerDiffusiveFluxY = DiffusiveFluxY
+const TracerDiffusiveFluxZ = DiffusiveFluxZ
 const TracerForcing = Forcing
 
 #+++ Advection
@@ -178,7 +186,109 @@ function TotalDiffusion(model, tracer_name; kwargs...)
     tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
     tracer = model.tracers[tracer_index]
     immersed_bc = tracer.boundary_conditions.immersed
-    return TotalDiffusion(model, tracer, immersed_bc, model.closure, model.closure_fields, Val(tracer_index), model.clock, fields(model), model.buoyancy; kwargs...)
+    return TotalDiffusion(model, tracer, immersed_bc, model.closure, model.closure_fields, Val(tracer_index), model.clock, fields(model), model.buoyancy)
+end
+
+"""
+    $(SIGNATURES)
+
+Calculates the sub-grid diffusive flux in the x-direction as determined by the 
+configured closure, using the Oceananigans kernel `diffusive_flux_x`.
+
+```jldoctest
+julia> using Oceananigans, Oceanostics
+
+julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
+
+julia> closure = AnisotropicMinimumDissipation()
+
+julia> model = NonhydrostaticModel(grid; closure, tracers=:a);
+
+julia> DIFF_FLUX_X = TracerEquation.DiffusiveFluxX(model, :a)
+TracerDiffusiveFluxX KernelFunctionOperation at (Face, Center, Center)
+├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── kernel_function: diffusive_flux_x (generic function with 15 methods)
+└── arguments: ("AnisotropicMinimumDissipation", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: sub-grid diffusive flux given by the configured closure
+```
+"""
+function DiffusiveFluxX(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Face, Center, Center))
+    validate_location(location, "DiffusiveFluxX", (Face, Center, Center))
+    return KernelFunctionOperation{Face, Center, Center}(diffusive_flux_x, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy)
+end
+
+function DiffusiveFluxX(model, tracer_name; kwargs...)
+    tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
+    tracer = model.tracers[tracer_index]
+    return DiffusiveFluxX(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
+end
+
+"""
+    $(SIGNATURES)
+
+Calculates the sub-grid diffusive flux in the y-direction as determined by the 
+configured closure, using the Oceananigans kernel `diffusive_flux_y`.
+
+```jldoctest
+julia> using Oceananigans, Oceanostics
+
+julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
+
+julia> closure = AnisotropicMinimumDissipation()
+
+julia> model = NonhydrostaticModel(grid; closure, tracers=:a);
+
+julia> DIFF_FLUX_Y = TracerEquation.DiffusiveFluxY(model, :a)
+TracerDiffusiveFluxY KernelFunctionOperation at (Center, Face, Center)
+├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── kernel_function: diffusive_flux_y (generic function with 15 methods)
+└── arguments: ("AnisotropicMinimumDissipation", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: sub-grid diffusive flux given by the configured closure
+```
+"""
+function DiffusiveFluxY(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Center, Face, Center))
+    validate_location(location, "DiffusiveFluxY", (Center, Face, Center))
+    return KernelFunctionOperation{Center, Face, Center}(diffusive_flux_y, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy)
+end
+
+function DiffusiveFluxY(model, tracer_name; kwargs...)
+    tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
+    tracer = model.tracers[tracer_index]
+    return DiffusiveFluxY(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
+end
+
+"""
+    $(SIGNATURES)
+
+Calculates the sub-grid diffusive flux in the z-direction as determined by the 
+configured closure, using the Oceananigans kernel `diffusive_flux_z`.
+
+```jldoctest
+julia> using Oceananigans, Oceanostics
+
+julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
+
+julia> closure = AnisotropicMinimumDissipation()
+
+julia> model = NonhydrostaticModel(grid; closure, tracers=:a);
+
+julia> DIFF_FLUX_Z = TracerEquation.DiffusiveFluxZ(model, :a)
+TracerDiffusiveFluxZ KernelFunctionOperation at (Center, Center, Face)
+├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── kernel_function: diffusive_flux_z (generic function with 17 methods)
+└── arguments: ("AnisotropicMinimumDissipation", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: sub-grid diffusive flux given by the configured closure
+```
+"""
+function DiffusiveFluxZ(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Center, Center, Face))
+    validate_location(location, "DiffusiveFluxZ", (Center, Center, Face))
+    return KernelFunctionOperation{Center, Center, Face}(diffusive_flux_z, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy)
+end
+
+function DiffusiveFluxZ(model, tracer_name; kwargs...)
+    tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
+    tracer = model.tracers[tracer_index]
+    return DiffusiveFluxZ(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
 end
 #---
 

--- a/src/TracerEquation.jl
+++ b/src/TracerEquation.jl
@@ -192,7 +192,7 @@ end
 """
     $(SIGNATURES)
 
-Calculates the sub-grid diffusive flux in the x-direction as determined by the 
+Calculates the sub-grid diffusive flux in the x-direction as determined by the
 configured closure, using the Oceananigans kernel `diffusive_flux_x`.
 
 ```jldoctest
@@ -200,7 +200,7 @@ julia> using Oceananigans, Oceanostics
 
 julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 
-julia> closure = AnisotropicMinimumDissipation()
+julia> closure = ScalarDiffusivity();
 
 julia> model = NonhydrostaticModel(grid; closure, tracers=:a);
 
@@ -208,8 +208,8 @@ julia> DIFF_FLUX_X = TracerEquation.XDiffusiveFlux(model, :a)
 TracerXDiffusiveFlux KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: diffusive_flux_x (generic function with 15 methods)
-└── arguments: ("AnisotropicMinimumDissipation", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
-└── computes: sub-grid diffusive flux given by the configured closure
+└── arguments: ("ScalarDiffusivity", "Nothing", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: subgrid tracer diffusion in x determined by the configured closure
 ```
 """
 function XDiffusiveFlux(model, val_tracer_index, tracer; location = (Face, Center, Center))
@@ -226,7 +226,7 @@ end
 """
     $(SIGNATURES)
 
-Calculates the sub-grid diffusive flux in the y-direction as determined by the 
+Calculates the sub-grid diffusive flux in the y-direction as determined by the
 configured closure, using the Oceananigans kernel `diffusive_flux_y`.
 
 ```jldoctest
@@ -234,7 +234,7 @@ julia> using Oceananigans, Oceanostics
 
 julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 
-julia> closure = AnisotropicMinimumDissipation()
+julia> closure = ScalarDiffusivity();
 
 julia> model = NonhydrostaticModel(grid; closure, tracers=:a);
 
@@ -242,8 +242,8 @@ julia> DIFF_FLUX_Y = TracerEquation.YDiffusiveFlux(model, :a)
 TracerYDiffusiveFlux KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: diffusive_flux_y (generic function with 15 methods)
-└── arguments: ("AnisotropicMinimumDissipation", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
-└── computes: sub-grid diffusive flux given by the configured closure
+└── arguments: ("ScalarDiffusivity", "Nothing", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: subgrid tracer diffusion in y determined by the configured closure
 ```
 """
 function YDiffusiveFlux(model, val_tracer_index, tracer; location = (Center, Face, Center))
@@ -260,7 +260,7 @@ end
 """
     $(SIGNATURES)
 
-Calculates the sub-grid diffusive flux in the z-direction as determined by the 
+Calculates the sub-grid diffusive flux in the z-direction as determined by the
 configured closure, using the Oceananigans kernel `diffusive_flux_z`.
 
 ```jldoctest
@@ -268,7 +268,7 @@ julia> using Oceananigans, Oceanostics
 
 julia> grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1));
 
-julia> closure = AnisotropicMinimumDissipation()
+julia> closure = ScalarDiffusivity();
 
 julia> model = NonhydrostaticModel(grid; closure, tracers=:a);
 
@@ -276,8 +276,8 @@ julia> DIFF_FLUX_Z = TracerEquation.ZDiffusiveFlux(model, :a)
 TracerZDiffusiveFlux KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: diffusive_flux_z (generic function with 17 methods)
-└── arguments: ("AnisotropicMinimumDissipation", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
-└── computes: sub-grid diffusive flux given by the configured closure
+└── arguments: ("ScalarDiffusivity", "Nothing", "Val", "Field", "Clock", "NamedTuple", "Nothing")
+└── computes: subgrid tracer diffusion in z determined by the configured closure
 ```
 """
 function ZDiffusiveFlux(model, val_tracer_index, tracer; location = (Center, Center, Face))

--- a/src/TracerEquation.jl
+++ b/src/TracerEquation.jl
@@ -186,7 +186,7 @@ function TotalDiffusion(model, tracer_name; kwargs...)
     tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
     tracer = model.tracers[tracer_index]
     immersed_bc = tracer.boundary_conditions.immersed
-    return TotalDiffusion(model, tracer, immersed_bc, model.closure, model.closure_fields, Val(tracer_index), model.clock, fields(model), model.buoyancy)
+    return TotalDiffusion(model, tracer, immersed_bc, model.closure, model.closure_fields, Val(tracer_index), model.clock, fields(model), model.buoyancy; kwargs...)
 end
 
 """

--- a/src/TracerEquation.jl
+++ b/src/TracerEquation.jl
@@ -8,7 +8,7 @@ using Oceananigans.TurbulenceClosures: diffusive_flux_x, diffusive_flux_y, diffu
 
 using Oceanostics: validate_location, CustomKFO
 
-export Advection, Diffusion, ImmersedDiffusion, TotalDiffusion, Forcing,
+export Advection, Diffusion, ImmersedDiffusion, TotalDiffusion, DiffusiveFluxX, DiffusiveFluxY, DiffusiveFluxZ, Forcing,
        TracerAdvection, TracerDiffusion, TracerImmersedDiffusion, TracerTotalDiffusion, 
        TracerDiffusiveFluxX, TracerDiffusiveFluxY, TracerDiffusiveFluxZ, TracerForcing
 

--- a/src/TracerEquation.jl
+++ b/src/TracerEquation.jl
@@ -8,9 +8,9 @@ using Oceananigans.TurbulenceClosures: diffusive_flux_x, diffusive_flux_y, diffu
 
 using Oceanostics: validate_location, CustomKFO
 
-export Advection, Diffusion, ImmersedDiffusion, TotalDiffusion, DiffusiveFluxX, DiffusiveFluxY, DiffusiveFluxZ, Forcing,
+export Advection, Diffusion, ImmersedDiffusion, TotalDiffusion, XDiffusiveFlux, YDiffusiveFlux, ZDiffusiveFlux, Forcing,
        TracerAdvection, TracerDiffusion, TracerImmersedDiffusion, TracerTotalDiffusion, 
-       TracerDiffusiveFluxX, TracerDiffusiveFluxY, TracerDiffusiveFluxZ, TracerForcing
+       TracerXDiffusiveFlux, TracerYDiffusiveFlux, TracerZDiffusiveFlux, TracerForcing
 
 # Inline function for total diffusion
 @inline total_∇_dot_qᶜ(i, j, k, grid, c, c_immersed_bc, closure, closure_fields, val_tracer_index, clock, model_fields, buoyancy) =
@@ -22,18 +22,18 @@ const Advection = CustomKFO{<:typeof(div_Uc)}
 const Diffusion = CustomKFO{<:typeof(∇_dot_qᶜ)}
 const ImmersedDiffusion = CustomKFO{<:typeof(immersed_∇_dot_qᶜ)}
 const TotalDiffusion = CustomKFO{<:typeof(total_∇_dot_qᶜ)}
-const DiffusiveFluxX = CustomKFO{<:typeof(diffusive_flux_x)}
-const DiffusiveFluxY = CustomKFO{<:typeof(diffusive_flux_y)}
-const DiffusiveFluxZ = CustomKFO{<:typeof(diffusive_flux_z)}
+const XDiffusiveFlux = CustomKFO{<:typeof(diffusive_flux_x)}
+const YDiffusiveFlux = CustomKFO{<:typeof(diffusive_flux_y)}
+const ZDiffusiveFlux = CustomKFO{<:typeof(diffusive_flux_z)}
 const Forcing = KernelFunctionOperation{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any}
 
 const TracerAdvection = Advection
 const TracerDiffusion = Diffusion
 const TracerImmersedDiffusion = ImmersedDiffusion
 const TracerTotalDiffusion = TotalDiffusion
-const TracerDiffusiveFluxX = DiffusiveFluxX
-const TracerDiffusiveFluxY = DiffusiveFluxY
-const TracerDiffusiveFluxZ = DiffusiveFluxZ
+const TracerXDiffusiveFlux = XDiffusiveFlux
+const TracerYDiffusiveFlux = YDiffusiveFlux
+const TracerZDiffusiveFlux = ZDiffusiveFlux
 const TracerForcing = Forcing
 
 #+++ Advection
@@ -204,23 +204,23 @@ julia> closure = AnisotropicMinimumDissipation()
 
 julia> model = NonhydrostaticModel(grid; closure, tracers=:a);
 
-julia> DIFF_FLUX_X = TracerEquation.DiffusiveFluxX(model, :a)
-TracerDiffusiveFluxX KernelFunctionOperation at (Face, Center, Center)
+julia> DIFF_FLUX_X = TracerEquation.XDiffusiveFlux(model, :a)
+TracerXDiffusiveFlux KernelFunctionOperation at (Face, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: diffusive_flux_x (generic function with 15 methods)
 └── arguments: ("AnisotropicMinimumDissipation", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
 └── computes: sub-grid diffusive flux given by the configured closure
 ```
 """
-function DiffusiveFluxX(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Face, Center, Center))
-    validate_location(location, "DiffusiveFluxX", (Face, Center, Center))
+function XDiffusiveFlux(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Face, Center, Center))
+    validate_location(location, "XDiffusiveFlux", (Face, Center, Center))
     return KernelFunctionOperation{Face, Center, Center}(diffusive_flux_x, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy)
 end
 
-function DiffusiveFluxX(model, tracer_name; kwargs...)
+function XDiffusiveFlux(model, tracer_name; kwargs...)
     tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
     tracer = model.tracers[tracer_index]
-    return DiffusiveFluxX(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
+    return XDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
 end
 
 """
@@ -238,23 +238,23 @@ julia> closure = AnisotropicMinimumDissipation()
 
 julia> model = NonhydrostaticModel(grid; closure, tracers=:a);
 
-julia> DIFF_FLUX_Y = TracerEquation.DiffusiveFluxY(model, :a)
-TracerDiffusiveFluxY KernelFunctionOperation at (Center, Face, Center)
+julia> DIFF_FLUX_Y = TracerEquation.YDiffusiveFlux(model, :a)
+TracerYDiffusiveFlux KernelFunctionOperation at (Center, Face, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: diffusive_flux_y (generic function with 15 methods)
 └── arguments: ("AnisotropicMinimumDissipation", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
 └── computes: sub-grid diffusive flux given by the configured closure
 ```
 """
-function DiffusiveFluxY(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Center, Face, Center))
-    validate_location(location, "DiffusiveFluxY", (Center, Face, Center))
+function YDiffusiveFlux(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Center, Face, Center))
+    validate_location(location, "YDiffusiveFlux", (Center, Face, Center))
     return KernelFunctionOperation{Center, Face, Center}(diffusive_flux_y, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy)
 end
 
-function DiffusiveFluxY(model, tracer_name; kwargs...)
+function YDiffusiveFlux(model, tracer_name; kwargs...)
     tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
     tracer = model.tracers[tracer_index]
-    return DiffusiveFluxY(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
+    return YDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
 end
 
 """
@@ -272,23 +272,23 @@ julia> closure = AnisotropicMinimumDissipation()
 
 julia> model = NonhydrostaticModel(grid; closure, tracers=:a);
 
-julia> DIFF_FLUX_Z = TracerEquation.DiffusiveFluxZ(model, :a)
-TracerDiffusiveFluxZ KernelFunctionOperation at (Center, Center, Face)
+julia> DIFF_FLUX_Z = TracerEquation.ZDiffusiveFlux(model, :a)
+TracerZDiffusiveFlux KernelFunctionOperation at (Center, Center, Face)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: diffusive_flux_z (generic function with 17 methods)
 └── arguments: ("AnisotropicMinimumDissipation", "NamedTuple", "Val", "Field", "Clock", "NamedTuple", "Nothing")
 └── computes: sub-grid diffusive flux given by the configured closure
 ```
 """
-function DiffusiveFluxZ(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Center, Center, Face))
-    validate_location(location, "DiffusiveFluxZ", (Center, Center, Face))
+function ZDiffusiveFlux(model, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy; location = (Center, Center, Face))
+    validate_location(location, "ZDiffusiveFlux", (Center, Center, Face))
     return KernelFunctionOperation{Center, Center, Face}(diffusive_flux_z, grid, closure, closure_fields, val_tracer_index, tracer, clock, model_fields, buoyancy)
 end
 
-function DiffusiveFluxZ(model, tracer_name; kwargs...)
+function ZDiffusiveFlux(model, tracer_name; kwargs...)
     tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
     tracer = model.tracers[tracer_index]
-    return DiffusiveFluxZ(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
+    return ZDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
 end
 #---
 

--- a/src/TracerEquation.jl
+++ b/src/TracerEquation.jl
@@ -219,7 +219,7 @@ end
 
 function XDiffusiveFlux(model, tracer_name; kwargs...)
     tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
-    tracer = model.tracers[tracer_index]
+    @inbounds tracer = model.tracers[tracer_name]
     return XDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
 end
 
@@ -253,7 +253,7 @@ end
 
 function YDiffusiveFlux(model, tracer_name; kwargs...)
     tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
-    tracer = model.tracers[tracer_index]
+    @inbounds tracer = model.tracers[tracer_name]
     return YDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
 end
 
@@ -287,7 +287,7 @@ end
 
 function ZDiffusiveFlux(model, tracer_name; kwargs...)
     tracer_index = findfirst(x -> x == tracer_name, keys(model.tracers))
-    tracer = model.tracers[tracer_index]
+    @inbounds tracer = model.tracers[tracer_name]
     return ZDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, Val(tracer_index), tracer, model.clock, fields(model), model.buoyancy; kwargs...)
 end
 #---

--- a/test/test_tracer_diagnostics.jl
+++ b/test/test_tracer_diagnostics.jl
@@ -100,6 +100,22 @@ function test_tracer_terms(model)
     @test DIFF isa TracerTotalDiffusion
     @test DIFF_field isa Field
 
+    FORC = TracerEquation.Forcing(model, model.forcing.a, model.clock, fields(model))
+    FORC_field = Field(FORC)
+    @test FORC isa TracerEquation.Forcing
+    @test FORC isa TracerForcing
+    @test FORC_field isa Field
+
+    FORC = TracerEquation.Forcing(model, :a)
+    FORC_field = Field(FORC)
+    @test FORC isa TracerEquation.Forcing
+    @test FORC isa TracerForcing
+    @test FORC_field isa Field
+
+    return nothing
+end
+
+function test_subgrid_tracer_fluxes(model)
     DIFF_FLUX = TracerEquation.DiffusiveFluxX(model, model.grid, model.closure, model.closure_fields, 
                                     Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
     DIFF_FLUX_field = Field(DIFF_FLUX)
@@ -139,18 +155,6 @@ function test_tracer_terms(model)
     @test DIFF_FLUX isa TracerDiffusiveFluxZ
     @test DIFF_FLUX_field isa Field
 
-    FORC = TracerEquation.Forcing(model, model.forcing.a, model.clock, fields(model))
-    FORC_field = Field(FORC)
-    @test FORC isa TracerEquation.Forcing
-    @test FORC isa TracerForcing
-    @test FORC_field isa Field
-
-    FORC = TracerEquation.Forcing(model, :a)
-    FORC_field = Field(FORC)
-    @test FORC isa TracerEquation.Forcing
-    @test FORC isa TracerForcing
-    @test FORC_field isa Field
-
     return nothing
 end
 #---
@@ -165,6 +169,12 @@ end
 
             @info "        Testing tracer terms"
             test_tracer_terms(model)
+
+            closure = ScalarDiffusivity()
+            model = model_type(grid; closure, model_kwargs...)
+
+            @info "        Testing subgrid tracer fluxes"
+            test_subgrid_tracer_fluxes(model)
         end
     end
 end

--- a/test/test_tracer_diagnostics.jl
+++ b/test/test_tracer_diagnostics.jl
@@ -116,43 +116,43 @@ function test_tracer_terms(model)
 end
 
 function test_subgrid_tracer_fluxes(model)
-    DIFF_FLUX = TracerEquation.DiffusiveFluxX(model, model.grid, model.closure, model.closure_fields, 
+    DIFF_FLUX = TracerEquation.XDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, 
                                     Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
     DIFF_FLUX_field = Field(DIFF_FLUX)
-    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxX
-    @test DIFF_FLUX isa TracerDiffusiveFluxX
+    @test DIFF_FLUX isa TracerEquation.XDiffusiveFlux
+    @test DIFF_FLUX isa TracerXDiffusiveFlux
     @test DIFF_FLUX_field isa Field
 
-    DIFF_FLUX = TracerEquation.DiffusiveFluxX(model, :a)
+    DIFF_FLUX = TracerEquation.XDiffusiveFlux(model, :a)
     DIFF_FLUX_field = Field(DIFF_FLUX)
-    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxX
-    @test DIFF_FLUX isa TracerDiffusiveFluxX
+    @test DIFF_FLUX isa TracerEquation.XDiffusiveFlux
+    @test DIFF_FLUX isa TracerXDiffusiveFlux
     @test DIFF_FLUX_field isa Field
     
-    DIFF_FLUX = TracerEquation.DiffusiveFluxY(model, model.grid, model.closure, model.closure_fields, 
+    DIFF_FLUX = TracerEquation.YDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, 
                                     Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
     DIFF_FLUX_field = Field(DIFF_FLUX)
-    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxY
-    @test DIFF_FLUX isa TracerDiffusiveFluxY
+    @test DIFF_FLUX isa TracerEquation.YDiffusiveFlux
+    @test DIFF_FLUX isa TracerYDiffusiveFlux
     @test DIFF_FLUX_field isa Field
 
-    DIFF_FLUX = TracerEquation.DiffusiveFluxY(model, :a)
+    DIFF_FLUX = TracerEquation.YDiffusiveFlux(model, :a)
     DIFF_FLUX_field = Field(DIFF_FLUX)
-    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxY
-    @test DIFF_FLUX isa TracerDiffusiveFluxY
+    @test DIFF_FLUX isa TracerEquation.YDiffusiveFlux
+    @test DIFF_FLUX isa TracerYDiffusiveFlux
     @test DIFF_FLUX_field isa Field
 
-    DIFF_FLUX = TracerEquation.DiffusiveFluxZ(model, model.grid, model.closure, model.closure_fields, 
+    DIFF_FLUX = TracerEquation.ZDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, 
                                     Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
     DIFF_FLUX_field = Field(DIFF_FLUX)
-    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxZ
-    @test DIFF_FLUX isa TracerDiffusiveFluxZ
+    @test DIFF_FLUX isa TracerEquation.ZDiffusiveFlux
+    @test DIFF_FLUX isa TracerZDiffusiveFlux
     @test DIFF_FLUX_field isa Field
 
-    DIFF_FLUX = TracerEquation.DiffusiveFluxZ(model, :a)
+    DIFF_FLUX = TracerEquation.ZDiffusiveFlux(model, :a)
     DIFF_FLUX_field = Field(DIFF_FLUX)
-    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxZ
-    @test DIFF_FLUX isa TracerDiffusiveFluxZ
+    @test DIFF_FLUX isa TracerEquation.ZDiffusiveFlux
+    @test DIFF_FLUX isa TracerZDiffusiveFlux
     @test DIFF_FLUX_field isa Field
 
     return nothing

--- a/test/test_tracer_diagnostics.jl
+++ b/test/test_tracer_diagnostics.jl
@@ -100,6 +100,45 @@ function test_tracer_terms(model)
     @test DIFF isa TracerTotalDiffusion
     @test DIFF_field isa Field
 
+    DIFF_FLUX = TracerEquation.DiffusiveFluxX(model, model.grid, model.closure, model.closure_fields, 
+                                    Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
+    DIFF_FLUX_field = Field(DIFF_FLUX)
+    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxX
+    @test DIFF_FLUX isa TracerDiffusiveFluxX
+    @test DIFF_FLUX_field isa Field
+
+    DIFF_FLUX = TracerEquation.DiffusiveFluxX(model, :a)
+    DIFF_FLUX_field = Field(DIFF_FLUX)
+    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxX
+    @test DIFF_FLUX isa TracerDiffusiveFluxX
+    @test DIFF_FLUX_field isa Field
+    
+    DIFF_FLUX = TracerEquation.DiffusiveFluxY(model, model.grid, model.closure, model.closure_fields, 
+                                    Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
+    DIFF_FLUX_field = Field(DIFF_FLUX)
+    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxY
+    @test DIFF_FLUX isa TracerDiffusiveFluxY
+    @test DIFF_FLUX_field isa Field
+
+    DIFF_FLUX = TracerEquation.DiffusiveFluxY(model, :a)
+    DIFF_FLUX_field = Field(DIFF_FLUX)
+    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxY
+    @test DIFF_FLUX isa TracerDiffusiveFluxY
+    @test DIFF_FLUX_field isa Field
+
+    DIFF_FLUX = TracerEquation.DiffusiveFluxZ(model, model.grid, model.closure, model.closure_fields, 
+                                    Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
+    DIFF_FLUX_field = Field(DIFF_FLUX)
+    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxZ
+    @test DIFF_FLUX isa TracerDiffusiveFluxZ
+    @test DIFF_FLUX_field isa Field
+
+    DIFF_FLUX = TracerEquation.DiffusiveFluxZ(model, :a)
+    DIFF_FLUX_field = Field(DIFF_FLUX)
+    @test DIFF_FLUX isa TracerEquation.DiffusiveFluxZ
+    @test DIFF_FLUX isa TracerDiffusiveFluxZ
+    @test DIFF_FLUX_field isa Field
+
     FORC = TracerEquation.Forcing(model, model.forcing.a, model.clock, fields(model))
     FORC_field = Field(FORC)
     @test FORC isa TracerEquation.Forcing

--- a/test/test_tracer_diagnostics.jl
+++ b/test/test_tracer_diagnostics.jl
@@ -116,8 +116,7 @@ function test_tracer_terms(model)
 end
 
 function test_subgrid_tracer_fluxes(model)
-    DIFF_FLUX = TracerEquation.XDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, 
-                                              Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
+    DIFF_FLUX = TracerEquation.XDiffusiveFlux(model, Val(:a), model.tracers.a)
     DIFF_FLUX_field = Field(DIFF_FLUX)
     @test DIFF_FLUX isa TracerEquation.XDiffusiveFlux
     @test DIFF_FLUX isa TracerXDiffusiveFlux
@@ -129,8 +128,7 @@ function test_subgrid_tracer_fluxes(model)
     @test DIFF_FLUX isa TracerXDiffusiveFlux
     @test DIFF_FLUX_field isa Field
     
-    DIFF_FLUX = TracerEquation.YDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, 
-                                              Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
+    DIFF_FLUX = TracerEquation.YDiffusiveFlux(model, Val(:a), model.tracers.a)
     DIFF_FLUX_field = Field(DIFF_FLUX)
     @test DIFF_FLUX isa TracerEquation.YDiffusiveFlux
     @test DIFF_FLUX isa TracerYDiffusiveFlux
@@ -142,8 +140,7 @@ function test_subgrid_tracer_fluxes(model)
     @test DIFF_FLUX isa TracerYDiffusiveFlux
     @test DIFF_FLUX_field isa Field
 
-    DIFF_FLUX = TracerEquation.ZDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, 
-                                              Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
+    DIFF_FLUX = TracerEquation.ZDiffusiveFlux(model, Val(:a), model.tracers.a)
     DIFF_FLUX_field = Field(DIFF_FLUX)
     @test DIFF_FLUX isa TracerEquation.ZDiffusiveFlux
     @test DIFF_FLUX isa TracerZDiffusiveFlux

--- a/test/test_tracer_diagnostics.jl
+++ b/test/test_tracer_diagnostics.jl
@@ -75,7 +75,7 @@ function test_tracer_terms(model)
     @test DIFF_field isa Field
 
     DIFF = TracerEquation.ImmersedDiffusion(model, model.tracers.a, model.tracers.a.boundary_conditions.immersed,
-                                   model.closure, model.closure_fields, Val(:a), model.clock, fields(model))
+                                            model.closure, model.closure_fields, Val(:a), model.clock, fields(model))
     DIFF_field = Field(DIFF)
     @test DIFF isa TracerEquation.ImmersedDiffusion
     @test DIFF isa TracerImmersedDiffusion
@@ -88,7 +88,7 @@ function test_tracer_terms(model)
     @test DIFF_field isa Field
 
     DIFF = TracerEquation.TotalDiffusion(model, model.tracers.a, model.tracers.a.boundary_conditions.immersed,
-                                model.closure, model.closure_fields, Val(:a), model.clock, fields(model), model.buoyancy)
+                                         model.closure, model.closure_fields, Val(:a), model.clock, fields(model), model.buoyancy)
     DIFF_field = Field(DIFF)
     @test DIFF isa TracerEquation.TotalDiffusion
     @test DIFF isa TracerTotalDiffusion
@@ -117,7 +117,7 @@ end
 
 function test_subgrid_tracer_fluxes(model)
     DIFF_FLUX = TracerEquation.XDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, 
-                                    Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
+                                              Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
     DIFF_FLUX_field = Field(DIFF_FLUX)
     @test DIFF_FLUX isa TracerEquation.XDiffusiveFlux
     @test DIFF_FLUX isa TracerXDiffusiveFlux
@@ -130,7 +130,7 @@ function test_subgrid_tracer_fluxes(model)
     @test DIFF_FLUX_field isa Field
     
     DIFF_FLUX = TracerEquation.YDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, 
-                                    Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
+                                              Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
     DIFF_FLUX_field = Field(DIFF_FLUX)
     @test DIFF_FLUX isa TracerEquation.YDiffusiveFlux
     @test DIFF_FLUX isa TracerYDiffusiveFlux
@@ -143,7 +143,7 @@ function test_subgrid_tracer_fluxes(model)
     @test DIFF_FLUX_field isa Field
 
     DIFF_FLUX = TracerEquation.ZDiffusiveFlux(model, model.grid, model.closure, model.closure_fields, 
-                                    Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
+                                              Val(:a), model.tracers.a, model.clock, fields(model), model.buoyancy)
     DIFF_FLUX_field = Field(DIFF_FLUX)
     @test DIFF_FLUX isa TracerEquation.ZDiffusiveFlux
     @test DIFF_FLUX isa TracerZDiffusiveFlux


### PR DESCRIPTION
This PR adds diagnostic functions for calculating subgrid fluxes for tracers that are determined by the configured closure.

The user exposed routines `DiffusiveFluxX`, `DiffusiveFluxY`, and `DiffusiveFluxZ` use the native Oceananigans kernels `diffusive_flux_x`, `diffusive_flux_y`, and `diffusive_flux_z` respectively.