### PR TITLE
Warn when a multi-direction filter runs on the slow fused path

### DIFF
--- a/docs/examples/kelvin_helmholtz.jl
+++ b/docs/examples/kelvin_helmholtz.jl
@@ -136,7 +136,10 @@ filter = GaussianFilter(; dims=(1, 3), σ=h / 2, boundary=:shrink)  # FWHM ≈ h
 
 u, w = model.velocities.u, model.velocities.w
 b = model.tracers.b
-ū, w̄, b̄ = filter(u), filter(w), filter(b)
+## Materialize each filtered field so the multi-direction filter takes its fast staged (separable)
+## path; composing the raw `filter(u)` into `ū^2 + w̄^2` below would instead run it fused (see the
+## filter performance notes and `check_filter_staging`).
+ū, w̄, b̄ = Field(filter(u)), Field(filter(w)), Field(filter(b))
 
 Kˡ = @at (Center, Center, Center) (ū^2 + w̄^2) / 2   # filtered kinetic energy ½ūᵢūᵢ
 w̄b̄ = @at (Center, Center, Center) (w̄ * b̄)           # buoyancy production of the filtered flow

--- a/docs/examples/rayleigh_taylor_instability.jl
+++ b/docs/examples/rayleigh_taylor_instability.jl
@@ -166,7 +166,10 @@ wbˢ = subfilter_covariance(w, b, gfilter)          # sub-filter buoyancy flux �
 # Together the two show how the filter splits the flow's kinetic energy between the scales it keeps and
 # the scales it removes:
 
-ū, v̄, w̄ = gfilter(u), gfilter(v), gfilter(w)
+## Materialize the filtered velocities so the multi-direction filter runs on its fast staged path;
+## feeding the raw `gfilter(u)` into `KineticEnergy` would run the filter fused (see the filter
+## performance notes and `check_filter_staging`).
+ū, v̄, w̄ = Field(gfilter(u)), Field(gfilter(v)), Field(gfilter(w))
 Kˡ = Oceanostics.KineticEnergy(model, ū, v̄, w̄)  #  kinetic energy of the coarse-grained flow
 
 # ## Output

--- a/docs/examples/spatial_filtering.jl
+++ b/docs/examples/spatial_filtering.jl
@@ -93,9 +93,9 @@ using Oceanostics
 
 filter = GaussianFilter(; dims=(1, 2), σ=σ)
 
-ω  = ∂x(v) - ∂y(u) # vorticity
-ω̄  = filter(ω)     # filtered (large-scale) vorticity
-ω′ = Field(ω - ω̄)  # subfilter fluctuation
+ω  = ∂x(v) - ∂y(u)      # vorticity
+ω̄  = Field(filter(ω))   # filtered (large-scale) vorticity, materialized so the filter runs staged
+ω′ = Field(ω - ω̄)       # subfilter fluctuation
 
 # We plot the vorticity, filtered vorticity, and subfilter fluctuations side by side:
 
@@ -151,17 +151,20 @@ fig_sweep
 # ``\tau_i = \overline{u_i c} - \bar{u}_i \bar{c}``: the difference between the filtered advective
 # flux and the flux carried by the filtered fields. We reuse the same `filter` object on each piece —
 # the two velocities, the tracer, and the two advective products ``u_i c`` — before combining: one
-# filter object, applied to five different fields.
+# filter object, applied to five different fields. Each filtered piece is wrapped in a `Field` so the
+# multi-direction filter takes its fast staged (separable) path; composing a raw `filter(u)` into the
+# products below would instead run it fused (see the filter performance notes and
+# [`check_filter_staging`](@ref)).
 
 using Oceananigans.AbstractOperations: @at
 
-ū  = filter(u)
-v̄  = filter(v)
-c̄  = filter(c)
+ū  = Field(filter(u))
+v̄  = Field(filter(v))
+c̄  = Field(filter(c))
 
-τx = filter(u * c) - ū * c̄   # overline(u c) - ū c̄
-τy = filter(v * c) - v̄ * c̄
-τ  = √(τx^2 + τy^2)          # subfilter flux magnitude
+τx = Field(filter(u * c)) - ū * c̄   # overline(u c) - ū c̄
+τy = Field(filter(v * c)) - v̄ * c̄
+τ  = √(τx^2 + τy^2)                  # subfilter flux magnitude
 
 # Finally we plot the tracer, its filtered version, and the magnitude of the subfilter flux:
 

