### PR TITLE
Build docs with `--threads=auto` and remove Rasters

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,4 +28,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
           JULIA_DEBUG: Documenter
-        run: julia --color=yes --project=docs/ docs/make.jl
+        run: julia --color=yes --threads=auto --project=docs/ docs/make.jl

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,7 +3,6 @@ CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
-Rasters = "a3a2b9e3-a471-40c9-b274-f788e487c689"
 SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 
 [compat]


### PR DESCRIPTION
Adds `--threads=auto` to the documentation build command so Oceananigans' CPU kernels can run multithreaded during the example simulations. On the `ubuntu-latest` runner that gives 4 threads.

## Why

The docs build spends ~24 min in `make.jl`, almost all of it in the five example simulations. This is the lowest-effort of the speedup options: it targets the numerical stepping in the larger 2D examples (256²) and lets dependency precompilation use multiple tasks. It does not touch any content: no doctests, simulations, or simulation lengths change.

## Caveat / what to watch

Most of the per-example cost is JIT compilation of Oceananigans/CairoMakie/NCDatasets rather than the numerics, and `--threads` does not help single-method compilation. The grids here are small (256² at most, plus a few small 3D cases), so the stepping speedup may be marginal. This PR is worth merging only if the build-time comparison against `main` shows a real improvement — check the `make.jl` wall time on this run vs. a recent `main` run before merging.

If it doesn't move the needle, the higher-leverage follow-ups are a PackageCompiler sysimage (kills the repeated JIT recompilation) and/or a per-example CI matrix (parallelizes the five examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)