### PR TITLE
Apply `Filter` boundary behavior via Oceananigans BC types (inherit from field)

### DIFF
--- a/docs/src/filters.md
+++ b/docs/src/filters.md
@@ -69,10 +69,26 @@ julia> size(Field(bf_edge(c))) == size(Field(bf_mixed(c))) == (32, 1, 32)
 true
 ```
 
+#### Oceananigans boundary conditions
+
+The boundary treatment can equivalently be given with Oceananigans' boundary-condition types (passed
+as `boundary` or the alias `boundary_conditions`): [`ShrinkingBoundaryCondition`](@ref) ↔ `:shrink`,
+`GradientBoundaryCondition(0)` (or a zero `FluxBoundaryCondition`) ↔ `:edge`, and
+`ValueBoundaryCondition(v)` ↔ constant padding with `v`. A `FieldBoundaryConditions` sets each side
+of each direction independently — these filter boundary conditions are separate from the field's own.
+
+```jldoctest filters
+julia> bcs = FieldBoundaryConditions(west=ShrinkingBoundaryCondition(), east=GradientBoundaryCondition(0));
+
+julia> size(Field(BoxFilter(; dims=1, N=3, boundary_conditions=bcs)(c)))
+(32, 1, 32)
+```
+
 ### API reference
 
 ```@docs
 BoxFilter
+ShrinkingBoundaryCondition
 ```
 
 ## Gaussian filter

--- a/docs/src/filters.md
+++ b/docs/src/filters.md
@@ -34,7 +34,7 @@ julia> c = CenterField(grid);
 julia> set!(c, (x, z) -> sin(2π * x) * z);
 
 julia> bf = BoxFilter(; dims=(1, 3), N=5)
-BoxFilter(dims=(1, 3), N=5, boundary=:shrink)
+BoxFilter(dims=(1, 3), N=5)
 
 julia> c̄ = Field(bf(c));
 
@@ -43,45 +43,40 @@ julia> size(c̄)
 ```
 
 The same `bf` can be applied to as many fields as you like. A one-step shortcut
-`BoxFilter(ψ; dims, N, boundary)`, which builds and applies the filter in a single call, is also
-accepted throughout.
+`BoxFilter(ψ; dims, N, boundary_conditions)`, which builds and applies the filter in a single call, is
+also accepted throughout.
 
 ### Boundary handling
 
-For `Periodic` directions, stencil offsets are always wrapped — the `boundary`
-keyword is silently ignored. For `Bounded` directions the `boundary` keyword
-selects how out-of-bounds offsets are treated:
+Boundary treatment is supplied through `boundary_conditions` using Oceananigans' boundary-condition
+types, kept **separate** from the filtered field's own boundary conditions:
 
-| `boundary`            | Behaviour                                                        |
-|:----------------------|:-----------------------------------------------------------------|
-| `:shrink` *(default)* | Drop out-of-bounds offsets from sum **and** count (honest local average; stencil shrinks near walls). |
-| `:edge`               | Replicate the nearest interior cell (`ψ[1]` or `ψ[N]`).          |
-| `(left=a, right=b)`   | Pad with constant `a` on the low side and `b` on the high side.  |
+  - `nothing` *(default)* — every side inherits the filtered field's own boundary condition.
+  - a single `BoundaryCondition` — applied to every filtered side.
+  - a `FieldBoundaryConditions` — one condition per side; any side left unset inherits the field's.
 
-A single spec applies to every filtered dimension, or a tuple gives per-dimension control:
+Each condition maps to a stencil rule:
+
+| boundary condition | behaviour |
+|:-------------------|:----------|
+| `ShrinkingBoundaryCondition()` | Drop out-of-bounds offsets from sum **and** count (honest local average; stencil shrinks near walls). |
+| zero `GradientBoundaryCondition` / `FluxBoundaryCondition` (incl. `NoFluxBoundaryCondition`) | Replicate the nearest interior cell. |
+| `ValueBoundaryCondition(v)` | Pad with the constant `v`. |
+| anything else (non-zero gradient/flux, `OpenBoundaryCondition`, …) | Fall back to the shrinking stencil. |
+
+`Periodic` directions are always wrapped, regardless of `boundary_conditions`. An `AbstractOperation`
+operand is first materialized into a `Field` (carrying Oceananigans' default boundary conditions),
+which then supplies the inherited conditions.
 
 ```jldoctest filters
-julia> bf_edge  = BoxFilter(; dims=(1, 3), N=3, boundary=:edge);
+julia> bf_edge = BoxFilter(; dims=(1, 3), N=3, boundary_conditions=GradientBoundaryCondition(0));
 
-julia> bf_mixed = BoxFilter(; dims=(1, 3), N=3, boundary=(:shrink, (left=0.0, right=0.0)));
+julia> z_bcs = FieldBoundaryConditions(bottom=ShrinkingBoundaryCondition(), top=ValueBoundaryCondition(0.0));
+
+julia> bf_mixed = BoxFilter(; dims=3, N=3, boundary_conditions=z_bcs);
 
 julia> size(Field(bf_edge(c))) == size(Field(bf_mixed(c))) == (32, 1, 32)
 true
-```
-
-#### Oceananigans boundary conditions
-
-The boundary treatment can equivalently be given with Oceananigans' boundary-condition types (passed
-as `boundary` or the alias `boundary_conditions`): [`ShrinkingBoundaryCondition`](@ref) ↔ `:shrink`,
-`GradientBoundaryCondition(0)` (or a zero `FluxBoundaryCondition`) ↔ `:edge`, and
-`ValueBoundaryCondition(v)` ↔ constant padding with `v`. A `FieldBoundaryConditions` sets each side
-of each direction independently — these filter boundary conditions are separate from the field's own.
-
-```jldoctest filters
-julia> bcs = FieldBoundaryConditions(west=ShrinkingBoundaryCondition(), east=GradientBoundaryCondition(0));
-
-julia> size(Field(BoxFilter(; dims=1, N=3, boundary_conditions=bcs)(c)))
-(32, 1, 32)
 ```
 
 ### API reference
@@ -122,7 +117,7 @@ stencil extends at least `2σ` on each side of the current cell. To override,
 pass `N` explicitly: a single odd integer (≥ 3) applies to every filtered
 dim, or a tuple of odd integers sets one count per dim.
 
-`dims` and `boundary` work identically to `BoxFilter`.
+`dims` and `boundary_conditions` work identically to `BoxFilter`.
 
 For a worked end-to-end example — coarse-graining a turbulent flow, a filter-width sweep, and a
 subfilter tracer flux — see the [Spatial filtering example](@ref spatial_filtering_example).