--- a/docs/src/filters.md
+++ b/docs/src/filters.md
@@ -225,8 +225,18 @@ The same reasoning applies to any filtered quantity assembled from operations ra
 Wrap the filtered velocities in `Field`s before forming `½(ū² + v̄² + w̄²)`, for instance. This is also why
 [`subfilter_stress_tensor`](@ref) materializes its filtered velocities and momentum fluxes internally.
 
+To check whether a given expression is affected, pass it to [`check_filter_staging`](@ref). It walks the
+operation tree and warns (returning `false`) if any multi-direction filter is positioned to run fused,
+so the fused path does not go unnoticed:
+
+```@repl filters_perf
+check_filter_staging(Field(gf(ε)) - εˡ)         # staged: filtered field materialized first
+check_filter_staging(gf(ε) - εˡ; warn=false)    # fused: filter nested in the subtraction
+```
+
 ### API reference
 
 ```@docs
 GaussianFilter
+check_filter_staging
 ```

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -67,7 +67,7 @@ export BottomCellValue
 #---
 
 #+++ SpatialFilters exports
-export BoxFilter, GaussianFilter
+export BoxFilter, GaussianFilter, check_filter_staging
 #---
 
 #+++ PotentialEnergyEquationTerms exports

--- a/src/SpatialFilters/SpatialFilters.jl
+++ b/src/SpatialFilters/SpatialFilters.jl
@@ -1,7 +1,7 @@
 module SpatialFilters
 using DocStringExtensions
 
-export BoxFilter, GaussianFilter
+export BoxFilter, GaussianFilter, check_filter_staging
 
 using Oceananigans: location
 using Oceananigans.Grids: topology, Periodic,
@@ -256,7 +256,7 @@ macro unroll_full(expr)
 end
 
 import Oceananigans.Fields: compute!
-using Oceananigans.Fields: Field, offset_index, set_status!
+using Oceananigans.Fields: Field, AbstractField, offset_index, set_status!
 using Oceananigans.AbstractOperations: compute_at!, _compute!
 using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Oceananigans.Architectures: architecture
@@ -329,5 +329,121 @@ end
 
 include("box_filter.jl")
 include("gaussian_filter.jl")
