### PR TITLE
Fix heap corruption when computing a multi-direction filter into a windowed field

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["tomchor <tomaschor@gmail.com>"]
 
 [deps]

--- a/src/SpatialFilters/SpatialFilters.jl
+++ b/src/SpatialFilters/SpatialFilters.jl
@@ -268,14 +268,9 @@ using Oceananigans.Utils: KernelParameters, launch!
 @inline _single_dim_kfo(loc, grid, kern, valw, pol, input) =
     KernelFunctionOperation{loc...}(kern, grid, valw, pol, input)
 
-# Evaluate `kfo` over the destination field's iteration space and write the
-# result into it. Reuses Oceananigans' trivial copy kernel `_compute!`
-# (`data[i,j,k] = operand[i,j,k]`). The iteration space is taken from `dest`
-# (its windowed size and index offsets), *not* from `kfo`: when `dest` is a
-# windowed output field (e.g. an output writer's `indices=(:, :, Nz)` slice)
-# its data holds only the window, so iterating over the full `size(kfo)` would
-# write out of bounds. This mirrors Oceananigans' own `compute_computed_field!`,
-# which launches with `KernelParameters(size(comp), map(offset_index, comp.indices))`.
+# Evaluate `kfo` into `dest` via Oceananigans' copy kernel. The iteration space comes from
+# `dest`, not `kfo`: a windowed `dest` (e.g. an output writer's `indices=(:, :, Nz)` slice)
+# holds only the window, so sizing the launch from `kfo` would write out of bounds.
 function _launch_compute_into!(dest, grid, kfo)
     arch = architecture(grid)
     params = KernelParameters(size(dest), map(offset_index, dest.indices))

--- a/src/SpatialFilters/SpatialFilters.jl
+++ b/src/SpatialFilters/SpatialFilters.jl
@@ -268,13 +268,18 @@ using Oceananigans.Utils: KernelParameters, launch!
 @inline _single_dim_kfo(loc, grid, kern, valw, pol, input) =
     KernelFunctionOperation{loc...}(kern, grid, valw, pol, input)
 
-# Run `kfo` over its iteration space and write the result into `data`.
-# Reuses Oceananigans' trivial copy kernel `_compute!`
-# (`data[i,j,k] = operand[i,j,k]`).
-function _launch_compute_into!(data, indices, grid, kfo)
+# Evaluate `kfo` over the destination field's iteration space and write the
+# result into it. Reuses Oceananigans' trivial copy kernel `_compute!`
+# (`data[i,j,k] = operand[i,j,k]`). The iteration space is taken from `dest`
+# (its windowed size and index offsets), *not* from `kfo`: when `dest` is a
+# windowed output field (e.g. an output writer's `indices=(:, :, Nz)` slice)
+# its data holds only the window, so iterating over the full `size(kfo)` would
+# write out of bounds. This mirrors Oceananigans' own `compute_computed_field!`,
+# which launches with `KernelParameters(size(comp), map(offset_index, comp.indices))`.
+function _launch_compute_into!(dest, grid, kfo)
     arch = architecture(grid)
-    params = KernelParameters(size(kfo), map(offset_index, indices))
-    launch!(arch, grid, params, _compute!, data, kfo)
+    params = KernelParameters(size(dest), map(offset_index, dest.indices))
+    launch!(arch, grid, params, _compute!, dest.data, kfo)
     return nothing
 end
 
@@ -286,7 +291,7 @@ end
 function _stage_into_temp(loc, grid, kern, valw, pol, input)
     kfo = _single_dim_kfo(loc, grid, kern, valw, pol, input)
     temp = Field(kfo, compute=false)
-    _launch_compute_into!(temp.data, temp.indices, grid, kfo)
+    _launch_compute_into!(temp, grid, kfo)
     return temp
 end
 
@@ -320,7 +325,7 @@ function _compute_staged_filter!(comp, time)
         final = _single_dim_kfo(loc, grid, kern3, valw3, pol3, temp2)
     end
 
-    _launch_compute_into!(comp.data, comp.indices, grid, final)
+    _launch_compute_into!(comp, grid, final)
     fill_halo_regions!(comp)
     set_status!(comp.status, time)
     return comp

--- a/test/test_spatial_filters.jl
+++ b/test/test_spatial_filters.jl
@@ -203,6 +203,25 @@ function test_kfo_input(grid, Filter, fkw)
     @test location(outer) == (Center, Center, Center)
 end
 
