### PR TITLE
Plot negated budget tendency in examples so curves sum to residual

### DIFF
--- a/docs/examples/kelvin_helmholtz.jl
+++ b/docs/examples/kelvin_helmholtz.jl
@@ -213,7 +213,8 @@ w̄b̄_pair = @. 0.5 * (∫w̄b̄_t[i1] + ∫w̄b̄_t[i2])
 Πₖ_pair = @. 0.5 * (∫Πₖ_t[i1] + ∫Πₖ_t[i2])
 εˡ_pair = @. 0.5 * (∫εˡ_t[i1] + ∫εˡ_t[i2])
 
-resid = @. dKˡdt - (w̄b̄_pair - Πₖ_pair - εˡ_pair)
+# Residual in sum-to-zero form: the negative tendency plus the three sources, so the plotted curves add to it
+resid = @. -dKˡdt + w̄b̄_pair - Πₖ_pair - εˡ_pair
 
 using Test                              #hide
 rms(x) = √(sum(abs2, x) / length(x))    #hide
@@ -275,12 +276,13 @@ Colorbar(fig[5, 2], hm5, vertical=false, height=8)
 hm6 = heatmap!(ax6, εˡₙ; colormap=:magma, colorrange=(0, ε_lim))
 Colorbar(fig[5, 3], hm6, vertical=false, height=8);
 
-# The bottom panel shows the volume-integrated coarse-grained kinetic-energy budget: `d(∫Kˡ)/dt`
-# against its three sources — buoyancy production `∫w̄b̄ dV`, minus the cross-scale flux `−∫Πₖ dV`, and
-# minus the coarse-grained dissipation `−∫εˡ dV` — with the residual.
+# The bottom panel shows the volume-integrated coarse-grained kinetic-energy budget. We plot the negative
+# tendency `−d(∫Kˡ)/dt` together with its three sources: buoyancy production `∫w̄b̄ dV`, the cross-scale
+# flux `−∫Πₖ dV`, and the coarse-grained dissipation `−∫εˡ dV`. With the tendency negated, the four curves
+# sum to the residual.
 
 ax_bud = Axis(fig[6, 1:3]; xlabel="Time", title="Coarse-grained KE budget", height=140)
-lines!(ax_bud, t_pair, dKˡdt, label="d(∫Kˡ)/dt")
+lines!(ax_bud, t_pair, -dKˡdt, label="−d(∫Kˡ)/dt")
 lines!(ax_bud, t_pair, w̄b̄_pair, label="∫w̄b̄ dV")
 lines!(ax_bud, t_pair, -Πₖ_pair, label="−∫Πₖ dV")
 lines!(ax_bud, t_pair, -εˡ_pair, label="−∫εˡ dV")
@@ -309,8 +311,8 @@ end
 # The bottom panel shows the volume-integrated coarse-grained kinetic-energy budget. As the billows
 # grow and overturn, the filtered flow mostly loses kinetic energy to potential energy (`∫w̄b̄ dV < 0`) and
 # feeds the subfilter scales through the cross-scale flux (`−∫Πₖ dV`), while the coarse-grained viscous
-# dissipation `∫εˡ dV` stays comparatively small at this Reynolds number. The residual (dashed) is the
-# gap between `d(∫Kˡ)/dt` and the sum of the three terms. Unlike the centered-advection
+# dissipation `∫εˡ dV` stays comparatively small at this Reynolds number. The residual (dashed), the
+# sum of the negative tendency `−d(∫Kˡ)/dt` and the three source terms, stays small. Unlike the centered-advection
 # [Two-dimensional turbulence example](@ref two_d_turbulence_example), the upwind scheme here adds some
 # numerical dissipation, but because it acts mostly at the grid scale it barely projects onto the
 # smooth filtered budget, which still closes to within a few percent.

--- a/docs/examples/rayleigh_taylor_instability.jl
+++ b/docs/examples/rayleigh_taylor_instability.jl
@@ -238,7 +238,8 @@ dKˢdt    = (∫Kˢ_t[i2] .- ∫Kˢ_t[i1]) ./ Δt_pair
 wbˢ_pair = @. 0.5 * (∫wbˢ_t[i1] + ∫wbˢ_t[i2])
 εˢ_pair  = @. 0.5 * (∫εˢ_t[i1] + ∫εˢ_t[i2])
 