+
+#+++ Staged-vs-fused diagnostic
+# A multi-direction `BoxFilter`/`GaussianFilter` is evaluated by its fast staged
+# (separable) kernel only when it is the *direct operand of a `Field`* — that is
+# the sole shape the `compute!` overrides in `box_filter.jl`/`gaussian_filter.jl`
+# match. Nesting it inside any other operation (`Field(f(ψ) - φ)`, `2 * f(ψ)`,
+# `Integral(f(ψ))`, …) hides it from that dispatch, so it silently falls back to
+# the fused single-kernel path (`Nᵈ` reads per output cell instead of `d × N`).
+# `check_filter_staging` walks an operation tree and flags every such fused case.
+#
+# The walk is structural and filter-agnostic: a node runs staged only if it is the
+# direct operand of a `Field`. We descend into struct fields by index (`getfield`)
+# and keep only the operation/field-typed ones, so no operation type needs
+# special-casing beyond `Field` and the four multi-direction filter aliases. Note
+# that in Oceananigans `AbstractOperation <: AbstractField`, so a *materialized*
+# field is matched as exactly `Field` while lazy operations are the other
+# `AbstractField`s. Reductions (`Integral`/`Average`) are a plain `Scan` wrapper,
+# reached through a `Field`'s `operand` and traversed by the same field walk.
+
+const _MultiDirFilter = Union{_BoxFilter2D, _BoxFilter3D, _GaussianFilter2D, _GaussianFilter3D}
+
+@inline _push_filter_child!(children, x::AbstractField) = (push!(children, x); nothing)
+@inline _push_filter_child!(children, x::Tuple) = (foreach(el -> _push_filter_child!(children, el), x); nothing)
+@inline _push_filter_child!(children, x) = nothing
+
+# Operation/field-typed fields of `node` (a lazy operation or a `Scan`-like wrapper).
+function _operation_children(node)
+    children = Any[]
+    for i in 1:nfields(node)
+        _push_filter_child!(children, getfield(node, i))
+    end
+    return children
+end
+
+function _collect_fused_filters!(found, seen, node, staged_ok)
+    (node in seen) && return found
+    push!(seen, node)
+
+    if node isa Field
+        # A `Field` materializes its direct operand, so that operand runs staged.
+        op = node.operand
+        op === nothing || _collect_fused_filters!(found, seen, op, true)
+        return found
+    end
+
+    # Not a direct `Field` operand ⇒ a multi-direction filter here runs fused.
+    (node isa _MultiDirFilter) && !staged_ok && push!(found, node)
+
+    # Anything nested below `node` is, by construction, not a direct `Field` operand.
+    for child in _operation_children(node)
+        _collect_fused_filters!(found, seen, child, false)
+    end
+    return found
+end
+
+"""
+    check_filter_staging(op; warn=true)
+
+Inspect the operation tree `op` (an `AbstractOperation`, a `Field`, or a reduction such as
+`Integral(...)`) for multi-direction Oceanostics filters — a [`BoxFilter`](@ref) or
+[`GaussianFilter`](@ref) over two or three directions — that will evaluate on the slow *fused*
+single-kernel path instead of the fast staged (separable) path.
+
+A multi-direction filter is evaluated by its staged kernel only when it is the **direct operand of a
+`Field`**, e.g. `Field(filter(ψ))`. Composing the filter into any other operation — `Field(filter(ψ)
+- φ)`, `2 * filter(ψ)`, `Integral(filter(ψ))`, and so on — hides it from that dispatch and it silently
+falls back to the fused path (`Nᵈ` reads per output cell instead of `d × N`, with the filtered operand
+recomputed at every stencil point). Both paths return the same values; only the speed differs. See
+[Performance notes](@ref filter_performance).
+
+The fix is to materialize the filtered field first: wrap `filter(ψ)` in its own `Field(...)` before
+composing it, e.g. write `Field(filter(ψ)) - φ` rather than `filter(ψ) - φ`.
+
+`op` is analyzed as if it were about to be wrapped in a `Field` and computed. Returns `true` when
+every multi-direction filter in `op` is positioned to run staged (nothing to fix), and `false` when
+at least one will run fused. When `warn = true` (the default), a `false` result also emits a `@warn`
+describing the problem. One-direction filters always use the single unrolled kernel (staged and fused
+coincide) and are never flagged.
+
+```jldoctest
+julia> using Oceananigans, Oceanostics
+
+julia> grid = RectilinearGrid(size=(8, 8, 8), extent=(1, 1, 1));
+
+julia> c = CenterField(grid); φ = CenterField(grid);
+
+julia> gf = GaussianFilter(; dims=(1, 2), σ=0.1);
+
+julia> check_filter_staging(Field(gf(c)))          # staged: direct Field operand
+true
+
+julia> check_filter_staging(Field(gf(c)) - φ)      # staged: filtered field materialized first
+true
+
+julia> check_filter_staging(gf(c) - φ; warn=false) # fused: filter nested in a larger operation
+false
+```
+"""
+function check_filter_staging(op; warn=true)
+    fused = _collect_fused_filters!(Any[], Base.IdSet{Any}(), op, true)
+    all_staged = isempty(fused)
+    if warn && !all_staged
+        n = length(fused)
+        @warn string(
+            "check_filter_staging found ", n, " multi-direction filter", (n == 1 ? "" : "s"),
+            " that will run on the slow fused path. A multi-direction `BoxFilter`/`GaussianFilter` ",
+            "is evaluated by its fast staged (separable) kernel only when it is the direct operand ",
+            "of a `Field`. Nesting it inside another operation (e.g. `Field(filter(ψ) - φ)`, ",
+            "`2 * filter(ψ)`, `Integral(filter(ψ))`) falls back to the fused single-kernel path ",
+            "(Nᵈ reads per cell instead of d×N). Materialize the filtered field first — wrap ",
+            "`filter(ψ)` in its own `Field(...)` before composing it. See the \"Spatial filters\" ",
+            "documentation, section \"Performance notes\", for details.")
+    end
+    return all_staged
+end
+#---
 
 end # module

--- a/src/SpatialFilters/SpatialFilters.jl
+++ b/src/SpatialFilters/SpatialFilters.jl
@@ -331,22 +331,10 @@ include("box_filter.jl")
 include("gaussian_filter.jl")
 
 #+++ Staged-vs-fused diagnostic