@@ -156,7 +151,7 @@ julia> stretched_grid = RectilinearGrid(size=(16, 16),
 julia> cz = CenterField(stretched_grid); set!(cz, (x, z) -> sin(2π*x) * z);
 
 julia> gf = GaussianFilter(; dims=(1, 3), σ=0.1)
-GaussianFilter(dims=(1, 3), σ=0.1, N=nothing, boundary=:shrink)
+GaussianFilter(dims=(1, 3), σ=0.1, N=nothing)
 
 julia> c̄z = Field(gf(cz));
 

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -63,7 +63,7 @@ export BottomCellValue
 #---
 
 #+++ SpatialFilters exports
-export BoxFilter, GaussianFilter
+export BoxFilter, GaussianFilter, ShrinkingBoundaryCondition
 #---
 
 #+++ PotentialEnergyEquationTerms exports

--- a/src/SpatialFilters/SpatialFilters.jl
+++ b/src/SpatialFilters/SpatialFilters.jl
@@ -1,7 +1,7 @@
 module SpatialFilters
 using DocStringExtensions
 
-export BoxFilter, GaussianFilter
+export BoxFilter, GaussianFilter, ShrinkingBoundaryCondition
 
 using Oceananigans: location
 using Oceananigans.Grids: topology, Periodic,
@@ -10,6 +10,9 @@ using Oceananigans.Grids: topology, Periodic,
                           xnode, ynode, znode
 using Oceananigans.Operators: xspacing, yspacing, zspacing
 using Oceananigans.AbstractOperations: KernelFunctionOperation
+using Oceananigans.BoundaryConditions: BoundaryCondition, FieldBoundaryConditions,
+                                       AbstractBoundaryConditionClassification, DefaultBoundaryCondition,
+                                       Value, Gradient, Flux
 
 using Oceanostics: CustomKFO
 
@@ -50,6 +53,40 @@ struct ConstantBoundary{T} <: AbstractBoundaryPolicy
     ConstantBoundary{T}(l, r) where {T} = new{T}(l, r)
 end
 ConstantBoundary(left, right) = ConstantBoundary{promote_type(typeof(left), typeof(right))}(promote(left, right)...)
+
+"""
+    SplitBoundary(left, right)
+
+Apply a different `AbstractBoundaryPolicy` to each side of a `Bounded` direction: `left` to offsets
+past the low-index end, `right` to offsets past the high-index end. Built automatically from a
+`FieldBoundaryConditions` whose two sides differ.
+"""
+struct SplitBoundary{L<:AbstractBoundaryPolicy, R<:AbstractBoundaryPolicy} <: AbstractBoundaryPolicy
+    left::L
+    right::R
+end
+#---
+
+#+++ Filter boundary conditions (Oceananigans BoundaryCondition interface)
+"""
+    Shrink <: AbstractBoundaryConditionClassification
+
+Boundary-condition classification marking a wall where a filter stencil should shrink. See
+[`ShrinkingBoundaryCondition`](@ref).
+"""
+struct Shrink <: AbstractBoundaryConditionClassification end
+
+"""
+    ShrinkingBoundaryCondition()
+
+Boundary condition telling a spatial filter to *shrink* its stencil at a wall, averaging only over
+the interior cells the stencil actually covers (the filter analog of the default `:shrink` policy).
+Unlike the symbol API it composes with Oceananigans' boundary-condition types, e.g.
+
+    boundary_conditions = FieldBoundaryConditions(west = ShrinkingBoundaryCondition(),
+                                                  east = GradientBoundaryCondition(0))
+"""
+ShrinkingBoundaryCondition() = BoundaryCondition(Shrink, nothing)
 #---
 
 #+++ Stencil value readers
@@ -89,6 +126,22 @@ end
     return ifelse(in_bounds, @inbounds(ψ[i, j, clamp(k, 1, N)]), zero(eltype(ψ))), Int(in_bounds)
 end
 
+@inline function x_stencil_fetch(b::SplitBoundary, ψ, i, j, k, N)
+    i < 1 && return x_stencil_fetch(b.left, ψ, i, j, k, N)
+    i > N && return x_stencil_fetch(b.right, ψ, i, j, k, N)
+    return (@inbounds(ψ[i, j, k]), 1)
+end
+@inline function y_stencil_fetch(b::SplitBoundary, ψ, i, j, k, N)
+    j < 1 && return y_stencil_fetch(b.left, ψ, i, j, k, N)
+    j > N && return y_stencil_fetch(b.right, ψ, i, j, k, N)
+    return (@inbounds(ψ[i, j, k]), 1)
+end
+@inline function z_stencil_fetch(b::SplitBoundary, ψ, i, j, k, N)
+    k < 1 && return z_stencil_fetch(b.left, ψ, i, j, k, N)
+    k > N && return z_stencil_fetch(b.right, ψ, i, j, k, N)
+    return (@inbounds(ψ[i, j, k]), 1)
+end
+
 @inline x_stencil_call(::PeriodicBoundary, f, i, j, k, N, grid, fargs...) = (f(wrap_periodic_index(i, N), j, k, grid, fargs...), 1)
 @inline y_stencil_call(::PeriodicBoundary, f, i, j, k, N, grid, fargs...) = (f(i, wrap_periodic_index(j, N), k, grid, fargs...), 1)
 @inline z_stencil_call(::PeriodicBoundary, f, i, j, k, N, grid, fargs...) = (f(i, j, wrap_periodic_index(k, N), grid, fargs...), 1)
@@ -113,6 +166,22 @@ end
     in_bounds = (1 <= k) & (k <= N)
     return ifelse(in_bounds, f(i, j, clamp(k, 1, N), grid, fargs...), zero(grid)), Int(in_bounds)
 end
+
+@inline function x_stencil_call(b::SplitBoundary, f, i, j, k, N, grid, fargs...)
+    i < 1 && return x_stencil_call(b.left, f, i, j, k, N, grid, fargs...)
+    i > N && return x_stencil_call(b.right, f, i, j, k, N, grid, fargs...)
+    return (f(i, j, k, grid, fargs...), 1)
+end
+@inline function y_stencil_call(b::SplitBoundary, f, i, j, k, N, grid, fargs...)
+    j < 1 && return y_stencil_call(b.left, f, i, j, k, N, grid, fargs...)
+    j > N && return y_stencil_call(b.right, f, i, j, k, N, grid, fargs...)
+    return (f(i, j, k, grid, fargs...), 1)
+end
+@inline function z_stencil_call(b::SplitBoundary, f, i, j, k, N, grid, fargs...)
+    k < 1 && return z_stencil_call(b.left, f, i, j, k, N, grid, fargs...)
+    k > N && return z_stencil_call(b.right, f, i, j, k, N, grid, fargs...)
+    return (f(i, j, k, grid, fargs...), 1)
+end
 #---
 
 #+++ Shared filter infrastructure
@@ -121,6 +190,14 @@ function resolve_filter_policies(ψ, dims, boundary)
 
     grid = ψ.grid
     loc = location(ψ)
+    sorted_dims = Tuple(d for d in (1, 2, 3) if d in dims)
+
+    # A `FieldBoundaryConditions` carries one condition per *side* of each direction, so it is
+    # resolved per dim rather than per user-supplied spec.
+    if boundary isa FieldBoundaryConditions
+        policies = ntuple(i -> dim_policy_from_field_bcs(grid, boundary, sorted_dims[i]), length(sorted_dims))
+        return grid, loc, sorted_dims, policies
+    end
 
     per_user_dim_specs = if boundary isa Tuple
         error_message = "`boundary` must be a single spec or a tuple with one entry per dim in `dims`; got length $(length(boundary)) for dims=$dims"
@@ -132,7 +209,6 @@ function resolve_filter_policies(ψ, dims, boundary)
 
     foreach(parse_boundary_spec, per_user_dim_specs)
 
-    sorted_dims = Tuple(d for d in (1, 2, 3) if d in dims)
     sorted_specs = ntuple(i -> begin
         user_idx = findfirst(==(sorted_dims[i]), dims)
         per_user_dim_specs[user_idx]
@@ -217,7 +293,37 @@ function parse_boundary_spec(nt::NamedTuple)
 end
 
 parse_boundary_spec(p::AbstractBoundaryPolicy) = p
-parse_boundary_spec(x) = throw(ArgumentError("`boundary` must be :shrink, :edge, or (left=a, right=b); got $(repr(x))"))
+
+# Oceananigans `BoundaryCondition` objects (the type-based spec; see `ShrinkingBoundaryCondition`).
+# `:edge` is the zero-gradient (homogeneous Neumann) case, so `GradientBoundaryCondition(0)` and the
+# `NoFluxBoundaryCondition`/zero-flux map onto it; `ValueBoundaryCondition(v)` is constant padding.
+parse_boundary_spec(::BoundaryCondition{<:Shrink}) = ShrinkBoundary()
+parse_boundary_spec(bc::BoundaryCondition{<:Gradient}) = bc.condition isa Number && iszero(bc.condition) ? EdgeBoundary() :
+    throw(ArgumentError("only a zero `GradientBoundaryCondition` (≡ `:edge`) is supported as a filter boundary condition so far; got $bc"))
+parse_boundary_spec(bc::BoundaryCondition{<:Flux}) = (bc.condition === nothing || (bc.condition isa Number && iszero(bc.condition))) ? EdgeBoundary() :
+    throw(ArgumentError("only a zero `FluxBoundaryCondition` is supported as a filter boundary condition so far; got $bc"))
+parse_boundary_spec(bc::BoundaryCondition{<:Value}) = bc.condition isa Number ? ConstantBoundary(bc.condition, bc.condition) :
+    throw(ArgumentError("a `ValueBoundaryCondition` used for filter padding must hold a number; got $(repr(bc.condition))"))
+parse_boundary_spec(bc::BoundaryCondition) =
+    throw(ArgumentError("unsupported filter boundary condition $bc; use ShrinkingBoundaryCondition(), a zero Gradient/Flux (≡ :edge), or a ValueBoundaryCondition"))
+
+# Translate one direction of a `FieldBoundaryConditions` into a policy: each side is mapped
+# independently and the two collapse to a single policy when they agree, or to a `SplitBoundary` when
+# they differ. Unspecified sides (Oceananigans `DefaultBoundaryCondition`) fall back to shrinking.
+function dim_policy_from_field_bcs(grid, fbc::FieldBoundaryConditions, d)
+    topology(grid, d) === Periodic && return PeriodicBoundary()
+    left_bc, right_bc = d == 1 ? (fbc.west, fbc.east) :
+                        d == 2 ? (fbc.south, fbc.north) :
+                                 (fbc.bottom, fbc.top)
+    left  = side_policy(left_bc)
+    right = side_policy(right_bc)
+    return left === right ? left : SplitBoundary(left, right)
+end
+
+side_policy(::DefaultBoundaryCondition) = ShrinkBoundary()
+side_policy(bc) = parse_boundary_spec(bc)
+
+parse_boundary_spec(x) = throw(ArgumentError("`boundary` must be :shrink, :edge, (left=a, right=b), an Oceananigans BoundaryCondition, or a FieldBoundaryConditions; got $(repr(x))"))
 #---
 
 #+++ Shared staged-compute infrastructure

--- a/src/SpatialFilters/SpatialFilters.jl
+++ b/src/SpatialFilters/SpatialFilters.jl
@@ -9,7 +9,7 @@ using Oceananigans.Grids: topology, Periodic,
                           xspacings, yspacings, zspacings,
                           xnode, ynode, znode
 using Oceananigans.Operators: xspacing, yspacing, zspacing
-using Oceananigans.AbstractOperations: KernelFunctionOperation
+using Oceananigans.AbstractOperations: KernelFunctionOperation, AbstractOperation
 using Oceananigans.BoundaryConditions: BoundaryCondition, FieldBoundaryConditions,
                                        AbstractBoundaryConditionClassification, DefaultBoundaryCondition,
                                        Value, Gradient, Flux
@@ -185,43 +185,16 @@ end
 #---
 
 #+++ Shared filter infrastructure
-function resolve_filter_policies(ψ, dims, boundary)
+function resolve_filter_policies(ψ, dims, boundary_conditions)
     validate_dims(dims)
 
     grid = ψ.grid
     loc = location(ψ)
+    field_bcs = ψ.boundary_conditions
     sorted_dims = Tuple(d for d in (1, 2, 3) if d in dims)
 
-    # A `FieldBoundaryConditions` carries one condition per *side* of each direction, so it is
-    # resolved per dim rather than per user-supplied spec.
-    if boundary isa FieldBoundaryConditions
-        policies = ntuple(i -> dim_policy_from_field_bcs(grid, boundary, sorted_dims[i]), length(sorted_dims))
-        return grid, loc, sorted_dims, policies
-    end
-
-    per_user_dim_specs = if boundary isa Tuple
-        error_message = "`boundary` must be a single spec or a tuple with one entry per dim in `dims`; got length $(length(boundary)) for dims=$dims"
-        length(boundary) == length(dims) || throw(ArgumentError(error_message))
-        boundary
-    else
-        ntuple(_ -> boundary, length(dims))
-    end
-
-    foreach(parse_boundary_spec, per_user_dim_specs)
-
-    sorted_specs = ntuple(i -> begin
-        user_idx = findfirst(==(sorted_dims[i]), dims)
-        per_user_dim_specs[user_idx]
-    end, length(sorted_dims))
-
-    policies = ntuple(i -> begin
-        d = sorted_dims[i]
-        if topology(grid, d) === Periodic
-            PeriodicBoundary()
-        else
-            parse_boundary_spec(sorted_specs[i])
-        end
-    end, length(sorted_dims))
+    policies = ntuple(i -> direction_policy(grid, sorted_dims[i], boundary_conditions, field_bcs),
+                      length(sorted_dims))
 
     return grid, loc, sorted_dims, policies
 end
@@ -281,49 +254,71 @@ function validate_periodic_widths(grid, sorted_dims, policies, widths)
     end
 end
 
-parse_boundary_spec(s::Symbol) =
-    s === :shrink ? ShrinkBoundary() :
-    s === :edge   ? EdgeBoundary()   :
-    throw(ArgumentError("`boundary` symbol must be :shrink or :edge; got :$s"))
+# `boundary_conditions` may be `nothing` (inherit every side from the filtered field), a single
+# `BoundaryCondition` (applied to every filtered side), or a `FieldBoundaryConditions` (per side;
+# sides left at their `DefaultBoundaryCondition` inherit from the field). These are kept separate
+# from the field's own boundary conditions.
+validate_boundary_conditions(::Nothing) = nothing
+validate_boundary_conditions(::BoundaryCondition) = nothing
+validate_boundary_conditions(::FieldBoundaryConditions) = nothing
+validate_boundary_conditions(x) = throw(ArgumentError(
+    "`boundary_conditions` must be `nothing`, an Oceananigans `BoundaryCondition`, or a `FieldBoundaryConditions`; " *
+    "got $(repr(x)). Symbol/NamedTuple specs (:shrink, :edge, (left=, right=)) were removed — use " *
+    "ShrinkingBoundaryCondition(), GradientBoundaryCondition(0), or ValueBoundaryCondition(v)."))
 
-function parse_boundary_spec(nt::NamedTuple)
-    ((length(nt) == 2) & haskey(nt, :left) & haskey(nt, :right)) ||
-        throw(ArgumentError("`boundary` NamedTuple must have exactly keys `:left` and `:right`; got keys $(keys(nt))"))
-    return ConstantBoundary(nt.left, nt.right)
+# Deprecated `boundary` keyword (the old symbol API).
+no_boundary_keyword(::Nothing) = nothing
+no_boundary_keyword(b) = throw(ArgumentError(
+    "the `boundary` keyword and its symbol specs (:shrink, :edge, (left=, right=)) were removed; pass " *
+    "`boundary_conditions` with Oceananigans boundary conditions instead (ShrinkingBoundaryCondition(), " *
+    "GradientBoundaryCondition(0), ValueBoundaryCondition(v), or a FieldBoundaryConditions). Got boundary=$(repr(b))."))
+
+# Materialize an `AbstractOperation` operand into a computed `Field` (carrying Oceananigans' default
+# boundary conditions, which the filter then inherits); a `Field` is passed through unchanged.
+function materialize_operand(ψ::AbstractOperation)
+    field = Field(ψ)
+    compute!(field)
+    return field
 end
+materialize_operand(ψ) = ψ
 
-parse_boundary_spec(p::AbstractBoundaryPolicy) = p
+# Effective boundary condition for one side: the user's, unless unset (`nothing`, or a
+# `DefaultBoundaryCondition` within a `FieldBoundaryConditions`), in which case the field's is used.
+user_side_bc(::Nothing, side) = nothing
+user_side_bc(bc::BoundaryCondition, side) = bc
+user_side_bc(fbc::FieldBoundaryConditions, side) =
+    (s = getproperty(fbc, side); s isa DefaultBoundaryCondition ? nothing : s)
 
-# Oceananigans `BoundaryCondition` objects (the type-based spec; see `ShrinkingBoundaryCondition`).
-# `:edge` is the zero-gradient (homogeneous Neumann) case, so `GradientBoundaryCondition(0)` and the
-# `NoFluxBoundaryCondition`/zero-flux map onto it; `ValueBoundaryCondition(v)` is constant padding.
-parse_boundary_spec(::BoundaryCondition{<:Shrink}) = ShrinkBoundary()
-parse_boundary_spec(bc::BoundaryCondition{<:Gradient}) = bc.condition isa Number && iszero(bc.condition) ? EdgeBoundary() :
-    throw(ArgumentError("only a zero `GradientBoundaryCondition` (≡ `:edge`) is supported as a filter boundary condition so far; got $bc"))
-parse_boundary_spec(bc::BoundaryCondition{<:Flux}) = (bc.condition === nothing || (bc.condition isa Number && iszero(bc.condition))) ? EdgeBoundary() :
-    throw(ArgumentError("only a zero `FluxBoundaryCondition` is supported as a filter boundary condition so far; got $bc"))
-parse_boundary_spec(bc::BoundaryCondition{<:Value}) = bc.condition isa Number ? ConstantBoundary(bc.condition, bc.condition) :
-    throw(ArgumentError("a `ValueBoundaryCondition` used for filter padding must hold a number; got $(repr(bc.condition))"))
-parse_boundary_spec(bc::BoundaryCondition) =
-    throw(ArgumentError("unsupported filter boundary condition $bc; use ShrinkingBoundaryCondition(), a zero Gradient/Flux (≡ :edge), or a ValueBoundaryCondition"))
+effective_side_bc(user_bcs, field_bcs, side) =
+    (u = user_side_bc(user_bcs, side); u === nothing ? getproperty(field_bcs, side) : u)
 
-# Translate one direction of a `FieldBoundaryConditions` into a policy: each side is mapped
-# independently and the two collapse to a single policy when they agree, or to a `SplitBoundary` when
-# they differ. Unspecified sides (Oceananigans `DefaultBoundaryCondition`) fall back to shrinking.
-function dim_policy_from_field_bcs(grid, fbc::FieldBoundaryConditions, d)
+side_names(d) = d == 1 ? (:west, :east) : d == 2 ? (:south, :north) : (:bottom, :top)
+
+# Translate one boundary condition into a stencil policy. `:edge` was the zero-gradient (homogeneous
+# Neumann) case, so a zero `Gradient`/`Flux` (incl. `NoFlux`) maps onto it; a `Value(v)` is constant
+# padding with `v`. Anything without a discrete analog (non-zero gradient/flux, `Open`, `nothing`, …)
+# falls back to a shrinking stencil — an honest local average that assumes nothing about the wall.
+bc_to_policy(::Nothing) = ShrinkBoundary()
+bc_to_policy(bc::DefaultBoundaryCondition) = bc_to_policy(bc.boundary_condition)
+bc_to_policy(::BoundaryCondition{<:Shrink}) = ShrinkBoundary()
+bc_to_policy(bc::BoundaryCondition{<:Gradient}) = bc.condition isa Number && iszero(bc.condition) ? EdgeBoundary() : ShrinkBoundary()
+bc_to_policy(bc::BoundaryCondition{<:Flux}) = (bc.condition === nothing || (bc.condition isa Number && iszero(bc.condition))) ? EdgeBoundary() : ShrinkBoundary()
+bc_to_policy(bc::BoundaryCondition{<:Value}) = bc.condition isa Number ? ConstantBoundary(bc.condition, bc.condition) : ShrinkBoundary()
+bc_to_policy(::BoundaryCondition) = ShrinkBoundary()
+
+# Per-direction policy: `Periodic` topology always wraps; otherwise the two sides are resolved and
+# translated independently, collapsing to one policy when they agree, or a `SplitBoundary` when not.
+function direction_policy(grid, d, user_bcs, field_bcs)
     topology(grid, d) === Periodic && return PeriodicBoundary()
-    left_bc, right_bc = d == 1 ? (fbc.west, fbc.east) :
-                        d == 2 ? (fbc.south, fbc.north) :
-                                 (fbc.bottom, fbc.top)
-    left  = side_policy(left_bc)
-    right = side_policy(right_bc)
+    lo, hi = side_names(d)
+    left  = bc_to_policy(effective_side_bc(user_bcs, field_bcs, lo))
+    right = bc_to_policy(effective_side_bc(user_bcs, field_bcs, hi))
     return left === right ? left : SplitBoundary(left, right)
 end
 
-side_policy(::DefaultBoundaryCondition) = ShrinkBoundary()
-side_policy(bc) = parse_boundary_spec(bc)
-
-parse_boundary_spec(x) = throw(ArgumentError("`boundary` must be :shrink, :edge, (left=a, right=b), an Oceananigans BoundaryCondition, or a FieldBoundaryConditions; got $(repr(x))"))
+# Compact one-line rendering of a stored `boundary_conditions` value for `show`.
+bc_summary(bc) = bc
+bc_summary(::FieldBoundaryConditions) = "FieldBoundaryConditions(…)"
 #---
 
 #+++ Shared staged-compute infrastructure

--- a/src/SpatialFilters/box_filter.jl
+++ b/src/SpatialFilters/box_filter.jl
@@ -83,14 +83,17 @@ end
     $(SIGNATURES)
 
 One-step form: apply a box filter to `ψ` directly, returning the `KernelFunctionOperation` that
-computes its local box-average. Equivalent to `BoxFilter(; dims, N, boundary)(ψ)`.
+computes its local box-average. Equivalent to `BoxFilter(; dims, N, boundary_conditions)(ψ)`.
 
-Refer to [`BoxFilter`](@ref)`(; dims, N, boundary)` for the full description of the
+Refer to [`BoxFilter`](@ref)`(; dims, N, boundary_conditions)` for the full description of the
 keyword arguments and boundary handling.
 """
-function BoxFilter(ψ; dims, N, boundary=:shrink, boundary_conditions=boundary)
+function BoxFilter(ψ; dims, N, boundary_conditions=nothing, boundary=nothing)
+    no_boundary_keyword(boundary)
     dims = tuplefy_dims(dims)
     validate_N(N)
+    validate_boundary_conditions(boundary_conditions)
+    ψ = materialize_operand(ψ)
     grid, loc, sorted_dims, policies = resolve_filter_policies(ψ, dims, boundary_conditions)
     width = (N - 1) ÷ 2
     widths = ntuple(_ -> width, length(sorted_dims))
@@ -103,17 +106,17 @@ end
 """
     BoxFilterOperator{D, NN, B}
 
-Returns a reusable box filter. Stores the `BoxFilter` parameters (`dims`,
-`N`, `boundary`) and, when called on a field `ψ`, returns `BoxFilter(ψ; dims, N, boundary)`.
-Construct one once with [`BoxFilter`](@ref)`(; …)` and apply it to many fields.
+Returns a reusable box filter. Stores the `BoxFilter` parameters (`dims`, `N`, `boundary_conditions`)
+and, when called on a field `ψ`, returns `BoxFilter(ψ; dims, N, boundary_conditions)`. Construct one
+once with [`BoxFilter`](@ref)`(; …)` and apply it to many fields.
 """
 struct BoxFilterOperator{D, NN, B}
     dims::D
     N::NN
-    boundary::B
+    boundary_conditions::B
 end
 
-(F::BoxFilterOperator)(ψ) = BoxFilter(ψ; dims=F.dims, N=F.N, boundary=F.boundary)
+(F::BoxFilterOperator)(ψ) = BoxFilter(ψ; dims=F.dims, N=F.N, boundary_conditions=F.boundary_conditions)
 
 """
     $(SIGNATURES)
@@ -143,40 +146,39 @@ instead.
 
 ## Boundary handling
 
-Stencil offsets that leave the interior `1:Nd_grid` of a direction (where `Nd_grid` is the number of
-cells along that direction) are handled per-direction. For `Periodic` directions offsets are always
-wrapped periodically, independent of the `boundary` keyword. For `Bounded` directions the `boundary`
-keyword picks the policy (default: `:shrink`):
+Stencil offsets that leave the interior `1:Nd_grid` of a direction are handled per-direction using
+Oceananigans boundary conditions, supplied via `boundary_conditions` and kept **separate** from the
+filtered field's own boundary conditions:
 
-  - `:shrink` — drop out-of-bounds offsets from *both* the sum and the count, so the filter is an
-    honest local average whose effective stencil shrinks near a wall. **This is the default for
-    `Bounded` directions.**
-  - `:edge` — replicate the boundary-cell value (reads `ψ[1]` or `ψ[Nd_grid]` for offsets past either
-    end).
-  - `(left=a, right=b)` — pad with constant `a` on the low-index side and `b` on the high-index side
-    (`a` and `b` are promoted to a common type).
+  - `nothing` (default) — every side inherits the filtered field's own boundary condition for that
+    direction.
+  - a single `BoundaryCondition` — applied to every filtered side.
+  - a `FieldBoundaryConditions` — one condition per side; any side left unset
+    (`DefaultBoundaryCondition`) inherits the field's.
 
-`boundary` may be a single spec applied to every filtered dim, or a tuple with one entry per dim in
-`dims` (in the order the user passed them):
+Each boundary condition maps to a stencil rule:
 
-    BoxFilter(; dims=(1, 2), N=7, boundary=:edge)
-    BoxFilter(; dims=(1, 2), N=7, boundary=(:shrink, :edge))
-    BoxFilter(; dims=(1,),   N=7, boundary=(left=0.0, right=1.0))
+  - `ShrinkingBoundaryCondition()` — drop out-of-bounds offsets from *both* the sum and the count, so
+    the filter is an honest local average whose effective stencil shrinks near a wall.
+  - a zero `GradientBoundaryCondition` / `FluxBoundaryCondition` (incl. `NoFluxBoundaryCondition`) —
+    replicate the boundary-cell value (reads `ψ[1]` or `ψ[Nd_grid]` past either end).
+  - `ValueBoundaryCondition(v)` — pad with the constant `v`.
+  - anything without a discrete analog (a non-zero gradient/flux, an `OpenBoundaryCondition`, …) falls
+    back to the shrinking stencil.
 
-Because every policy wraps, clamps, or skips indices up front, `halo_size(grid)` does not constrain
-`N`: a small halo on a bounded direction is fine. The output location matches the location of the
-field the filter is applied to, which can be any input that supports the standard Oceananigans
-`ψ[i, j, k]` indexing contract (e.g. a `Field` or any `AbstractOperation`).
+For `Periodic` directions offsets are always wrapped, independent of `boundary_conditions`. When an
+`AbstractOperation` is filtered it is first materialized into a `Field` (carrying Oceananigans'
+default boundary conditions), which then supplies the inherited conditions.
 
-For `Periodic` directions the stencil must span at most one period: `N ≤ 2*Nd_grid + 1`, where
-`Nd_grid` is the number of cells along that direction. This is enforced when the filter is applied.
+Because every rule wraps, clamps, or skips indices up front, `halo_size(grid)` does not constrain `N`:
+a small halo on a bounded direction is fine. The output location matches the location of the filtered
+field. For `Periodic` directions the stencil must span at most one period: `N ≤ 2*Nd_grid + 1`.
 
 ## Examples
 
 Build a box filter and apply it on a 2D (xz) grid that is periodic in `x` and bounded in `z`. The
-`boundary=:edge` keyword explicitly overrides the default `:shrink` policy for the bounded
-`z`-direction; `x` is `Periodic` so the `boundary` spec is silently ignored for that direction
-regardless.
+`GradientBoundaryCondition(0)` (≡ edge replication) applies to the bounded `z`-direction; `x` is
+`Periodic` so it is wrapped regardless.
 
 ```jldoctest
 julia> using Oceananigans, Oceanostics
@@ -186,24 +188,30 @@ julia> grid = RectilinearGrid(size=(8, 8), x=(0, 1), z=(0, 1),
 
 julia> c = CenterField(grid);
 
-julia> bf = BoxFilter(; dims=(1, 3), N=5, boundary=:edge)
-BoxFilter(dims=(1, 3), N=5, boundary=:edge)
+julia> bf = BoxFilter(; dims=(1, 3), N=5, boundary_conditions=GradientBoundaryCondition(0))
+BoxFilter(dims=(1, 3), N=5, boundary_conditions=GradientBoundaryCondition: 0)
 
 julia> bf(c) isa KernelFunctionOperation
 true
 ```
 
-A one-step shortcut `BoxFilter(ψ; dims, N, boundary)` is also accepted, which applies the filter to
-`ψ` immediately (equivalent to `BoxFilter(; dims, N, boundary)(ψ)`).
+A one-step shortcut `BoxFilter(ψ; dims, N, boundary_conditions)` is also accepted, which applies the
+filter to `ψ` immediately (equivalent to `BoxFilter(; dims, N, boundary_conditions)(ψ)`).
 """
-function BoxFilter(; dims, N, boundary=:shrink, boundary_conditions=boundary)
+function BoxFilter(; dims, N, boundary_conditions=nothing, boundary=nothing)
+    no_boundary_keyword(boundary)
     dims = tuplefy_dims(dims)
     validate_dims(dims)
     validate_N(N)
+    validate_boundary_conditions(boundary_conditions)
     return BoxFilterOperator(dims, N, boundary_conditions)
 end
 
-Base.show(io::IO, F::BoxFilterOperator) = print(io, "BoxFilter(dims=", F.dims, ", N=", F.N, ", boundary=", repr(F.boundary), ")")
+function Base.show(io::IO, F::BoxFilterOperator)
+    print(io, "BoxFilter(dims=", F.dims, ", N=", F.N)
+    F.boundary_conditions === nothing || print(io, ", boundary_conditions=", bc_summary(F.boundary_conditions))
+    print(io, ")")
+end
 #---
 
 #+++ Staged multi-direction evaluation

--- a/src/SpatialFilters/box_filter.jl
+++ b/src/SpatialFilters/box_filter.jl
@@ -88,10 +88,10 @@ computes its local box-average. Equivalent to `BoxFilter(; dims, N, boundary)(ψ
 Refer to [`BoxFilter`](@ref)`(; dims, N, boundary)` for the full description of the
 keyword arguments and boundary handling.
 """
-function BoxFilter(ψ; dims, N, boundary=:shrink)
+function BoxFilter(ψ; dims, N, boundary=:shrink, boundary_conditions=boundary)
     dims = tuplefy_dims(dims)
     validate_N(N)
-    grid, loc, sorted_dims, policies = resolve_filter_policies(ψ, dims, boundary)
+    grid, loc, sorted_dims, policies = resolve_filter_policies(ψ, dims, boundary_conditions)
     width = (N - 1) ÷ 2
     widths = ntuple(_ -> width, length(sorted_dims))
     validate_periodic_widths(grid, sorted_dims, policies, widths)
@@ -196,11 +196,11 @@ true
 A one-step shortcut `BoxFilter(ψ; dims, N, boundary)` is also accepted, which applies the filter to
 `ψ` immediately (equivalent to `BoxFilter(; dims, N, boundary)(ψ)`).
 """
-function BoxFilter(; dims, N, boundary=:shrink)
+function BoxFilter(; dims, N, boundary=:shrink, boundary_conditions=boundary)
     dims = tuplefy_dims(dims)
     validate_dims(dims)
     validate_N(N)
-    return BoxFilterOperator(dims, N, boundary)
+    return BoxFilterOperator(dims, N, boundary_conditions)
 end
 
 Base.show(io::IO, F::BoxFilterOperator) = print(io, "BoxFilter(dims=", F.dims, ", N=", F.N, ", boundary=", repr(F.boundary), ")")

--- a/src/SpatialFilters/gaussian_filter.jl
+++ b/src/SpatialFilters/gaussian_filter.jl
@@ -348,14 +348,17 @@ end
     $(SIGNATURES)
 
 One-step form: apply a Gaussian filter to `ψ` directly, returning the `KernelFunctionOperation` that
-computes its Gaussian-weighted local average. Equivalent to `GaussianFilter(; dims, σ, N, boundary)(ψ)`.
+computes its Gaussian-weighted local average. Equivalent to `GaussianFilter(; dims, σ, N, boundary_conditions)(ψ)`.
 
-Refer to [`GaussianFilter`](@ref)`(; dims, σ, N, boundary)` for the full description of the
+Refer to [`GaussianFilter`](@ref)`(; dims, σ, N, boundary_conditions)` for the full description of the
 keyword arguments, the Gaussian weighting, stretched-grid handling, and boundary handling.
 """
-function GaussianFilter(ψ; dims, σ, N=nothing, boundary=:shrink, boundary_conditions=boundary)
+function GaussianFilter(ψ; dims, σ, N=nothing, boundary_conditions=nothing, boundary=nothing)
+    no_boundary_keyword(boundary)
     dims = tuplefy_dims(dims)
     validate_σ(σ)
+    validate_boundary_conditions(boundary_conditions)
+    ψ = materialize_operand(ψ)
     grid, loc, sorted_dims, policies = resolve_filter_policies(ψ, dims, boundary_conditions)
 
     sorted_widths = resolve_gaussian_widths(N, σ, grid, dims, sorted_dims)
@@ -370,18 +373,19 @@ end
 """
     GaussianFilterOperator{D, S, NN, B}
 
-Returns a reusable Gaussian filter. Stores the `GaussianFilter` parameters
-(`dims`, `σ`, `N`, `boundary`) and, when called on a field `ψ`, returns `GaussianFilter(ψ; dims, σ, N, boundary)`.
-Construct one once with [`GaussianFilter`](@ref)`(; …)` and apply it to many fields.
+Returns a reusable Gaussian filter. Stores the `GaussianFilter` parameters (`dims`, `σ`, `N`,
+`boundary_conditions`) and, when called on a field `ψ`, returns
+`GaussianFilter(ψ; dims, σ, N, boundary_conditions)`. Construct one once with
+[`GaussianFilter`](@ref)`(; …)` and apply it to many fields.
 """
 struct GaussianFilterOperator{D, S, NN, B}
     dims::D
     σ::S
     N::NN
-    boundary::B
+    boundary_conditions::B
 end
 
-(F::GaussianFilterOperator)(ψ) = GaussianFilter(ψ; dims=F.dims, σ=F.σ, N=F.N, boundary=F.boundary)
+(F::GaussianFilterOperator)(ψ) = GaussianFilter(ψ; dims=F.dims, σ=F.σ, N=F.N, boundary_conditions=F.boundary_conditions)
 
 """
     $(SIGNATURES)
@@ -427,7 +431,7 @@ odd-integer count per dim in `dims` (in the order the user passed them). For `Pe
 directions the stencil must span at most one period (`N ≤ 2*Nd_grid + 1`, where `Nd_grid` is the
 number of cells along that direction); this is enforced when the filter is applied.
 
-See `BoxFilter` for the `dims` and `boundary` keyword documentation.
+See `BoxFilter` for the `dims` and `boundary_conditions` keyword documentation.
 
 ## Performance notes
 
@@ -451,25 +455,30 @@ julia> grid = RectilinearGrid(size=(8, 8), x=(0, 1), z=(0, 1),
 julia> c = CenterField(grid);
 
 julia> gf = GaussianFilter(; dims=(1, 3), σ=0.1)
-GaussianFilter(dims=(1, 3), σ=0.1, N=nothing, boundary=:shrink)
+GaussianFilter(dims=(1, 3), σ=0.1, N=nothing)
 
 julia> gf(c) isa KernelFunctionOperation
 true
 ```
 
-A one-step shortcut `GaussianFilter(ψ; dims, σ, N, boundary)` is also accepted, which applies the
-filter to `ψ` immediately (equivalent to `GaussianFilter(; dims, σ, N, boundary)(ψ)`).
+A one-step shortcut `GaussianFilter(ψ; dims, σ, N, boundary_conditions)` is also accepted, which applies
+the filter to `ψ` immediately (equivalent to `GaussianFilter(; dims, σ, N, boundary_conditions)(ψ)`).
 """
-function GaussianFilter(; dims, σ, N=nothing, boundary=:shrink, boundary_conditions=boundary)
+function GaussianFilter(; dims, σ, N=nothing, boundary_conditions=nothing, boundary=nothing)
+    no_boundary_keyword(boundary)
     dims = tuplefy_dims(dims)
     validate_dims(dims)
     validate_σ(σ)
+    validate_boundary_conditions(boundary_conditions)
     N === nothing || (N isa Tuple ? foreach(validate_N, N) : validate_N(N))
     return GaussianFilterOperator(dims, σ, N, boundary_conditions)
 end
 
-Base.show(io::IO, F::GaussianFilterOperator) =
-    print(io, "GaussianFilter(dims=", F.dims, ", σ=", F.σ, ", N=", F.N, ", boundary=", repr(F.boundary), ")")
+function Base.show(io::IO, F::GaussianFilterOperator)
+    print(io, "GaussianFilter(dims=", F.dims, ", σ=", F.σ, ", N=", F.N)
+    F.boundary_conditions === nothing || print(io, ", boundary_conditions=", bc_summary(F.boundary_conditions))
+    print(io, ")")
+end
 #---
 
 infer_width(σ, grid, d) = ceil(Int, 2σ / direction_min_spacing(grid, d))

--- a/src/SpatialFilters/gaussian_filter.jl
+++ b/src/SpatialFilters/gaussian_filter.jl
@@ -353,10 +353,10 @@ computes its Gaussian-weighted local average. Equivalent to `GaussianFilter(; di
 Refer to [`GaussianFilter`](@ref)`(; dims, σ, N, boundary)` for the full description of the
 keyword arguments, the Gaussian weighting, stretched-grid handling, and boundary handling.
 """
-function GaussianFilter(ψ; dims, σ, N=nothing, boundary=:shrink)
+function GaussianFilter(ψ; dims, σ, N=nothing, boundary=:shrink, boundary_conditions=boundary)
     dims = tuplefy_dims(dims)
     validate_σ(σ)
-    grid, loc, sorted_dims, policies = resolve_filter_policies(ψ, dims, boundary)
+    grid, loc, sorted_dims, policies = resolve_filter_policies(ψ, dims, boundary_conditions)
 
     sorted_widths = resolve_gaussian_widths(N, σ, grid, dims, sorted_dims)
     validate_periodic_widths(grid, sorted_dims, policies, sorted_widths)
@@ -460,12 +460,12 @@ true
 A one-step shortcut `GaussianFilter(ψ; dims, σ, N, boundary)` is also accepted, which applies the
 filter to `ψ` immediately (equivalent to `GaussianFilter(; dims, σ, N, boundary)(ψ)`).
 """
-function GaussianFilter(; dims, σ, N=nothing, boundary=:shrink)
+function GaussianFilter(; dims, σ, N=nothing, boundary=:shrink, boundary_conditions=boundary)
     dims = tuplefy_dims(dims)
     validate_dims(dims)
     validate_σ(σ)
     N === nothing || (N isa Tuple ? foreach(validate_N, N) : validate_N(N))
-    return GaussianFilterOperator(dims, σ, N, boundary)
+    return GaussianFilterOperator(dims, σ, N, boundary_conditions)
 end
 
 Base.show(io::IO, F::GaussianFilterOperator) =

--- a/test/test_spatial_filters.jl
+++ b/test/test_spatial_filters.jl
@@ -38,6 +38,11 @@ function compute_filter(ψ, Filter, dims, width; kwargs...)
     return cf
 end
 
+# A `FieldBoundaryConditions` setting just the two sides of one direction `d` (the others inherit).
+dim_fbc(d, low, high) = d == 1 ? FieldBoundaryConditions(west=low, east=high) :
+                        d == 2 ? FieldBoundaryConditions(south=low, north=high) :
+                                 FieldBoundaryConditions(bottom=low, top=high)
+
 box_weights(width) = ntuple(_ -> 1.0, 2*width + 1)
 gauss_weights(width, σ) = ntuple(idx -> exp(-(idx - width - 1)^2 / (2σ^2)), 2*width + 1)
 #---
@@ -254,8 +259,8 @@ function test_small_halo(Filter, fkw)
     for g in (tiny_periodic, tiny_bounded, tiny_mixed)
         c = CenterField(g)
         @test Filter(c; dims=(1,),      N=11, fkw...)                                 isa KernelFunctionOperation
-        @test Filter(c; dims=(1, 2, 3), N=11, boundary=:edge, fkw...)                 isa KernelFunctionOperation
-        @test Filter(c; dims=(1, 2, 3), N=11, boundary=(left=0.0, right=0.0), fkw...) isa KernelFunctionOperation
+        @test Filter(c; dims=(1, 2, 3), N=11, boundary_conditions=GradientBoundaryCondition(0), fkw...) isa KernelFunctionOperation
+        @test Filter(c; dims=(1, 2, 3), N=11, boundary_conditions=ValueBoundaryCondition(0.0), fkw...)  isa KernelFunctionOperation
     end
 end
 
@@ -265,7 +270,7 @@ function test_shrink_boundary(Ns, Filter, make_weights, fkw)
     ic = Array(interior(c))
     for dims in [(1,), (2,), (3,), (1, 2), (1, 2, 3)]
         width = 2
-        cf  = compute_filter(c, Filter, dims, width; fkw...)
+        cf  = compute_filter(c, Filter, dims, width; boundary_conditions=ShrinkingBoundaryCondition(), fkw...)
         w1d = make_weights(width)
         ref = reference_weighted_average_shrink(ic, dims, width, Ns, w1d)
         @test Array(interior(cf)) ≈ ref
@@ -278,7 +283,7 @@ function test_edge_boundary(Ns, Filter, make_weights, fkw)
     ic = Array(interior(c))
     for dims in [(1,), (2,), (3,), (1, 2, 3)]
         width = 2
-        cf  = compute_filter(c, Filter, dims, width; boundary=:edge, fkw...)
+        cf  = compute_filter(c, Filter, dims, width; boundary_conditions=GradientBoundaryCondition(0), fkw...)
         w1d = make_weights(width)
         ref = reference_weighted_average_edge(ic, dims, width, Ns, w1d)
         @test Array(interior(cf)) ≈ ref
@@ -292,7 +297,8 @@ function test_constant_pad_boundary(Ns, Filter, make_weights, fkw)
     left, right = -1.25, 2.5
     for (d, width) in [(1, 2), (2, 3), (3, 2)]
         dims = (d,)
-        cf  = compute_filter(c, Filter, dims, width; boundary=(left=left, right=right), fkw...)
+        cf  = compute_filter(c, Filter, dims, width;
+                             boundary_conditions=dim_fbc(d, ValueBoundaryCondition(left), ValueBoundaryCondition(right)), fkw...)
         w1d = make_weights(width)
         ref = reference_weighted_average_constant_1d(ic, d, width, Ns, w1d, left, right)
         @test Array(interior(cf)) ≈ ref
@@ -304,7 +310,10 @@ function test_per_dim_boundary(Ns, Filter, make_weights, fkw)
     c  = center_field_from(bounded_grid, (x, y, z) -> sin(2π * x) * cos(2π * y))
     ic = Array(interior(c))
     width = 2
-    cf = compute_filter(c, Filter, (1, 2), width; boundary=(:shrink, :edge), fkw...)
+    cf = compute_filter(c, Filter, (1, 2), width;
+                        boundary_conditions=FieldBoundaryConditions(west=ShrinkingBoundaryCondition(), east=ShrinkingBoundaryCondition(),
+                                                                    south=GradientBoundaryCondition(0), north=GradientBoundaryCondition(0)),
+                        fkw...)
     w1d = make_weights(width)
     shrink_in_x       = reference_weighted_average_shrink(ic,        (1,), width, Ns, w1d)
     edge_of_shrink_xy = reference_weighted_average_edge(shrink_in_x, (2,), width, Ns, w1d)
@@ -315,18 +324,19 @@ function test_periodic_ignores_boundary(Filter, fkw)
     mixed_grid = make_grid(; halo=(1, 1, 1), topology=(Periodic, Bounded, Bounded))
     c = center_field_from(mixed_grid, (x, y, z) -> sin(2π * x) + y)
     cf_default = compute_filter(c, Filter, (1,), 3; fkw...)
-    cf_absurd  = compute_filter(c, Filter, (1,), 3; boundary=(left=1e6, right=-1e6), fkw...)
+    cf_absurd  = compute_filter(c, Filter, (1,), 3; boundary_conditions=ValueBoundaryCondition(1e6), fkw...)
     @test Array(interior(cf_default)) ≈ Array(interior(cf_absurd))
 end
 
 function test_boundary_validation(grid, Filter, fkw)
     c = CenterField(grid)
-    @test_throws ArgumentError Filter(c; dims=(1,),   N=3, boundary=:foo, fkw...)
-    @test_throws ArgumentError Filter(c; dims=(1,),   N=3, boundary=(foo=1,), fkw...)
-    @test_throws ArgumentError Filter(c; dims=(1,),   N=3, boundary=(left=1, right=2, mid=3), fkw...)
-    @test_throws ArgumentError Filter(c; dims=(1,),   N=3, boundary=42, fkw...)
-    @test_throws ArgumentError Filter(c; dims=(1, 2), N=3, boundary=(:shrink,), fkw...)
-    @test_throws ArgumentError Filter(c; dims=(1,),   N=3, boundary=(:shrink, :edge), fkw...)
+    # `boundary_conditions` must be nothing / a BoundaryCondition / a FieldBoundaryConditions.
+    @test_throws ArgumentError Filter(c; dims=(1,), N=3, boundary_conditions=:edge, fkw...)
+    @test_throws ArgumentError Filter(c; dims=(1,), N=3, boundary_conditions=(left=1, right=2), fkw...)
+    @test_throws ArgumentError Filter(c; dims=(1,), N=3, boundary_conditions=42, fkw...)
+    @test_throws ArgumentError Filter(c; dims=(1,), N=3, boundary_conditions=(ShrinkingBoundaryCondition(),), fkw...)
+    # The old `boundary` keyword and its symbol specs were removed.
+    @test_throws ArgumentError Filter(c; dims=(1,), N=3, boundary=:shrink, fkw...)
 end
 #---
 
@@ -357,30 +367,34 @@ function test_1d_bounded_hand_computed()
     fill_halo_regions!(c)
 
     # :shrink, width=2
+    shrink = ShrinkingBoundaryCondition()
+    edge   = GradientBoundaryCondition(0)
+    pad(l, r) = FieldBoundaryConditions(west=ValueBoundaryCondition(l), east=ValueBoundaryCondition(r))
+
     shrink_expected = [1, 1.5, 2, 3, 4, 5, 6, 7, 7.5, 8]
-    @test Array(interior(compute_filter(c, BoxFilter, (1,), 2)))[:] ≈ shrink_expected
+    @test Array(interior(compute_filter(c, BoxFilter, (1,), 2; boundary_conditions=shrink)))[:] ≈ shrink_expected
 
-    # :shrink, width=3
+    # shrink, width=3
     shrink_expected_w3 = [1.5, 2, 2.5, 3, 4, 5, 6, 6.5, 7, 7.5]
-    @test Array(interior(compute_filter(c, BoxFilter, (1,), 3)))[:] ≈ shrink_expected_w3
+    @test Array(interior(compute_filter(c, BoxFilter, (1,), 3; boundary_conditions=shrink)))[:] ≈ shrink_expected_w3
 
-    # :edge, width=2
+    # edge, width=2
     edge_expected = [0.6, 1.2, 2, 3, 4, 5, 6, 7, 7.8, 8.4]
-    @test Array(interior(compute_filter(c, BoxFilter, (1,), 2; boundary=:edge)))[:] ≈ edge_expected
+    @test Array(interior(compute_filter(c, BoxFilter, (1,), 2; boundary_conditions=edge)))[:] ≈ edge_expected
 
-    # :edge, width=3
+    # edge, width=3
     edge_expected_w3 = [6/7, 10/7, 15/7, 3, 4, 5, 6, 48/7, 53/7, 57/7]
-    @test Array(interior(compute_filter(c, BoxFilter, (1,), 3; boundary=:edge)))[:] ≈ edge_expected_w3
+    @test Array(interior(compute_filter(c, BoxFilter, (1,), 3; boundary_conditions=edge)))[:] ≈ edge_expected_w3
 
     # Constant-pad (left=-1, right=-2), width=2
     const_expected = [0.2, 1, 2, 3, 4, 5, 6, 7, 5.6, 4]
     @test Array(interior(compute_filter(c, BoxFilter, (1,), 2;
-                                        boundary=(left=-1.0, right=-2.0))))[:] ≈ const_expected
+                                        boundary_conditions=pad(-1.0, -2.0))))[:] ≈ const_expected
 
     # Constant-pad (left=-1, right=-2), width=3
     const_expected_w3 = [3/7, 8/7, 2, 3, 4, 5, 6, 37/7, 31/7, 24/7]
     @test Array(interior(compute_filter(c, BoxFilter, (1,), 3;
-                                        boundary=(left=-1.0, right=-2.0))))[:] ≈ const_expected_w3
+                                        boundary_conditions=pad(-1.0, -2.0))))[:] ≈ const_expected_w3
 end
 #---
 
@@ -551,8 +565,8 @@ function test_gaussian_stretched_numerical()
         # Bounded stretched z, :shrink and :edge
         gz = make_stretched_z_grid()
         cz = center_field_from(gz, (x, y, z) -> sin(2π*x) * cos(2π*y) + z^2 + 0.3z)
-        for boundary in (:shrink, :edge)
-            cf = compute_filter(cz, GaussianFilter, (3,), width; σ=σ, boundary=boundary)
+        for (boundary, bc) in ((:shrink, ShrinkingBoundaryCondition()), (:edge, GradientBoundaryCondition(0)))
+            cf = compute_filter(cz, GaussianFilter, (3,), width; σ=σ, boundary_conditions=bc)
             ref = reference_gaussian_stretched(cz, gz, 3, σ, width; boundary=boundary)
             @test Array(interior(cf)) ≈ ref
         end
@@ -705,9 +719,9 @@ function test_reusable_box_filter(grid)
     # The two filtered fields differ (the operator did not capture the field).
     @test !(Array(interior(Field(F(c)))) ≈ Array(interior(Field(F(d)))))
 
-    # The boundary keyword is threaded through.
-    Fb = BoxFilter(; dims=(1,), N=5, boundary=:edge)
-    @test Fb(c) == BoxFilter(c; dims=(1,), N=5, boundary=:edge)
+    # The boundary_conditions keyword is threaded through.
+    Fb = BoxFilter(; dims=(1,), N=5, boundary_conditions=GradientBoundaryCondition(0))
+    @test Fb(c) == BoxFilter(c; dims=(1,), N=5, boundary_conditions=GradientBoundaryCondition(0))
 
     # show prints something tidy.
     @test occursin("BoxFilter(dims=", sprint(show, F))
@@ -732,9 +746,9 @@ function test_reusable_gaussian_filter(grid)
 
     @test !(Array(interior(Field(F(c)))) ≈ Array(interior(Field(F(d)))))
 
-    # The N and boundary keywords are threaded through.
-    FN = GaussianFilter(; dims=(1,), σ=0.1, N=5, boundary=:edge)
-    @test FN(c) == GaussianFilter(c; dims=(1,), σ=0.1, N=5, boundary=:edge)
+    # The N and boundary_conditions keywords are threaded through.
+    FN = GaussianFilter(; dims=(1,), σ=0.1, N=5, boundary_conditions=GradientBoundaryCondition(0))
+    @test FN(c) == GaussianFilter(c; dims=(1,), σ=0.1, N=5, boundary_conditions=GradientBoundaryCondition(0))
 
     @test occursin("GaussianFilter(dims=", sprint(show, F))
 
@@ -747,32 +761,53 @@ function test_reusable_gaussian_filter(grid)
     @test Array(interior(Field(GaussianFilter(c; dims=1, σ=0.1)))) ≈ Array(interior(Field(GaussianFilter(c; dims=(1,), σ=0.1))))
 end
 
-# Oceananigans `BoundaryCondition` interface (issue #251): type-based specs reproduce the symbol /
-# NamedTuple API, the `boundary_conditions` keyword aliases `boundary`, and a `FieldBoundaryConditions`
-# resolves per side (collapsing when symmetric, splitting when not).
-function test_boundary_condition_interface(Filter, fkw)
+# Oceananigans `BoundaryCondition` interface (issue #251): boundary conditions are inherited per
+# direction from the filtered field, a single BC or a partial `FieldBoundaryConditions` overrides,
+# `AbstractOperation`s are materialized first, and the resolution is robust across BC kinds.
+function test_boundary_condition_interface(Ns, Filter, make_weights, fkw)
     grid = make_grid(; halo=(1, 1, 1), topology=(Bounded, Bounded, Bounded))
     c = center_field_from(grid, (x, y, z) -> sin(2π * x) * cos(2π * y) + z^2)
+    ic = Array(interior(c))
     ia(ψ) = Array(interior(ψ))
-    w = 2
+    w1d = make_weights(2)
 
-    @test ia(compute_filter(c, Filter, (1, 3), w; boundary=ShrinkingBoundaryCondition(), fkw...)) ≈ ia(compute_filter(c, Filter, (1, 3), w; boundary=:shrink, fkw...))
-    @test ia(compute_filter(c, Filter, (1, 3), w; boundary=GradientBoundaryCondition(0), fkw...)) ≈ ia(compute_filter(c, Filter, (1, 3), w; boundary=:edge, fkw...))
-    @test ia(compute_filter(c, Filter, (1, 3), w; boundary=ValueBoundaryCondition(0.5), fkw...))  ≈ ia(compute_filter(c, Filter, (1, 3), w; boundary=(left=0.5, right=0.5), fkw...))
+    edge3   = reference_weighted_average_edge(ic,   (1, 2, 3), 2, Ns, w1d)
+    shrink3 = reference_weighted_average_shrink(ic, (1, 2, 3), 2, Ns, w1d)
+    edgex   = reference_weighted_average_edge(ic,   (1,),      2, Ns, w1d)
+    shrinkx = reference_weighted_average_shrink(ic, (1,),      2, Ns, w1d)
 
-    # `boundary_conditions` is an alias for `boundary`.
-    @test ia(compute_filter(c, Filter, (1, 3), w; boundary_conditions=:edge, fkw...)) ≈ ia(compute_filter(c, Filter, (1, 3), w; boundary=:edge, fkw...))
+    # Default (`nothing`): a CenterField carries NoFlux BCs, which map to edge replication.
+    @test ia(compute_filter(c, Filter, (1, 2, 3), 2; fkw...)) ≈ edge3
 
-    # FieldBoundaryConditions: symmetric reproduces the symbol spec; asymmetric is finite and distinct.
-    fbc_sym  = FieldBoundaryConditions(west=GradientBoundaryCondition(0), east=GradientBoundaryCondition(0))
-    @test ia(compute_filter(c, Filter, (1,), w; boundary_conditions=fbc_sym, fkw...)) ≈ ia(compute_filter(c, Filter, (1,), w; boundary=:edge, fkw...))
-    fbc_asym = FieldBoundaryConditions(west=ValueBoundaryCondition(0.0), east=GradientBoundaryCondition(0))
-    a = ia(compute_filter(c, Filter, (1,), w; boundary_conditions=fbc_asym, fkw...))
-    @test all(isfinite, a)
-    @test !(a ≈ ia(compute_filter(c, Filter, (1,), w; boundary=:edge, fkw...)))
+    # A single BoundaryCondition overrides every filtered side.
+    @test ia(compute_filter(c, Filter, (1, 2, 3), 2; boundary_conditions=ShrinkingBoundaryCondition(), fkw...)) ≈ shrink3
+    @test ia(compute_filter(c, Filter, (1, 2, 3), 2; boundary_conditions=GradientBoundaryCondition(0),  fkw...)) ≈ edge3
 
-    # Unsupported (non-zero) gradient/flux conditions error.
-    @test_throws ArgumentError compute_filter(c, Filter, (1,), w; boundary=GradientBoundaryCondition(1.0), fkw...)
+    # A partial FieldBoundaryConditions overrides the west side and inherits the east side from the
+    # field (NoFlux → edge): equal to spelling both sides out, and distinct from either pure case.
+    partial = FieldBoundaryConditions(west=ShrinkingBoundaryCondition())
+    full    = FieldBoundaryConditions(west=ShrinkingBoundaryCondition(), east=GradientBoundaryCondition(0))
+    mixed   = ia(compute_filter(c, Filter, (1,), 2; boundary_conditions=partial, fkw...))
+    @test mixed ≈ ia(compute_filter(c, Filter, (1,), 2; boundary_conditions=full, fkw...))
+    @test !(mixed ≈ edgex) && !(mixed ≈ shrinkx)
+
+    # An AbstractOperation operand is materialized to a Field first; filtering it matches filtering the
+    # pre-materialized Field.
+    opf = Field(c + c); compute!(opf)
+    @test ia(compute_filter(c + c, Filter, (1, 2), 2; boundary_conditions=ShrinkingBoundaryCondition(), fkw...)) ≈
+          ia(compute_filter(opf,   Filter, (1, 2), 2; boundary_conditions=ShrinkingBoundaryCondition(), fkw...))
+
+    # Robust across BC kinds: conditions without a discrete analog (non-zero gradient, Open, …) fall
+    # back to shrinking instead of erroring.
+    @test ia(compute_filter(c, Filter, (1,), 2; boundary_conditions=GradientBoundaryCondition(3.0), fkw...)) ≈ shrinkx
+
+    # A field whose own BCs are ValueBoundaryConditions has them inherited by the default filter.
+    vfbc = FieldBoundaryConditions(grid, (Center(), Center(), Center()),
+                                   west=ValueBoundaryCondition(0.0), east=ValueBoundaryCondition(0.0))
+    cv = CenterField(grid; boundary_conditions=vfbc)
+    set!(cv, (x, y, z) -> sin(2π * x) * cos(2π * y) + z^2)
+    @test ia(compute_filter(cv, Filter, (1,), 2; fkw...)) ≈
+          ia(compute_filter(cv, Filter, (1,), 2; boundary_conditions=ValueBoundaryCondition(0.0), fkw...))
 end
 #---
 
@@ -817,7 +852,7 @@ filter_configs = [
             end
 
             @testset "BoundaryCondition interface" begin
-                test_boundary_condition_interface(Filter, fkw)
+                test_boundary_condition_interface(Ns, Filter, make_weights, fkw)
             end
 
             @testset "Composability" begin

--- a/test/test_spatial_filters.jl
+++ b/test/test_spatial_filters.jl
@@ -746,6 +746,34 @@ function test_reusable_gaussian_filter(grid)
     @test GaussianFilter(; dims=1, σ=0.1).dims === (1,)
     @test Array(interior(Field(GaussianFilter(c; dims=1, σ=0.1)))) ≈ Array(interior(Field(GaussianFilter(c; dims=(1,), σ=0.1))))
 end
+
+# Oceananigans `BoundaryCondition` interface (issue #251): type-based specs reproduce the symbol /
+# NamedTuple API, the `boundary_conditions` keyword aliases `boundary`, and a `FieldBoundaryConditions`
+# resolves per side (collapsing when symmetric, splitting when not).
+function test_boundary_condition_interface(Filter, fkw)
+    grid = make_grid(; halo=(1, 1, 1), topology=(Bounded, Bounded, Bounded))
+    c = center_field_from(grid, (x, y, z) -> sin(2π * x) * cos(2π * y) + z^2)
+    ia(ψ) = Array(interior(ψ))
+    w = 2
+
+    @test ia(compute_filter(c, Filter, (1, 3), w; boundary=ShrinkingBoundaryCondition(), fkw...)) ≈ ia(compute_filter(c, Filter, (1, 3), w; boundary=:shrink, fkw...))
+    @test ia(compute_filter(c, Filter, (1, 3), w; boundary=GradientBoundaryCondition(0), fkw...)) ≈ ia(compute_filter(c, Filter, (1, 3), w; boundary=:edge, fkw...))
+    @test ia(compute_filter(c, Filter, (1, 3), w; boundary=ValueBoundaryCondition(0.5), fkw...))  ≈ ia(compute_filter(c, Filter, (1, 3), w; boundary=(left=0.5, right=0.5), fkw...))
+
+    # `boundary_conditions` is an alias for `boundary`.
+    @test ia(compute_filter(c, Filter, (1, 3), w; boundary_conditions=:edge, fkw...)) ≈ ia(compute_filter(c, Filter, (1, 3), w; boundary=:edge, fkw...))
+
+    # FieldBoundaryConditions: symmetric reproduces the symbol spec; asymmetric is finite and distinct.
+    fbc_sym  = FieldBoundaryConditions(west=GradientBoundaryCondition(0), east=GradientBoundaryCondition(0))
+    @test ia(compute_filter(c, Filter, (1,), w; boundary_conditions=fbc_sym, fkw...)) ≈ ia(compute_filter(c, Filter, (1,), w; boundary=:edge, fkw...))
+    fbc_asym = FieldBoundaryConditions(west=ValueBoundaryCondition(0.0), east=GradientBoundaryCondition(0))
+    a = ia(compute_filter(c, Filter, (1,), w; boundary_conditions=fbc_asym, fkw...))
+    @test all(isfinite, a)
+    @test !(a ≈ ia(compute_filter(c, Filter, (1,), w; boundary=:edge, fkw...)))
+
+    # Unsupported (non-zero) gradient/flux conditions error.
+    @test_throws ArgumentError compute_filter(c, Filter, (1,), w; boundary=GradientBoundaryCondition(1.0), fkw...)
+end
 #---
 
 #+++ Run tests
@@ -786,6 +814,10 @@ filter_configs = [
                 test_constant_pad_boundary(Ns, Filter, make_weights, fkw)
                 test_per_dim_boundary(Ns, Filter, make_weights, fkw)
                 test_periodic_ignores_boundary(Filter, fkw)
+            end
+
+            @testset "BoundaryCondition interface" begin
+                test_boundary_condition_interface(Filter, fkw)
             end
 
             @testset "Composability" begin


### PR DESCRIPTION
Closes #251

Spatial filters take their boundary treatment from Oceananigans boundary conditions; the symbol API is removed. `boundary_conditions` accepts:

- `nothing` *(default)* — every side inherits the filtered field’s own boundary condition
- a single `BoundaryCondition` — applied to every filtered side
- a `FieldBoundaryConditions` — per side; any unset side inherits from the field

Resolution is per side/direction (explicit overrides, unset inherits), kept separate from the field’s own BCs. Mapping: `ShrinkingBoundaryCondition()` → shrink, zero `Gradient`/`Flux` (incl. `NoFlux`) → edge, `ValueBoundaryCondition(v)` → constant pad. Anything without a discrete analog (non-zero gradient/flux, `Open`, …) falls back to shrinking, so it stays robust across BC kinds. An `AbstractOperation` operand is materialized into a `Field` first (so it too carries conditions to inherit).

```julia
bcs = FieldBoundaryConditions(east=GradientBoundaryCondition(0))  # east set; other sides inherit u’s BCs
ū = GaussianFilter(; dims=(1, 3), σ=0.1, boundary_conditions=bcs)(u)
```

**Breaking:** `:shrink`/`:edge`/`(left=, right=)` and the `boundary` keyword now error with a migration message; the default changes from `:shrink` to inheriting the field’s BCs (a default `CenterField` is `NoFlux` → edge).

### Still open
- Non-zero `Gradient`/`Flux` extrapolation isn’t implemented (falls back to shrinking).
- `show` renders a stored `FieldBoundaryConditions` compactly as `FieldBoundaryConditions(…)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)