-resid = @. dKˢdt - (Πₖ_pair + wbˢ_pair - εˢ_pair)
+# Residual in sum-to-zero form: the negative tendency plus the sources, so the plotted curves add to it
+resid = @. -dKˢdt + Πₖ_pair + wbˢ_pair - εˢ_pair
 
 using Test                                                          #hide
 rms(x) = √(sum(abs2, x) / length(x))                                #hide
@@ -291,13 +292,14 @@ Colorbar(fig[3, 2], hmKˡ)
 hmKˢ = heatmap!(axKˢ, x_caa, z_aac, Kˢₙ; colormap=:magma, colorrange=(0, Kˢlim))
 Colorbar(fig[3, 4], hmKˢ)
 
-# The bottom panel shows the volume-integrated sub-filter-scale kinetic-energy budget: `d(∫Kˢ)/dt`
-# against the two sources that feed it, the cross-scale flux `∫Πₖ dV` handed down from the filtered
-# scales and the sub-filter buoyancy flux `∫τ(w,b) dV`, and the single sink that drains it, the
-# sub-filter dissipation `−∫εˢ dV`, together with the residual.
+# The bottom panel shows the volume-integrated sub-filter-scale kinetic-energy budget. We plot the
+# negative tendency `−d(∫Kˢ)/dt` together with the two sources that feed it, the cross-scale flux
+# `∫Πₖ dV` handed down from the filtered scales and the sub-filter buoyancy flux `∫τ(w,b) dV`, and the
+# single sink that drains it, the sub-filter dissipation `−∫εˢ dV`. With the tendency negated, the four
+# curves sum to the residual.
 
 ax_bud = Axis(fig[4, 1:4]; xlabel="time [free-fall units]", title="Sub-filter-scale KE budget")
-lines!(ax_bud, t_pair ./ τ, dKˢdt,    label="d(∫Kˢ)/dt")
+lines!(ax_bud, t_pair ./ τ, -dKˢdt,   label="−d(∫Kˢ)/dt")
 lines!(ax_bud, t_pair ./ τ, Πₖ_pair,  label="∫Πₖ dV  (flux from filtered scales)")
 lines!(ax_bud, t_pair ./ τ, wbˢ_pair, label="∫τ(w,b) dV  (sub-filter buoyancy flux)")
 lines!(ax_bud, t_pair ./ τ, -εˢ_pair, label="−∫εˢ dV  (sub-filter dissipation)")
@@ -319,5 +321,5 @@ end
 # As the heavy fluid falls in spikes and the light fluid rises in bubbles, the flow rolls up and
 # breaks into a turbulent mixing layer. The bottom panel shows the volume-integrated SFS KE budget.
 # The sub-filter buoyancy flux `∫τ(w,b) dV` and dissipation `∫εˢ dV` are the dominant terms, with the
-# tendency `d(∫Kˢ)/dt` in third place. The residual is small, which shows that the budget closes well
+# tendency `−d(∫Kˢ)/dt` in third place. The residual is small, which shows that the budget closes well
 # and that the coarse-graining analysis is consistent with the simulation.

--- a/docs/examples/two_dimensional_turbulence.jl
+++ b/docs/examples/two_dimensional_turbulence.jl
@@ -186,8 +186,10 @@ dc²dt    = (∫c²_t[idx2] .- ∫c²_t[idx1]) ./ Δt_pair
 ε_pair   = @. 0.5 * (∫ε_t[idx1] + ∫ε_t[idx2])
 χ_pair   = @. 0.5 * (∫χ_t[idx1] + ∫χ_t[idx2])
 
-KE_resid = @. dKEdt - (-ε_pair)
-c²_resid = @. dc²dt - (-χ_pair)
+# Budget residuals in sum-to-zero form: the negative tendency plus the source term. Plotting every
+# curve with these signs makes them add up to the residual, which stays near zero.
+KE_resid = @. -dKEdt - ε_pair
+c²_resid = @. -dc²dt - χ_pair
 
 using Test                                #hide
 rms(x) = √(sum(abs2, x) / length(x))      #hide
