### PR TITLE
Use DocumenterCodeBlocks for nicer code blocks in the docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,11 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCodeBlocks = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 
 [compat]
-Documenter = "1"
+Documenter = "1.17"
+DocumenterCodeBlocks = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@ using Pkg; Pkg.instantiate()
 using Base64
 
 using Documenter
+using DocumenterCodeBlocks: CodeBlocks
 using Literate
 
 using Oceananigans
@@ -165,6 +166,11 @@ format = Documenter.HTML(collapselevel = 1,
 #---
 
 #+++ Make the docs
+# `CodeBlocks()` tokenizes Julia code blocks at build time with JuliaSyntax instead of leaving
+# them to highlight.js in the browser. That buys a real parse (so function calls, types and
+# macros get their own colors), line numbers with linkable gutters, and hover popups linking
+# identifiers to their docstrings. It only touches `julia`/`julia-repl`/`jldoctest` blocks, so
+# the executed-output blocks retagged by `colorize_ansi_output` above are left alone.
 makedocs(sitename = "Oceanostics.jl",
          authors = "Tomas Chor and contributors",
          pages = pages,
@@ -172,6 +178,7 @@ makedocs(sitename = "Oceanostics.jl",
          doctest = true,
          clean = true,
          format = format,
+         plugins = [CodeBlocks()],
          checkdocs = :none,
          doctestfilters = [r"with \d+ methods?"], # method count drifts with Oceananigans versions
          )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -166,11 +166,6 @@ format = Documenter.HTML(collapselevel = 1,
 #---
 
 #+++ Make the docs
-# `CodeBlocks()` tokenizes Julia code blocks at build time with JuliaSyntax instead of leaving
-# them to highlight.js in the browser. That buys a real parse (so function calls, types and
-# macros get their own colors), line numbers with linkable gutters, and hover popups linking
-# identifiers to their docstrings. It only touches `julia`/`julia-repl`/`jldoctest` blocks, so
-# the executed-output blocks retagged by `colorize_ansi_output` above are left alone.
 makedocs(sitename = "Oceanostics.jl",
          authors = "Tomas Chor and contributors",
          pages = pages,


### PR DESCRIPTION
Adds [DocumenterCodeBlocks.jl](https://github.com/fredrikekre/DocumenterCodeBlocks.jl).

The `plugins = [CodeBlocks()]` to `makedocs` tokenizes Julia blocks at build time with JuliaSyntax instead of leaving them to highlight.js in the browser, which at its defaults gives:

- line numbers, with clickable gutters producing stable URL fragments like `#c-e61e7f97-L3-L7`,
- better colors, since a real parse can tell function calls, types and macros apart,
- identifiers linked to their docstrings, with hover popups showing the signature.