-# A multi-direction `BoxFilter`/`GaussianFilter` is evaluated by its fast staged
-# (separable) kernel only when it is the *direct operand of a `Field`* — that is
-# the sole shape the `compute!` overrides in `box_filter.jl`/`gaussian_filter.jl`
-# match. Nesting it inside any other operation (`Field(f(ψ) - φ)`, `2 * f(ψ)`,
-# `Integral(f(ψ))`, …) hides it from that dispatch, so it silently falls back to
-# the fused single-kernel path (`Nᵈ` reads per output cell instead of `d × N`).
-# `check_filter_staging` walks an operation tree and flags every such fused case.
-#
-# The walk is structural and filter-agnostic: a node runs staged only if it is the
-# direct operand of a `Field`. We descend into struct fields by index (`getfield`)
-# and keep only the operation/field-typed ones, so no operation type needs
-# special-casing beyond `Field` and the four multi-direction filter aliases. Note
-# that in Oceananigans `AbstractOperation <: AbstractField`, so a *materialized*
-# field is matched as exactly `Field` while lazy operations are the other
-# `AbstractField`s. Reductions (`Integral`/`Average`) are a plain `Scan` wrapper,
-# reached through a `Field`'s `operand` and traversed by the same field walk.
+# A multi-direction filter takes its fast staged (separable) path only as the direct operand of a
+# `Field`; nesting it in any other operation falls back to the slow fused kernel. `check_filter_staging`
+# walks an operation tree structurally (a node is staged only if it is a `Field`'s direct operand) and
+# flags every filter that will run fused. See the "Spatial filters" docs ("Performance notes") for why.
 
 const _MultiDirFilter = Union{_BoxFilter2D, _BoxFilter3D, _GaussianFilter2D, _GaussianFilter3D}
 