+# A windowed output field — e.g. an output writer's `indices=(:, :, Nz)` surface
+# slice — must compute through the staged multi-direction path without writing
+# out of bounds, and must agree with the matching slice of the full field.
+# Regression test for a heap corruption where the staged compute used the full
+# operand size as its iteration space instead of the windowed destination size.
+function test_windowed_output_matches_full(grid, Filter, fkw)
+    c = center_field_from(grid, (x, y, z) -> sin(2π*x) * cos(2π*y) + sin(2π*z))
+    Nx, Ny, Nz = size(grid)
+    for (dims, indices) in [((1, 2),    (:, :, Nz)),     # window outside the filtered dims
+                            ((1, 2),    (:, Ny, :)),     # window inside a filtered dim
+                            ((1, 2, 3), (:, :, Nz))]     # 3D staged path, windowed
+        full = Field(Filter(c; dims=dims, N=3, fkw...))
+        win  = Field(Filter(c; dims=dims, N=3, fkw...); indices=indices)
+        compute!(full); compute!(win)
+        ref_indices = ntuple(d -> indices[d] isa Colon ? Colon() : (indices[d]:indices[d]), 3)
+        @test Array(interior(win)) ≈ Array(view(interior(full), ref_indices...))
+    end
+end
+
 function test_dims_validation(grid, Filter, fkw)
     c = CenterField(grid)
     @test_throws ArgumentError Filter(c; dims=(),     N=3, fkw...)
@@ -791,6 +810,10 @@ filter_configs = [
             @testset "Composability" begin
                 test_abstract_operation_input(grid, Nx, Ny, Filter, fkw)
                 test_kfo_input(grid, Filter, fkw)
+            end
+
+            @testset "Windowed output" begin
+                test_windowed_output_matches_full(grid, Filter, fkw)
             end
 
             @testset "Argument validation" begin

--- a/test/test_spatial_filters.jl
+++ b/test/test_spatial_filters.jl
@@ -203,11 +203,9 @@ function test_kfo_input(grid, Filter, fkw)
     @test location(outer) == (Center, Center, Center)
 end
 
-# A windowed output field — e.g. an output writer's `indices=(:, :, Nz)` surface
-# slice — must compute through the staged multi-direction path without writing
-# out of bounds, and must agree with the matching slice of the full field.
-# Regression test for a heap corruption where the staged compute used the full
-# operand size as its iteration space instead of the windowed destination size.
+# Regression test: a windowed output field (e.g. an output writer's `indices=(:, :, Nz)`
+# slice) must compute through the staged path without writing out of bounds, and must agree
+# with the matching slice of the full field.
 function test_windowed_output_matches_full(grid, Filter, fkw)
     c = center_field_from(grid, (x, y, z) -> sin(2π*x) * cos(2π*y) + sin(2π*z))
     Nx, Ny, Nz = size(grid)


### PR DESCRIPTION
Closes https://github.com/tomchor/Oceanostics.jl/issues/262

Computing a multi-direction `BoxFilter` / `GaussianFilter` into a windowed field (e.g. an output writer's `indices=(:, :, Nz)` surface slice) trows an error:

```julia
using Oceananigans, Oceanostics

grid = RectilinearGrid(size=(4, 4, 4), x=(0, 1), y=(0, 1), z=(0, 1),
                       topology=(Periodic, Periodic, Bounded))
c = CenterField(grid)

filtered = GaussianFilter(c; dims=(1, 2), σ=0.2)     # 2D filter → staged compute path
surface  = Field(filtered; indices=(:, :, grid.Nz))  # windowed output, e.g. a surface slice
compute!(surface)                                     # aborts the process before this fix
```

A 1D filter or a full (non-windowed) `Field(filtered)` both work fine, which is why the bug only surfaced when an output writer sliced the filter output with `indices`.

## Root cause

Multi-direction filters are separable and are evaluated through a staged path (`_compute_staged_filter!`) that runs one 1D pass per direction. The final pass launched its copy kernel over `size(kfo)`, the full-grid operand size, while writing into the destination field's data:

```julia
params = KernelParameters(size(kfo), map(offset_index, indices))
launch!(arch, grid, params, _compute!, data, kfo)
```

When the destination is a windowed field its data holds only the window, so the launch iterated past the end of the buffer and wrote out of bounds. Oceananigans' own `compute_computed_field!` sizes the launch from the destination (`KernelParameters(size(comp), map(offset_index, comp.indices))`), which is why the standard `Field(op)` path is unaffected.

## Fix

Size the staged launch from the destination field (`size(dest)` / `dest.indices`) instead of the operand. For full-field destinations `size(dest) == size(kfo)`, so the common path and its performance are unchanged; only windowed destinations are corrected.

## Testing

- Added `test_windowed_output_matches_full` (runs for both `BoxFilter` and `GaussianFilter`), covering a window outside the filtered dims, a window inside a filtered dim, and the 3D staged path; each windowed result is checked against the matching slice of the full field.
- `TEST_GROUP=spatial_filters` passes (208/208).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