@@ -237,20 +239,20 @@ Colorbar(fig[3, 3], hm_KE; vertical=false, height=8, ticklabelsize=12)
 hm_c = heatmap!(ax_c, cₙ, colormap = :balance, colorrange=(-1.5, 1.5))
 Colorbar(fig[3, 4], hm_c; vertical=false, height=8, ticklabelsize=12)
 
-# Volume-integrated KE budget — `d(∫KE)/dt` against `-∫ε dV`, with the residual.
+# Volume-integrated KE budget: the negative tendency `-d(∫KE)/dt` and `-∫ε dV`, which sum to the residual.
 
 budget_kwargs = (height = 180, width = 1080)
 
 ax_KEbud = Axis(fig[4, 1:4]; title = "Volume-integrated KE budget", budget_kwargs...)
-lines!(ax_KEbud, t_pair, dKEdt,   label = "d(∫KE)/dt")
+lines!(ax_KEbud, t_pair, -dKEdt,  label = "-d(∫KE)/dt")
 lines!(ax_KEbud, t_pair, -ε_pair, label = "-∫ε dV")
 lines!(ax_KEbud, t_pair, KE_resid, label = "residual", color = :black, linestyle = :dash)
 axislegend(ax_KEbud; labelsize = 10, position = :rb)
 
-# Volume-integrated c² budget — `d(∫c²)/dt` against `-∫χ dV`, with the residual.
+# Volume-integrated c² budget: the negative tendency `-d(∫c²)/dt` and `-∫χ dV`, which sum to the residual.
 
 ax_c²bud = Axis(fig[5, 1:4]; title = "Volume-integrated ∫c² budget", xlabel = "Time", budget_kwargs...)
-lines!(ax_c²bud, t_pair, dc²dt,   label = "d(∫c²)/dt")
+lines!(ax_c²bud, t_pair, -dc²dt,  label = "-d(∫c²)/dt")
 lines!(ax_c²bud, t_pair, -χ_pair, label = "-∫χ dV")
 lines!(ax_c²bud, t_pair, c²_resid, label = "residual", color = :black, linestyle = :dash)
 axislegend(ax_c²bud; labelsize = 10, position = :rb)
@@ -275,7 +277,8 @@ nothing #hide
 
 # ![](two_dimensional_turbulence.mp4)
 #
-# The two bottom panels show the volume-integrated KE and ``c^2`` budgets: ``d/dt`` of the
-# integrated quantity is compared against ``-\int \varepsilon\, dV`` (respectively
-# ``-\int \chi\, dV``), the only term that survives volume-integration for a periodic
-# incompressible flow with a centered advection scheme. The residual shows the gap between them.
+# The two bottom panels show the volume-integrated KE and ``c^2`` budgets. Each plots the negative
+# tendency ``-d/dt`` of the integrated quantity alongside ``-\int \varepsilon\, dV`` (respectively
+# ``-\int \chi\, dV``), the only source term that survives volume-integration for a periodic
+# incompressible flow with a centered advection scheme. With the tendency negated, the two curves add
+# up to the residual, which stays near zero.


### PR DESCRIPTION
In the volume-integrated budget panels of the two-dimensional-turbulence, Kelvin-Helmholtz, and Rayleigh-Taylor examples, plot the negative tendency `-d/dt` of the integrated quantity instead of `+d/dt`. Moving the tendency onto the same side as the source terms casts each budget in sum-to-zero form, so the negated tendency and the source terms all add up to the residual rather than the tendency being balanced against the sources.

Each residual variable is rewritten in the same sum-to-zero form (negative tendency plus sources), so the plotted residual line equals the sum of the other plotted curves exactly. The residual magnitudes are unchanged, so the embedded budget-closure `@test` assertions (which compare `rms` values, sign-invariant) still hold. Plot labels and the surrounding prose are updated to match.

Panels affected: KE and tracer-variance `c²` budgets (`two_dimensional_turbulence.jl`), coarse-grained KE budget (`kelvin_helmholtz.jl`), and sub-filter-scale KE budget (`rayleigh_taylor_instability.jl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)