@@ -354,7 +342,6 @@ const _MultiDirFilter = Union{_BoxFilter2D, _BoxFilter3D, _GaussianFilter2D, _Ga
 @inline _push_filter_child!(children, x::Tuple) = (foreach(el -> _push_filter_child!(children, el), x); nothing)
 @inline _push_filter_child!(children, x) = nothing
 
-# Operation/field-typed fields of `node` (a lazy operation or a `Scan`-like wrapper).
 function _operation_children(node)
     children = Any[]
     for i in 1:nfields(node)
@@ -368,16 +355,13 @@ function _collect_fused_filters!(found, seen, node, staged_ok)
     push!(seen, node)
 
     if node isa Field
-        # A `Field` materializes its direct operand, so that operand runs staged.
         op = node.operand
         op === nothing || _collect_fused_filters!(found, seen, op, true)
         return found
     end
 
-    # Not a direct `Field` operand ⇒ a multi-direction filter here runs fused.
     (node isa _MultiDirFilter) && !staged_ok && push!(found, node)
 
-    # Anything nested below `node` is, by construction, not a direct `Field` operand.
     for child in _operation_children(node)
         _collect_fused_filters!(found, seen, child, false)
     end

--- a/test/test_spatial_filters.jl
+++ b/test/test_spatial_filters.jl
@@ -1,4 +1,5 @@
 using Test
+import Logging
 using CUDA: has_cuda_gpu, @allowscalar
 using Oceananigans
 using Oceananigans: fill_halo_regions!, location
@@ -765,6 +766,46 @@ function test_reusable_gaussian_filter(grid)
 end
 #---
 
+#+++ Staged-vs-fused detection (`check_filter_staging`)
+# A multi-direction filter runs on its fast staged path only as the *direct* operand of a `Field`;
+# nesting it in any other operation silently falls back to the slow fused path. `check_filter_staging`
+# flags that, returning `true` when everything is staged and `false` (plus a `@warn`) when some filter
+# will run fused. 1D filters always use the single unrolled kernel, so they are never flagged.
+function test_check_filter_staging()
+    grid = make_grid()
+    c = center_field_from(grid, (x, y, z) -> sin(2π*x) + cos(2π*z))
+    φ = center_field_from(grid, (x, y, z) -> cos(2π*y))
+
+    gf2 = GaussianFilter(; dims=(1, 2), σ=0.1)      # multi-direction (2D)
+    bf3 = BoxFilter(; dims=(1, 2, 3), N=3)          # multi-direction (3D)
+    gf1 = GaussianFilter(; dims=1, σ=0.1)           # single direction — always staged
+
+    # Positioned to run staged: returns `true` and stays silent.
+    staged = (gf2(c),                               # a bare filter is staged once wrapped in a `Field`
+              Field(gf2(c)),                        # the canonical staged form
+              Field(gf2(c)) - φ,                    # filtered field materialized before composing
+              2 * Field(gf2(c)),
+              Field(Integral(Field(bf3(c)))),       # materialized before the reduction
+              gf1(c) - φ,                           # 1D filters never fuse, even when nested
+              Field(gf1(c) - φ))
+    for op in staged
+        @test check_filter_staging(op; warn=false) == true
+        @test_logs min_level=Logging.Warn check_filter_staging(op)   # warn=true stays silent
+    end
+
+    # Will run fused: returns `false` and warns.
+    fused = (gf2(c) - φ,
+             Field(gf2(c) - φ),
+             2 * gf2(c),
+             bf3(c) * φ,
+             Field(Integral(gf2(c))))               # filter nested inside the reduction
+    for op in fused
+        @test check_filter_staging(op; warn=false) == false
+        @test_logs (:warn,) check_filter_staging(op)                 # exactly one warning
+    end
+end
+#---
+
 #+++ Run tests
 # Reference weights are computed in cells; the GaussianFilter API takes σ in
 # physical units. The shared test grid is uniform with Δ = 1/8, so a physical
@@ -847,6 +888,10 @@ filter_configs = [
     @testset "Reusable (field-less) filter objects" begin
         test_reusable_box_filter(make_grid())
         test_reusable_gaussian_filter(make_grid())
+    end
+
+    @testset "check_filter_staging (staged vs fused)" begin
+        test_check_filter_staging()
     end
 end
 #---


### PR DESCRIPTION
Follow-up to the staged/fused filter work. A multi-direction `BoxFilter`/`GaussianFilter` takes its fast staged (separable) path only when it is the *direct operand of a `Field`* — the sole shape the `compute!` overrides match. Nest it inside any other operation and it silently falls back to the fused single-kernel path (`Nᵈ` reads per output cell instead of `d × N`, with the filtered operand recomputed at every stencil point):

```julia
Field(gf(ψ))       # staged
Field(gf(ψ) - φ)   # fused — same result, only slower
```

Both give the same answer, so the mistake is easy to miss. This adds a host-side checker so it does not go unnoticed.

## What this adds

`check_filter_staging(op)` walks an operation tree (an `AbstractOperation`, a `Field`, or a reduction such as `Integral(...)`) and reports whether every multi-direction filter in it is positioned to run staged. It returns `true` when all are staged, and `false` — plus a `@warn` explaining the fix — when at least one will run fused. `warn=false` suppresses the warning for a pure predicate.

```julia
check_filter_staging(Field(gf(c)))          # true  (direct Field operand)
check_filter_staging(Field(gf(c)) - φ)      # true  (filtered field materialized first)
check_filter_staging(gf(c) - φ)             # false (nested → fused), warns
```

The suggested fix, matching the existing docs guidance, is to materialize the filtered field first: write `Field(gf(ψ)) - φ` rather than `gf(ψ) - φ`.

## How it works

The walk is structural and filter-agnostic. A node runs staged only when it is the direct operand of a `Field`, so the traversal descends struct fields by index (`getfield`), keeps only the operation/field-typed ones, and special-cases just `Field` and the four multi-direction filter aliases (`_BoxFilter2D/3D`, `_GaussianFilter2D/3D`). Since in Oceananigans `AbstractOperation <: AbstractField`, a *materialized* field is matched as exactly `Field` while lazy operations are the other `AbstractField`s. Reductions (`Integral`/`Average`) are a plain `Scan` wrapper reached through a `Field`'s `operand` and traversed by the same walk. One-direction filters always use the single unrolled kernel (staged and fused coincide), so they are never flagged.

I confirmed the existing filter-consuming diagnostics (`subfilter_stress_tensor`, `subfilter_covariance`, the coarse-grained KE budget terms) already materialize their filtered fields internally, so the checker reports `true` on them — no false positives.

## Tests and docs

- New `spatial_filters` testset `check_filter_staging (staged vs fused)` covering staged shapes (bare filter, `Field(f(ψ))`, materialized-before-composing, materialized-before-reduction, 1D nested) and fused shapes (`f(ψ) - φ`, `Field(f(ψ) - φ)`, `2 * f(ψ)`, `Integral(f(ψ))`), asserting both the return value and the presence/absence of the `@warn`. Full `spatial_filters` group passes (232/232).
- Docstring with a runnable `jldoctest`, registered in the filters API reference.
- A short note plus a live `@repl` example in the "Performance notes" section pointing users at the checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)