### PR TITLE
Restore ProgressMessenger colors in the docs examples

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -49,6 +49,37 @@ function externalize_images(name)
 end
 
 """
+    colorize_ansi_output(content)
+
+Retag Literate's executed-output blocks so Documenter renders their ANSI escape sequences as
+colors. `Literate.markdown(..., execute = true)` writes each block's captured stdout/stderr into
+an info-less ```` ```` ```` fence, and Documenter's HTML writer only runs a code block through
+its ANSI-to-HTML printer when the block is tagged `documenter-ansi`; otherwise the escapes are
+emitted verbatim and the `ProgressMessengers` output reads as literal `^[[93m` (issue #284).
+Under the previous Documenter-executed `@example` path this came for free, because Documenter
+colorized the output it had captured itself.
+
+Prose fences carry three backticks and Literate's own code chunks carry a `julia` info string,
+so an info-less fence of four or more backticks is unambiguously executed output.
+"""
+function colorize_ansi_output(content::AbstractString)
+    lines = String.(split(content, '\n'))
+    fence = 0 # backtick count that opened the block we are inside; 0 when outside a block
+    for (i, line) in enumerate(lines)
+        m = match(r"^(`{3,})(.*)$", line)
+        m === nothing && continue
+        ticks, info = length(m[1]), strip(m[2])
+        if fence == 0
+            fence = ticks
+            isempty(info) && ticks >= 4 && (lines[i] = m[1] * "documenter-ansi")
+        elseif ticks >= fence && isempty(info)
+            fence = 0
+        end
+    end
+    return join(lines, '\n')
+end
+
+"""
     generate_example(slug)
 
 Run `examples/\$slug.jl` through Literate with `execute = true`. This runs the example
@@ -61,7 +92,7 @@ from the rendered code, exactly as under the previous Documenter-executed `@exam
 generate_example(slug) =
     Literate.markdown(joinpath(EXAMPLES_DIR, slug * ".jl"), OUTPUT_DIR;
                       execute = true, flavor = Literate.DocumenterFlavor(),
-                      postprocess = externalize_images(slug))
+                      postprocess = colorize_ansi_output ∘ externalize_images(slug))
 
 # Single-example mode: when OCEANOSTICS_DOCS_EXAMPLE names one example, build only that
 # page and stop. This is what each parallel CI job runs; the resulting page and media are


### PR DESCRIPTION
Fixes #284.

## Cause

Not a `ProgressMessengers` regression. `ColoredNumber` bakes the SGR escapes into a plain `String` unconditionally, so the escape bytes are in the captured output exactly as they always were. What changed is who converts them to HTML.

#265 moved example execution from Documenter to Literate (`execute = true`), which is what lets the examples be built one per CI job in parallel. Documenter only runs a code block through its ANSI-to-HTML printer in two cases: output it captured itself while running an `@example` block, or a block explicitly tagged `documenter-ansi` (`HTMLWriter.jl`, `domify(::DCtx, ::Node, ::MarkdownAST.CodeBlock)`). Literate writes captured stdout/stderr into an info-less fence, which matches neither, so the escapes get HTML-escaped into the page verbatim. That is why the colors survive in v0.17.3 and break from v0.18.0 onward: #265 landed between the two.

## Fix

A Literate postprocess that retags those output fences as `documenter-ansi`, composed with the existing `externalize_images`. That puts them back on `domify_ansicoloredtext` and reuses the ANSI CSS Documenter's HTML theme already ships. Nothing about execution changes, so the parallel docs build is untouched.

The discriminator is unambiguous on Literate's output: prose fences carry three backticks, Literate's own code chunks carry a `julia` info string, and only executed output gets an info-less fence of four backticks.

## Verification

Built a minimal Literate + Documenter site from a page whose chunk logs `@info "[\e[93m001.00%\e[39m] step"`, using the `colorize_ansi_output` definition read straight out of `docs/make.jl`. Before the change the page contained the raw escape bytes; after it the HTML contains `<span class="sgr93">001.00%</span>` and no escape bytes, with `julia` fences, `math` blocks and three-backtick prose fences untouched.

Also ran the function over every markdown page under `docs/src` as a smoke test. It only rewrites the generated example pages, only ever on output-block openers (never on a closing fence), and it is idempotent.

## Known limitations

- The retagged blocks get `nohighlight hljs ansi` but not the `.documenter-example-output` class Documenter's own path applied, so output blocks may be styled slightly differently from before v0.18.0.
- The postprocess depends on how Literate fences executed output, so a change to `plain_fence` upstream would silently stop the retagging (colors would revert to the current broken state; nothing would be corrupted).
- This only restores color for text that bakes escapes into the string, which is what `ColoredNumber` does. Literate calls `IOCapture.capture` without `color = true`, so anything that instead checks `get(io, :color, false)` stays uncolored. Fixing that needs an upstream Literate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
