### PR TITLE
(0.20.0) Derive the local APE budget, and add the terms it was missing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,13 @@ All kernel functions use Oceananigans' staggered grid conventions with location 
   diagnosed), and `VerticalSort` (the sorted column on its own `1×1×N` grid of equal-volume cells).
   Only the last three actually sort: `ProfileLookup` handed an external profile does not.
   `reference_buoyancy(z✶)` returns the buoyancy that pairs with z✶ cell by cell, which is the sorted
-  profile b✶ under `VerticalSort` and the model's own buoyancy under the model-grid methods. It also
-  owns `Ψ = ∫b✶dz̃` (`reference_potential`), a property of the reference profile that
-  `AvailablePotentialEnergy` consumes. No method runs on an `ImmersedBoundaryGrid` yet. The profile
+  profile b✶ under `VerticalSort` and the model's own buoyancy under the model-grid methods.
+  `reference_buoyancy_at_height(z✶)` is the other sampling of the same profile, b✶(z) at each cell's
+  *own* height, which is what `ReferenceBuoyancyAnomaly` measures b against; its field reads the
+  profile off the sort through `s.permutation` (`reference_profile`) rather than sorting again, and is
+  piecewise constant on the same slots `Ψ` integrates, so b✶(z) is that `Ψ`'s derivative rather than a
+  second reconstruction. It also owns `Ψ = ∫b✶dz̃` (`reference_potential`), a property of the reference
+  profile that `AvailablePotentialEnergy` consumes. No method runs on an `ImmersedBoundaryGrid` yet. The profile
   arrays live wherever the field does, so this module must stay clear of host-side element access:
   single-element writes go through one-element broadcasts (`@views f[1:1] .= x`) and ordering checks
   through `is_nondecreasing` rather than `issorted`, since both `setindex!` and `issorted`'s iteration
@@ -100,10 +104,21 @@ All kernel functions use Oceananigans' staggered grid conventions with location 
   `PotentialEnergyEquation`, so it is included after it
 - **`AvailablePotentialEnergyEquation`**: the other half of the Winters et al. (1995) split,
   `AvailablePotentialEnergy` (Eₐ), computed in the local Holliday & McIntyre (1981) form
-  `∫[b✶(z̃) - b]dz̃`, which is non-negative everywhere rather than only in the integral. Built on
-  `BackgroundPotentialEnergyEquation`, so it is included after it, and it re-exports
-  `reference_height`, `reference_buoyancy` and the four reference-height methods so either module can
-  be used on its own
+  `∫[b✶(z̃) - b]dz̃`, which is non-negative everywhere rather than only in the integral, plus the terms
+  of its budget: `DisplacementPotential` (Υ = z✶ - z, named `BuoyancyDisplacementPotential` before
+  0.20), `AvailablePotentialEnergyDissipationRate` (εₐ = -qⱼ∂ⱼΥ), `ReferenceBuoyancyAnomaly`
+  (bᵣ = b - b✶(z)) and `AvailablePotentialToKineticEnergyConversion` (wbᵣ). That last one is *not*
+  `PotentialToKineticEnergyConversion`, which is uᵢbᵢ over the total buoyancy and belongs to the eₚ
+  budget: the two differ by wb✶(z), the exchange with the background state, and since both form the
+  product on the same face (`ℑzᵃᵃᶠ` of a cell-centered buoyancy, which is what `z_dot_g_bᶜᶜᶠ` is under
+  a vertical gravity) the split wb = wbᵣ + wb✶ holds to roundoff cell by cell, not just in the volume
+  integral where wb✶ integrates away. `wbᵣ` takes its anomaly as a KFO argument, so passing
+  `anomaly = Field(...)` shares one computed anomaly the way `upsilon` shares one Υ — and handing it
+  `reference_buoyancy_at_height(z✶)` instead is how the tests form wb✶. Υ, bᵣ, wbᵣ and εₐ are maps on
+  the model grid, so all four reject `VerticalSort` (`validate_reference_height_grid`) and default to
+  `HeavisideIntegral`. Built on `BackgroundPotentialEnergyEquation`, so it is included after it, and it
+  re-exports `reference_height`, `reference_buoyancy`, `reference_buoyancy_at_height` and the four
+  reference-height methods so either module can be used on its own
 - **`FilteredAvailablePotentialEnergyEquation`**: the APE of the *filtered* buoyancy and its
   dissipation — `FilteredAvailablePotentialEnergy` (Eₐˡ = eₐ(b̄, z), the local APE kernel evaluated on
   the reference height of b̄ = filter(b); its kernel `filtered_ape_ccc` just forwards to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,11 @@ All kernel functions use Oceananigans' staggered grid conventions with location 
 - **`AvailablePotentialEnergyEquation`**: the other half of the Winters et al. (1995) split,
   `AvailablePotentialEnergy` (Eₐ), computed in the local Holliday & McIntyre (1981) form
   `∫[b✶(z̃) - b]dz̃`, which is non-negative everywhere rather than only in the integral, plus the terms
-  of its budget: `DisplacementPotential` (Υ = z✶ - z, named `BuoyancyDisplacementPotential` before
-  0.20), `AvailablePotentialEnergyDissipationRate` (εₐ = -qⱼ∂ⱼΥ), `ReferenceBuoyancyAnomaly`
-  (bᵣ = b - b✶(z)) and `AvailablePotentialToKineticEnergyConversion` (wbᵣ). That last one is *not*
+  of its budget: `AvailablePotentialEnergyDisplacementPotential` (Υ = z✶ - z, named
+  `BuoyancyDisplacementPotential` before 0.20, and aliased `DisplacementPotential` inside the module
+  the way `AvailablePotentialEnergyDissipationRate` is aliased `DissipationRate` — exported by the
+  module, not by `Oceanostics`), `AvailablePotentialEnergyDissipationRate` (εₐ = -qⱼ∂ⱼΥ),
+  `ReferenceBuoyancyAnomaly` (bᵣ = b - b✶(z)) and `AvailablePotentialToKineticEnergyConversion` (wbᵣ). That last one is *not*
   `PotentialToKineticEnergyConversion`, which is uᵢbᵢ over the total buoyancy and belongs to the eₚ
   budget: the two differ by wb✶(z), the exchange with the background state, and since both form the
   product on the same face (`ℑzᵃᵃᶠ` of a cell-centered buoyancy, which is what `z_dot_g_bᶜᶜᶠ` is under

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
-version = "0.19.3"
+version = "0.20.0"
 authors = ["tomchor <tomaschor@gmail.com>"]
 
 [deps]

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,3 +15,20 @@ julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'; julia --color=yes
 
 If the docs are built successfully you can view them by opening `docs/build/index.html` from
 your favorite browser.
+
+## Building a single page
+
+A full build takes minutes, most of it spent running the examples, which is a poor loop when what you
+are editing is the prose of one page. `docs/build_single_page.jl` renders one page on its own:
+
+```
+julia --project=docs
+julia> include("docs/build_single_page.jl")
+```
+
+The first include loads Documenter and Oceanostics and opens the rendered page
+(`docs/build_single_page/html/index.html`) in a browser. Every include after that rebuilds it in about
+a second, so the loop is edit, re-include, refresh the tab. `PAGE` selects a different page and
+`DOCTEST = true` runs that page's `jldoctest` blocks; the header of the script has the details. Links
+into the pages a single-page build leaves out cannot resolve, so they are reported as warnings and the
+build carries on.

--- a/docs/build_single_page.jl
+++ b/docs/build_single_page.jl
@@ -1,0 +1,97 @@
+# Build one page of the docs, over and over, from a REPL:
+#
+#     julia --project=docs
+#     julia> include("docs/build_single_page.jl")   # re-include after every edit to the page
+#
+# `PAGE` picks which page, and `DOCTEST` runs the `jldoctest` blocks written on it (off by default,
+# since the prose and the math are what usually need iterating on; the doctests inside docstrings
+# belong to the module and only run in the full build):
+#
+#     julia> PAGE = "filtered_available_potential_energy_equation.md"; include("docs/build_single_page.jl")
+#     julia> DOCTEST = true; include("docs/build_single_page.jl")
+#
+# Both stay set for the rest of the session. The full docs are still built with `docs/make.jl`; this
+# is a fast loop for one page, not a substitute for it.
+
+#+++ Environment (only the first `include` of a session pays for this)
+using Pkg
+if !@isdefined(SINGLE_PAGE_ENVIRONMENT_READY)
+    Base.active_project() == joinpath(@__DIR__, "Project.toml") || Pkg.activate(@__DIR__)
+
+    # `Oceanostics` comes from the parent environment, as in `make.jl`.
+    parent_environment = normpath(joinpath(@__DIR__, ".."))
+    parent_environment in LOAD_PATH || pushfirst!(LOAD_PATH, parent_environment)
+
+    try
+        Pkg.instantiate()
+    catch # a manifest older than `Project.toml` can be missing a dependency it has since gained
+        Pkg.resolve()
+        Pkg.instantiate()
+    end
+
+    SINGLE_PAGE_ENVIRONMENT_READY = true
+end
+
+using Documenter
+using DocumenterCodeBlocks: CodeBlocks
+using Oceananigans
+using Oceanostics
+#---
+
+#+++ Stage a source directory holding only this page
+# `makedocs` expands *every* `.md` it finds under `source`, so aiming it at `docs/src` would drag in
+# the example pages and every other module page on each rebuild. Giving the one page a source
+# directory of its own keeps a rebuild to a few seconds. The copy is refreshed on every include, so
+# it always renders whatever is currently on disk.
+page = @isdefined(PAGE) ? PAGE : "available_potential_energy_equation.md"
+page_path = joinpath(@__DIR__, "src", page)
+isfile(page_path) || error("$(page_path) does not exist")
+
+staging = joinpath(@__DIR__, "build_single_page") # `docs/build_*` is gitignored
+source  = joinpath(staging, "src")
+build   = joinpath(staging, "html")
+
+# Staged as `index.md` so it *is* the landing page: Documenter warns about a site without one, and
+# a browser (or `LiveServer.serve`) then lands on the page with no path to type.
+rm(source, recursive=true, force=true)
+mkpath(source)
+cp(page_path, joinpath(source, "index.md"))
+
+# The page's own first heading is all the navigation menu needs.
+heading = match(r"^#[ \t]+(.+)$"m, read(page_path, String))
+title = heading === nothing ? page : String(strip(heading.captures[1]))
+#---
+
+#+++ Build
+first_build = !isdir(build)
+
+makedocs(sitename = "Oceanostics.jl",
+         root = @__DIR__,
+         source = source,
+         build = build,
+         pages = [title => "index.md"],
+         doctest = @isdefined(DOCTEST) ? DOCTEST : false,
+         doctestfilters = [r"with \d+ methods?"], # as in `make.jl`: method counts drift with Oceananigans
+         clean = true,
+         format = Documenter.HTML(collapselevel = 1, prettyurls = false, mathengine = MathJax3()),
+         plugins = [CodeBlocks()],
+         checkdocs = :none,
+         # Links into the pages this build leaves out cannot resolve, so cross-references warn
+         # instead of failing. Everything else (a malformed `@docs` block, a failing doctest) still
+         # errors, which is the point of building at all.
+         warnonly = [:cross_references],
+         )
+
+html = joinpath(build, "index.html")
+@info "Built $(page)" html
+
+# Open a tab on the first build; after that the tab only needs a refresh. `using LiveServer;
+# serve(dir=build)` in a second REPL does the refreshing for you (`build` stays defined out here).
+if first_build
+    try
+        run(pipeline(`xdg-open $(html)`, stdout=devnull, stderr=devnull), wait=false)
+    catch
+        @info "Could not open a browser; point one at the path above"
+    end
+end
+#---

--- a/docs/build_single_page.jl
+++ b/docs/build_single_page.jl
@@ -12,6 +12,31 @@
 #
 # Both stay set for the rest of the session. The full docs are still built with `docs/make.jl`; this
 # is a fast loop for one page, not a substitute for it.
+#
+# An example page is a special case. Those are Literate scripts under `docs/examples`, rendered to
+# `docs/src/generated/<name>.md`, and it is that generated page this script stages:
+#
+#     julia> PAGE = "generated/lock_release.md"; include("docs/build_single_page.jl")
+#
+# Editing the `.jl` therefore changes nothing here until Literate regenerates the page. For a preview
+# of the prose and the structure, regenerate it in CommonMark flavor, which emits plain fenced code
+# blocks:
+#
+#     julia> using Literate
+#     julia> Literate.markdown("docs/examples/lock_release.jl", "docs/src/generated";
+#                              execute = false, flavor = Literate.CommonMarkFlavor())
+#
+# That takes seconds, runs none of the code, and drops the `#hide` lines. `DocumenterFlavor` is the
+# wrong tool for a preview: it emits `@example` blocks, which Documenter runs itself while expanding
+# the page, so `execute = false` hands the simulation to `makedocs` rather than skipping it, and in
+# this staged directory it fails outright when the example's output writer looks for a NetCDF file
+# that is not there. `make.jl` pairs that flavor with `execute = true`, which bakes the outputs in and
+# takes the several minutes this script exists to avoid.
+#
+# Two more things to know. The figures and movies live beside the page in `docs/src/generated` and are
+# not staged here, so they render as broken links. And `make.jl` reuses any generated page newer than
+# its `.jl`, so a page left behind by a preview would be reused as it stands: delete it, or touch the
+# `.jl`, before the next full build.
 
 #+++ Environment (only the first `include` of a session pays for this)
 using Pkg

--- a/docs/examples/lock_release.jl
+++ b/docs/examples/lock_release.jl
@@ -109,7 +109,7 @@ KE            = KineticEnergy(model)
 # single term and each drains through a dissipation of its own,
 #
 # ```math
-# \frac{d}{dt}\int e_k\, dV = \int wb\, dV - \int \varepsilon_k\, dV, \qquad
+# \frac{d}{dt}\int e_k\, dV = +\int w b_r\, dV - \int \varepsilon_k\, dV, \qquad
 # \frac{d}{dt}\int e_a\, dV = -\int w b_r\, dV - \int \varepsilon_a\, dV .
 # ```
 #
@@ -117,14 +117,13 @@ KE            = KineticEnergy(model)
 # the walls are free-slip and insulating, so the viscous and diffusive fluxes leave nothing at the
 # boundary either. What survives is the exchange between the two reservoirs and the two sinks.
 #
-# The exchange is written differently in the two budgets. The kinetic energy is produced at ``wb``, the
-# term the model's own momentum equation carries
-# ([`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion)),
-# while the available potential energy is released at
-# ``w b_r`` ([`AvailablePotentialToKineticEnergyConversion`](@ref)), set by the buoyancy anomaly
-# ``b_r = b - b^\star(z)`` relative to the reference profile at the parcel's own height. They are
-# different fields, and equal in the volume integral, which is what lets them cancel from the sum of the
-# two budgets. [Two ways of writing the exchange](@ref) below is that statement made in the data.
+# Note that exchange term is written ``w b_r`` ([`AvailablePotentialToKineticEnergyConversion`](@ref))
+# in both budgets, not ``wb`` ([`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion)),
+# where ``b_r = b - b^\star(z)`` is the buoyancy anomaly relative to the reference profile at the parcel's own height.
+# representing an exchange between kinetic energy and _Available potential_ energy, not _potential_ energy. This is possible in
+# the KE equation since ``b_r`` is a function of height only, and therefore the reference profile's
+# hydrostatic pressure contribution can be absorbed into the pressure term. That said, both terms
+# are equal in an integrated sense (as we'll show below).
 #
 # ``\varepsilon_a`` is the term this example is built around. It is the contraction of the buoyancy
 # gradient with the displacement potential
@@ -133,8 +132,7 @@ KE            = KineticEnergy(model)
 #
 # ```math
 # \varepsilon_a = \kappa\, \partial_i b\, \partial_i \Upsilon
-#               = \kappa \left[\frac{\partial z^\star}{\partial b} |\nabla b|^2
-#                              - \frac{\partial b}{\partial z}\right] ,
+#               = \kappa \left[\frac{\partial z^\star}{\partial b} |\nabla b|^2 - \frac{\partial b}{\partial z}\right] ,
 # ```
 # the diapycnal mixing rate of Winters et al. (1995) less the diffusion the reference state undergoes
 # on its own, which carries no available energy with it.
@@ -145,19 +143,19 @@ KE            = KineticEnergy(model)
 # ``z^\star`` a function of buoyancy alone, so tied cells do not spread ``z^\star`` over the depth they
 # fill and show up in ``\nabla \Upsilon`` as grid-scale noise.
 
-εₐ = AvailablePotentialEnergyDissipationRate(model, z✶_heaviside)
-εₖ = KineticEnergyDissipationRate(model)
-wb = PotentialToKineticEnergyConversion(model)
-
-# ``w b_r`` takes the same reference height, and builds its own anomaly from it rather than being
-# handed one, since nothing else here needs ``b_r`` on its own:
-
+εₐ  = AvailablePotentialEnergyDissipationRate(model, z✶_heaviside)
+εₖ  = KineticEnergyDissipationRate(model)
 wbᵣ = AvailablePotentialToKineticEnergyConversion(model, z✶_heaviside)
 
-∫wb  = Integral(wb)
+# Let's also calculate the exchange between kinetic and potential energy ``wb`` for comparison
+# along with integrals for all terms
+
+wb = PotentialToKineticEnergyConversion(model)
+
 ∫wbᵣ = Integral(wbᵣ)
-∫εₖ = Integral(εₖ)
-∫εₐ = Integral(εₐ)
+∫wb  = Integral(wb)
+∫εₖ  = Integral(εₖ)
+∫εₐ  = Integral(εₐ)
 
 using NCDatasets
 filename = "lock_release"

--- a/docs/examples/lock_release.jl
+++ b/docs/examples/lock_release.jl
@@ -117,25 +117,31 @@ KE            = KineticEnergy(model)
 # the walls are free-slip and insulating, so the viscous and diffusive fluxes leave nothing at the
 # boundary either. What survives is the exchange between the two reservoirs and the two sinks.
 #
-# Note that exchange term is written ``w b_r`` ([`AvailablePotentialToKineticEnergyConversion`](@ref))
+# Note that the exchange term is written ``w b_r`` ([`AvailablePotentialToKineticEnergyConversion`](@ref))
 # in both budgets, not ``wb`` ([`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion)),
-# where ``b_r = b - b^\star(z)`` is the buoyancy anomaly relative to the reference profile at the parcel's own height.
-# representing an exchange between kinetic energy and _Available potential_ energy, not _potential_ energy. This is possible in
-# the KE equation since ``b_r`` is a function of height only, and therefore the reference profile's
-# hydrostatic pressure contribution can be absorbed into the pressure term. That said, both terms
-# are equal in an integrated sense (as we'll show below).
+# where ``b_r = b - b^\star(z)`` is the buoyancy anomaly relative to the reference profile at the
+# parcel's own height, representing an exchange between kinetic energy and _available potential_
+# energy rather than _potential_ energy. This is possible in the KE equation since ``b^\star`` is a
+# function of height alone, so the hydrostatic pressure that goes with it, ``p^\star(z)`` with
+# ``\partial p^\star/\partial z = b^\star``, has no horizontal gradient and can be absorbed into the
+# pressure term. That said, both terms are equal in an integrated sense (as we'll show below).
 #
-# ``\varepsilon_a`` is the term this example is built around. It is the contraction of the buoyancy
-# gradient with the displacement potential
+# ``\varepsilon_a`` is the term this example is built around. It is the contraction of the closure's
+# diffusive buoyancy flux with the gradient of the displacement potential
 # [``\Upsilon = z^\star - z``](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential),
 # which is ``\partial e_a / \partial b`` and hence the conjugate of ``b``:
 #
 # ```math
-# \varepsilon_a = \kappa\, \partial_i b\, \partial_i \Upsilon
-#               = \kappa \left[\frac{\partial z^\star}{\partial b} |\nabla b|^2 - \frac{\partial b}{\partial z}\right] ,
+# \varepsilon_a = -q_i\, \partial_i \Upsilon
+#               = -\frac{\partial z^\star}{\partial b}\, q_i\, \partial_i b \;+\; q_3 ,
 # ```
-# the diapycnal mixing rate of Winters et al. (1995) less the diffusion the reference state undergoes
-# on its own, which carries no available energy with it.
+# where ``q_i`` is whatever diffusive buoyancy flux the closure supplies. Nothing here assumes a form
+# for it: the diagnostic reads it off the model's own closure, so these expressions hold for an LES
+# closure as they do for the constant diffusivity this run uses. The first term is the diapycnal mixing
+# rate of Winters et al. (1995), and the second removes the diffusion the reference state undergoes on
+# its own, which carries no available energy with it. That second piece is ``q_3 = -\Phi``, the
+# diffusive buoyancy flux the [Potential energy equation](@ref) defines, with the sign it carries
+# there.
 #
 # We hand ``\varepsilon_a`` the [`HeavisideIntegral`](@ref) reference height already built above rather
 # than letting it sort the domain again, and that method rather than another because
@@ -480,7 +486,7 @@ nothing #hide
 # `BPE` never turns back, since mixing across density surfaces cannot be undone. Everything the flow
 # can still do sits in `APE`, which trades with `KE` as the box seiches, each cycle weaker than the
 # last. The dashed total is `∫KE + ∫eₚ`, and it has no reason to fall monotonically: viscosity drains it
-# at `∫εₖ` while diffusion working against gravity feeds it back at `∫κ ∂b/∂z`, and a run quiet enough
+# at `∫εₖ` while the diffusive flux working against gravity feeds it back at `∫Φ dV = -∫q₃ dV`, and a run quiet enough
 # for the second to win would see the total edge back up. At `Re = 1000` the first stays the larger of
 # the two throughout, and the total ends down by about a fifth of the available energy the lock started
 # with.
@@ -507,7 +513,7 @@ wbᵣ_pair = pair_mean(wbᵣ_bud);
 # Both budgets are written in sum-to-zero form: each curve is plotted with the sign it carries here, so
 # the panels below add up to the residual.
 
-KE_resid  = @. -dKEdt  + wb_pair  - ε_pair
+KE_resid  = @. -dKEdt  + wbᵣ_pair - ε_pair
 APE_resid = @. -dAPEdt - wbᵣ_pair - εₐ_pair
 
 rms(x) = √(sum(abs2, x) / length(x))                                       #hide
@@ -529,7 +535,7 @@ budget_kwargs = (xlabel = "Time", ylabel = "Rate", height = 190, width = 560)
 
 ax_KE_bud = Axis(fig4[1, 1]; title = "Volume-integrated KE budget", budget_kwargs...)
 lines!(ax_KE_bud, t_pair, -dKEdt,   label = "-d(∫KE)/dt")
-lines!(ax_KE_bud, t_pair,  wb_pair, label = "∫wb dV")
+lines!(ax_KE_bud, t_pair, wbᵣ_pair, label = "∫wbᵣ dV")
 lines!(ax_KE_bud, t_pair, -ε_pair,  label = "-∫εₖ dV")
 lines!(ax_KE_bud, t_pair, KE_resid; label = "residual", color = :black, linestyle = :dash)
 Legend(fig4[1, 2], ax_KE_bud; labelsize = 12, framevisible = false)
@@ -567,8 +573,9 @@ nothing #hide
 # definition allows: at `t = 0` the lock is uniform in the vertical, the reference state has nothing to
 # diffuse along, and `εₐ` is the whole diapycnal mixing rate, but as the current lays the fluid out in
 # layers the reference state's own diffusion catches up and for a moment overtakes it. A sign-definite
-# quantity like `κ|∇b|²` cannot go negative at all, which is the practical difference between `εₐ` and
-# the buoyancy variance dissipation it is easily confused with.
+# quantity like the buoyancy variance dissipation `-2 qᵢ∂ᵢb`, which no down-gradient closure lets turn
+# negative, cannot do that at all. That is the practical difference between `εₐ` and the variance
+# dissipation it is easily confused with.
 #
 # Both residuals stay near zero. They do not vanish, and cannot: the discrete KE and `eₐ` equations are
 # not derived from the discrete momentum and buoyancy equations the model steps, so the two sides agree
@@ -579,10 +586,10 @@ nothing #hide
 
 # ## Two ways of writing the exchange
 #
-# The KE budget above is closed with `∫wb dV` and the APE budget with `∫wbᵣ dV`, and both residuals are
-# small, which can only happen if the two integrals agree. They do, and the reason is visible in the
-# maps: what separates them is `w b✶(z)`, the work the flow does against the reference stratification,
-# which is a flux divergence and integrates to nothing in a closed box.
+# Both budgets above are closed with `∫wbᵣ dV`, and closing the KE one with `∫wb dV` instead would work
+# just as well, since the two integrals agree. The reason is visible in the maps: what separates them is
+# `w b✶(z)`, the work the flow does against the reference stratification, which is a flux divergence and
+# integrates to nothing in a closed box.
 
 wb_t  = FieldTimeSeries(filepath, "wb")
 wbᵣ_t = FieldTimeSeries(filepath, "wbᵣ")

--- a/docs/examples/lock_release.jl
+++ b/docs/examples/lock_release.jl
@@ -126,22 +126,14 @@ KE            = KineticEnergy(model)
 # ``\partial p^\star/\partial z = b^\star``, has no horizontal gradient and can be absorbed into the
 # pressure term. That said, both terms are equal in an integrated sense (as we'll show below).
 #
-# ``\varepsilon_a`` is the term this example is built around. It is the contraction of the closure's
-# diffusive buoyancy flux with the gradient of the displacement potential
-# [``\Upsilon = z^\star - z``](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential),
-# which is ``\partial e_a / \partial b`` and hence the conjugate of ``b``:
+# The dissipation term ``\varepsilon_a`` is the contraction of the closure's diffusive buoyancy
+# flux with the gradient of the displacement potential
+# [``\Upsilon = z^\star - z``](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential):
 #
 # ```math
 # \varepsilon_a = -q_i\, \partial_i \Upsilon
-#               = -\frac{\partial z^\star}{\partial b}\, q_i\, \partial_i b \;+\; q_3 ,
 # ```
-# where ``q_i`` is whatever diffusive buoyancy flux the closure supplies. Nothing here assumes a form
-# for it: the diagnostic reads it off the model's own closure, so these expressions hold for an LES
-# closure as they do for the constant diffusivity this run uses. The first term is the diapycnal mixing
-# rate of Winters et al. (1995), and the second removes the diffusion the reference state undergoes on
-# its own, which carries no available energy with it. That second piece is ``q_3 = -\Phi``, the
-# diffusive buoyancy flux the [Potential energy equation](@ref) defines, with the sign it carries
-# there.
+# where ``q_i`` is whatever diffusive buoyancy flux the closure supplies.
 #
 # We hand ``\varepsilon_a`` the [`HeavisideIntegral`](@ref) reference height already built above rather
 # than letting it sort the domain again, and that method rather than another because

--- a/docs/examples/lock_release.jl
+++ b/docs/examples/lock_release.jl
@@ -110,17 +110,26 @@ KE            = KineticEnergy(model)
 #
 # ```math
 # \frac{d}{dt}\int e_k\, dV = \int wb\, dV - \int \varepsilon_k\, dV, \qquad
-# \frac{d}{dt}\int e_a\, dV = -\int wb\, dV - \int \varepsilon_a\, dV .
+# \frac{d}{dt}\int e_a\, dV = -\int w b_r\, dV - \int \varepsilon_a\, dV .
 # ```
 #
 # Advection and the pressure gradient integrate to zero for an incompressible flow in a closed box, and
 # the walls are free-slip and insulating, so the viscous and diffusive fluxes leave nothing at the
-# boundary either. What survives is the buoyancy production ``wb``, which carries opposite signs in the
-# two budgets and so cancels from their sum, and the two sinks.
+# boundary either. What survives is the exchange between the two reservoirs and the two sinks.
+#
+# The exchange is written differently in the two budgets. The kinetic energy is produced at ``wb``, the
+# term the model's own momentum equation carries
+# ([`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion)),
+# while the available potential energy is released at
+# ``w b_r`` ([`AvailablePotentialToKineticEnergyConversion`](@ref)), set by the buoyancy anomaly
+# ``b_r = b - b^\star(z)`` relative to the reference profile at the parcel's own height. They are
+# different fields, and equal in the volume integral, which is what lets them cancel from the sum of the
+# two budgets. [Two ways of writing the exchange](@ref) below is that statement made in the data.
 #
 # ``\varepsilon_a`` is the term this example is built around. It is the contraction of the buoyancy
-# gradient with the [`DisplacementPotential`](@ref) ``\Upsilon = z^\star - z``, which is
-# ``\partial e_a / \partial b`` and hence the conjugate of ``b``:
+# gradient with the displacement potential
+# [``\Upsilon = z^\star - z``](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential),
+# which is ``\partial e_a / \partial b`` and hence the conjugate of ``b``:
 #
 # ```math
 # \varepsilon_a = \kappa\, \partial_i b\, \partial_i \Upsilon
@@ -140,7 +149,13 @@ KE            = KineticEnergy(model)
 εₖ = KineticEnergyDissipationRate(model)
 wb = PotentialToKineticEnergyConversion(model)
 
-∫wb = Integral(wb)
+# ``w b_r`` takes the same reference height, and builds its own anomaly from it rather than being
+# handed one, since nothing else here needs ``b_r`` on its own:
+
+wbᵣ = AvailablePotentialToKineticEnergyConversion(model, z✶_heaviside)
+
+∫wb  = Integral(wb)
+∫wbᵣ = Integral(wbᵣ)
 ∫εₖ = Integral(εₖ)
 ∫εₐ = Integral(εₐ)
 
@@ -152,7 +167,7 @@ filename = "lock_release"
 # its own `N`-cell vertical axis.
 
 outputs = (; b, KE, APE_ranked, APE_heaviside, APE_lookup, APE_column,
-             z✶_ranked, z✶_heaviside, z✶_lookup, z✶_column, b✶_column)
+             z✶_ranked, z✶_heaviside, z✶_lookup, z✶_column, b✶_column, wb, wbᵣ)
 
 simulation.output_writers[:fields] = NetCDFWriter(model, outputs,
                                                   filename = joinpath(@__DIR__, filename),
@@ -165,7 +180,7 @@ simulation.output_writers[:fields] = NetCDFWriter(model, outputs,
 # The `∫APE_heaviside` written here is the tendency term that pairs with ``\varepsilon_a``, since the
 # two come off the same sort.
 
-integrals = (; ∫BPE, ∫KE, ∫APE, ∫APE_heaviside, ∫APE_lookup, ∫APE_column, ∫wb, ∫εₖ, ∫εₐ)
+integrals = (; ∫BPE, ∫KE, ∫APE, ∫APE_heaviside, ∫APE_lookup, ∫APE_column, ∫wb, ∫wbᵣ, ∫εₖ, ∫εₐ)
 
 simulation.output_writers[:budget] = NetCDFWriter(model, integrals,
                                                   filename = joinpath(@__DIR__, filename * "_budget"),
@@ -419,6 +434,7 @@ BPE_bud  = ds["∫BPE"][:]
 APE_bud  = ds["∫APE_heaviside"][:]
 KE_bud   = ds["∫KE"][:]
 wb_bud   = ds["∫wb"][:]
+wbᵣ_bud  = ds["∫wbᵣ"][:]
 ε_bud    = ds["∫εₖ"][:]
 εₐ_bud  = ds["∫εₐ"][:]
 ## all four methods integrate to the same eₐ, however they place cells of equal buoyancy  #hide
@@ -486,14 +502,15 @@ dAPEdt = (APE_bud[idx2] .- APE_bud[idx1]) ./ Δt_pair
 pair_mean(x) = @. 0.5 * (x[idx1] + x[idx2])
 
 wb_pair  = pair_mean(wb_bud);
+wbᵣ_pair = pair_mean(wbᵣ_bud);
 ε_pair   = pair_mean(ε_bud);
 εₐ_pair = pair_mean(εₐ_bud);
 
 # Both budgets are written in sum-to-zero form: each curve is plotted with the sign it carries here, so
 # the panels below add up to the residual.
 
-KE_resid  = @. -dKEdt  + wb_pair - ε_pair
-APE_resid = @. -dAPEdt - wb_pair - εₐ_pair
+KE_resid  = @. -dKEdt  + wb_pair  - ε_pair
+APE_resid = @. -dAPEdt - wbᵣ_pair - εₐ_pair
 
 rms(x) = √(sum(abs2, x) / length(x))                                       #hide
 @test rms(KE_resid)  < 0.01 * rms(dKEdt)                                   #hide
@@ -502,7 +519,8 @@ rms(x) = √(sum(abs2, x) / length(x))                                       #hi
 ## the sharp one: the APE residual is a small fraction of εₐ itself, so the budget resolves     #hide
 ## the new term rather than closing to within its size                                           #hide
 @test rms(APE_resid) < 0.05 * rms(εₐ_pair)                                #hide
-## `wb` is the same term in both, so it cancels from the sum of the two budgets                  #hide
+## the two conversions have the same volume integral, so they cancel from the sum of the budgets #hide
+@test rms(wb_pair .- wbᵣ_pair) < 1e-8 * rms(wb_pair)                       #hide
 @test rms(KE_resid .+ APE_resid) < 0.02 * rms(ε_pair)                      #hide
 ## and εₐ takes both signs over the run, which is what the discussion below rests on            #hide
 @test minimum(εₐ_pair) < 0 < maximum(εₐ_pair);                           #hide
@@ -520,7 +538,7 @@ Legend(fig4[1, 2], ax_KE_bud; labelsize = 12, framevisible = false)
 
 ax_APE_bud = Axis(fig4[2, 1]; title = "Volume-integrated APE budget", budget_kwargs...)
 lines!(ax_APE_bud, t_pair, -dAPEdt,   label = "-d(∫eₐ)/dt")
-lines!(ax_APE_bud, t_pair, -wb_pair,  label = "-∫wb dV")
+lines!(ax_APE_bud, t_pair, -wbᵣ_pair, label = "-∫wbᵣ dV")
 lines!(ax_APE_bud, t_pair, -εₐ_pair, label = "-∫εₐ dV")
 lines!(ax_APE_bud, t_pair, APE_resid; label = "residual", color = :black, linestyle = :dash)
 Legend(fig4[2, 2], ax_APE_bud; labelsize = 12, framevisible = false)
@@ -560,3 +578,58 @@ nothing #hide
 # [the two-dimensional turbulence example](@ref two_d_turbulence_example), with one more source of
 # discrepancy here: `Integral(eₐ)` of the local Holliday & McIntyre density samples the reference
 # profile at the model's cell centers, and that midpoint quadrature is itself second order in `Δz`.
+
+# ## Two ways of writing the exchange
+#
+# The KE budget above is closed with `∫wb dV` and the APE budget with `∫wbᵣ dV`, and both residuals are
+# small, which can only happen if the two integrals agree. They do, and the reason is visible in the
+# maps: what separates them is `w b✶(z)`, the work the flow does against the reference stratification,
+# which is a flux divergence and integrates to nothing in a closed box.
+
+wb_t  = FieldTimeSeries(filepath, "wb")
+wbᵣ_t = FieldTimeSeries(filepath, "wbᵣ")
+
+t_peak = t_e[argmax(abs.(wb_bud[idx1]))]   # the snapshot where the exchange is strongest
+n_peak = argmin(abs.(times .- t_peak))
+
+wb_map  = interior(wb_t[n_peak],  :, 1, :)
+wbᵣ_map = interior(wbᵣ_t[n_peak], :, 1, :)
+wb✶_map = wb_map .- wbᵣ_map                # `wb = wbᵣ + w b✶(z)` holds cell by cell
+
+## the two conversions are genuinely different maps, so the agreement above is about the integral #hide
+@test maximum(abs, wb✶_map) > 0.1 * maximum(abs, wb_map)                                          #hide
+## while their difference is the piece that integrates away, which is what lets either one close  #hide
+## the integrated budget: on a uniform grid that is the plain sum over the cells                   #hide
+@test abs(sum(wb✶_map)) < 1e-8 * sum(abs, wb✶_map);                                               #hide
+
+set_theme!(Theme(fontsize = 20)) #hide
+fig5 = Figure(size = (900, 640))
+
+lim = maximum(abs, wb_map)
+conv_kwargs = (ylabel = "z", height = 150, aspect = DataAspect())
+xs, zs = xnodes(grid, Center()), znodes(grid, Center())
+
+ax_wb  = Axis(fig5[2, 1]; title = "wb,  the KE budget's production",     conv_kwargs...)
+ax_wbᵣ = Axis(fig5[4, 1]; title = "wbᵣ,  the eₐ budget's release",      conv_kwargs...)
+ax_dif = Axis(fig5[6, 1]; title = "wb - wbᵣ = w b✶(z)", xlabel = "x",   conv_kwargs...)
+
+for (row, (ax, conversion)) in enumerate(zip((ax_wb, ax_wbᵣ, ax_dif), (wb_map, wbᵣ_map, wb✶_map)))
+    hm = heatmap!(ax, xs, zs, conversion; colormap = :balance, colorrange = (-lim, lim))
+    Colorbar(fig5[2row + 1, 1], hm; vertical = false, height = 8)
+end
+
+Label(fig5[1, 1], "Conversion terms,  t = " * string(round(t_peak, digits = 1)),
+      fontsize = 22, tellwidth = false)
+
+resize_to_layout!(fig5)
+save("lock_release_conversion.png", fig5)
+set_theme!() #hide
+nothing #hide
+
+# ![](lock_release_conversion.png)
+#
+# `wbᵣ` is the local release of `eₐ`: it vanishes wherever a parcel already carries the buoyancy its own
+# height calls for, whatever the vertical velocity is doing there. `wb` does not, since it counts the
+# reference stratification's own contribution as well, which is the horizontally banded pattern in the
+# bottom panel. Only `wbᵣ` maps where available potential energy is actually being converted; only in
+# the volume integral can `wb` stand in for it.

--- a/docs/examples/lock_release.jl
+++ b/docs/examples/lock_release.jl
@@ -119,7 +119,7 @@ KE            = KineticEnergy(model)
 # two budgets and so cancels from their sum, and the two sinks.
 #
 # ``\varepsilon_a`` is the term this example is built around. It is the contraction of the buoyancy
-# gradient with the [`BuoyancyDisplacementPotential`](@ref) ``\Upsilon = z^\star - z``, which is
+# gradient with the [`DisplacementPotential`](@ref) ``\Upsilon = z^\star - z``, which is
 # ``\partial e_a / \partial b`` and hence the conjugate of ``b``:
 #
 # ```math

--- a/docs/examples/lock_release.jl
+++ b/docs/examples/lock_release.jl
@@ -626,9 +626,3 @@ nothing #hide
 
 # ![](lock_release_conversion.png)
 #
-# `wbᵣ` is the local release of `eₐ`: it concentrates in the two intruding noses and falls away to
-# nothing in the fluid the fronts have not reached yet, where each parcel still carries the buoyancy its
-# own height calls for. `wb` does not, since it counts the reference stratification's own contribution
-# as well, the banded pattern about `z = 0.5` in the bottom panel, and that contribution is large enough
-# here to leave `wbᵣ` running at about twice the amplitude of `wb`. Only `wbᵣ` maps where available
-# potential energy is actually being converted; only in the volume integral can `wb` stand in for it.

--- a/docs/examples/lock_release.jl
+++ b/docs/examples/lock_release.jl
@@ -603,20 +603,21 @@ wb✶_map = wb_map .- wbᵣ_map                # `wb = wbᵣ + w b✶(z)` holds 
 @test abs(sum(wb✶_map)) < 1e-8 * sum(abs, wb✶_map);                                               #hide
 
 set_theme!(Theme(fontsize = 20)) #hide
-fig5 = Figure(size = (900, 640))
+fig5 = Figure(size = (900, 620))
 
-lim = maximum(abs, wb_map)
+## one range for all three panels, taken over all three: `wbᵣ` runs about twice as large as `wb` here,
+## and scaling each panel to itself would hide that
+lim = maximum(maximum(abs, conversion) for conversion in (wb_map, wbᵣ_map, wb✶_map))
 conv_kwargs = (ylabel = "z", height = 150, aspect = DataAspect())
 xs, zs = xnodes(grid, Center()), znodes(grid, Center())
 
-ax_wb  = Axis(fig5[2, 1]; title = "wb,  the KE budget's production",     conv_kwargs...)
-ax_wbᵣ = Axis(fig5[4, 1]; title = "wbᵣ,  the eₐ budget's release",      conv_kwargs...)
-ax_dif = Axis(fig5[6, 1]; title = "wb - wbᵣ = w b✶(z)", xlabel = "x",   conv_kwargs...)
+ax_wb  = Axis(fig5[2, 1]; title = "wb,  the KE budget's production",   conv_kwargs...)
+ax_wbᵣ = Axis(fig5[3, 1]; title = "wbᵣ,  the eₐ budget's release",    conv_kwargs...)
+ax_dif = Axis(fig5[4, 1]; title = "wb - wbᵣ = w b✶(z)", xlabel = "x", conv_kwargs...)
 
-for (row, (ax, conversion)) in enumerate(zip((ax_wb, ax_wbᵣ, ax_dif), (wb_map, wbᵣ_map, wb✶_map)))
-    hm = heatmap!(ax, xs, zs, conversion; colormap = :balance, colorrange = (-lim, lim))
-    Colorbar(fig5[2row + 1, 1], hm; vertical = false, height = 8)
-end
+hms = [heatmap!(ax, xs, zs, conversion; colormap = :balance, colorrange = (-lim, lim))
+       for (ax, conversion) in zip((ax_wb, ax_wbᵣ, ax_dif), (wb_map, wbᵣ_map, wb✶_map))]
+Colorbar(fig5[5, 1], hms[1]; vertical = false, height = 8)
 
 Label(fig5[1, 1], "Conversion terms,  t = " * string(round(t_peak, digits = 1)),
       fontsize = 22, tellwidth = false)
@@ -628,8 +629,9 @@ nothing #hide
 
 # ![](lock_release_conversion.png)
 #
-# `wbᵣ` is the local release of `eₐ`: it vanishes wherever a parcel already carries the buoyancy its own
-# height calls for, whatever the vertical velocity is doing there. `wb` does not, since it counts the
-# reference stratification's own contribution as well, which is the horizontally banded pattern in the
-# bottom panel. Only `wbᵣ` maps where available potential energy is actually being converted; only in
-# the volume integral can `wb` stand in for it.
+# `wbᵣ` is the local release of `eₐ`: it concentrates in the two intruding noses and falls away to
+# nothing in the fluid the fronts have not reached yet, where each parcel still carries the buoyancy its
+# own height calls for. `wb` does not, since it counts the reference stratification's own contribution
+# as well, the banded pattern about `z = 0.5` in the bottom panel, and that contribution is large enough
+# here to leave `wbᵣ` running at about twice the amplitude of `wb`. Only `wbᵣ` maps where available
+# potential energy is actually being converted; only in the volume integral can `wb` stand in for it.

--- a/docs/examples/lock_release.jl
+++ b/docs/examples/lock_release.jl
@@ -425,13 +425,13 @@ nothing #hide
 # energy curves use; the pair as a whole is what gives `d/dt` further down.
 
 ds = NCDataset(simulation.output_writers[:budget].filepath)
-t_bud    = ds["time"][:]
-BPE_bud  = ds["∫BPE"][:]
-APE_bud  = ds["∫APE_heaviside"][:]
-KE_bud   = ds["∫KE"][:]
-wb_bud   = ds["∫wb"][:]
-wbᵣ_bud  = ds["∫wbᵣ"][:]
-ε_bud    = ds["∫εₖ"][:]
+t_bud   = ds["time"][:]
+BPE_bud = ds["∫BPE"][:]
+APE_bud = ds["∫APE_heaviside"][:]
+KE_bud  = ds["∫KE"][:]
+wb_bud  = ds["∫wb"][:]
+wbᵣ_bud = ds["∫wbᵣ"][:]
+εₖ_bud  = ds["∫εₖ"][:]
 εₐ_bud  = ds["∫εₐ"][:]
 ## all four methods integrate to the same eₐ, however they place cells of equal buoyancy  #hide
 @test ds["∫APE"][:]        ≈ APE_bud rtol=1e-8                                             #hide
@@ -499,25 +499,25 @@ pair_mean(x) = @. 0.5 * (x[idx1] + x[idx2])
 
 wb_pair  = pair_mean(wb_bud);
 wbᵣ_pair = pair_mean(wbᵣ_bud);
-ε_pair   = pair_mean(ε_bud);
-εₐ_pair = pair_mean(εₐ_bud);
+εₖ_pair  = pair_mean(εₖ_bud);
+εₐ_pair  = pair_mean(εₐ_bud);
 
 # Both budgets are written in sum-to-zero form: each curve is plotted with the sign it carries here, so
 # the panels below add up to the residual.
 
-KE_resid  = @. -dKEdt  + wbᵣ_pair - ε_pair
+KE_resid  = @. -dKEdt  + wbᵣ_pair - εₖ_pair
 APE_resid = @. -dAPEdt - wbᵣ_pair - εₐ_pair
 
 rms(x) = √(sum(abs2, x) / length(x))                                       #hide
 @test rms(KE_resid)  < 0.01 * rms(dKEdt)                                   #hide
-@test rms(KE_resid)  < 0.02 * rms(ε_pair)                                  #hide
+@test rms(KE_resid)  < 0.02 * rms(εₖ_pair)                                  #hide
 @test rms(APE_resid) < 0.01 * rms(dAPEdt)                                  #hide
 ## the sharp one: the APE residual is a small fraction of εₐ itself, so the budget resolves     #hide
 ## the new term rather than closing to within its size                                           #hide
 @test rms(APE_resid) < 0.05 * rms(εₐ_pair)                                #hide
 ## the two conversions have the same volume integral, so they cancel from the sum of the budgets #hide
 @test rms(wb_pair .- wbᵣ_pair) < 1e-8 * rms(wb_pair)                       #hide
-@test rms(KE_resid .+ APE_resid) < 0.02 * rms(ε_pair)                      #hide
+@test rms(KE_resid .+ APE_resid) < 0.02 * rms(εₖ_pair)                      #hide
 ## and εₐ takes both signs over the run, which is what the discussion below rests on            #hide
 @test minimum(εₐ_pair) < 0 < maximum(εₐ_pair);                           #hide
 
@@ -528,7 +528,7 @@ budget_kwargs = (xlabel = "Time", ylabel = "Rate", height = 190, width = 560)
 ax_KE_bud = Axis(fig4[1, 1]; title = "Volume-integrated KE budget", budget_kwargs...)
 lines!(ax_KE_bud, t_pair, -dKEdt,   label = "-d(∫KE)/dt")
 lines!(ax_KE_bud, t_pair, wbᵣ_pair, label = "∫wbᵣ dV")
-lines!(ax_KE_bud, t_pair, -ε_pair,  label = "-∫εₖ dV")
+lines!(ax_KE_bud, t_pair, -εₖ_pair, label = "-∫εₖ dV")
 lines!(ax_KE_bud, t_pair, KE_resid; label = "residual", color = :black, linestyle = :dash)
 Legend(fig4[1, 2], ax_KE_bud; labelsize = 12, framevisible = false)
 

--- a/docs/src/available_potential_energy_equation.md
+++ b/docs/src/available_potential_energy_equation.md
@@ -74,37 +74,40 @@ example for an application of this budget.
 
 ## Terms and what is implemented
 
-Three of the quantities above have diagnostics of their own. The conversion has one that matches it
-only under a volume integral, and the two transports and ``R`` have none.
+Five of the quantities above have diagnostics; the two transport terms and ``R`` have none.
 
 | Quantity | Expression | Diagnostic |
 |:---|:---|:---|
 | Available potential energy | ``e_a = \int_{z^\star(b)}^{z} \left[b^\star(\tilde z,\, t) - b\right] \mathrm{d}\tilde z`` | [`AvailablePotentialEnergy`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergy) |
-| Displacement potential | ``\Upsilon = z^\star - z`` | [`BuoyancyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.BuoyancyDisplacementPotential) |
+| Displacement potential | ``\Upsilon = z^\star - z`` | [`DisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.DisplacementPotential) |
 | Advection | ``\partial_j(u_j e_a)`` | not implemented |
-| APE to KE conversion | ``w b_r``, with ``b_r = b - b^\star(z,\, t)`` | not implemented |
+| Buoyancy anomaly | ``b_r = b - b^\star(z,\, t)`` | [`ReferenceBuoyancyAnomaly`](@ref Oceanostics.AvailablePotentialEnergyEquation.ReferenceBuoyancyAnomaly) |
+| APE to KE conversion | ``w b_r`` | [`AvailablePotentialToKineticEnergyConversion`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialToKineticEnergyConversion) |
 | Diffusive transport | ``\partial_j(\Upsilon q_j)`` | not implemented |
 | Dissipation | ``\varepsilon_a = -q_j \, \partial_j \Upsilon`` | [`AvailablePotentialEnergyDissipationRate`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate) |
 | Reference tendency | ``R = \int_{z^\star}^{z} \partial_t b^\star(\tilde z,\, t) \, \mathrm{d}\tilde z`` | not implemented |
 
 The available potential energy converts to kinetic energy at a rate set by the buoyancy anomaly
 ``b_r``, not by the buoyancy itself. The remainder ``w \, b^\star(z,\, t)`` exchanges kinetic energy
-with the background state. Their
-sum,
+with the background state. Their sum,
 
 ```math
 w b = w b_r + w \, b^\star(z,\, t) ,
 ```
 
-is implemented as [`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion).
-Under a volume integral the distinction goes away since ``w \, b^\star(z,\, t)`` is a divergence.
+is [`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion),
+the conversion of the ``e_p`` budget. Both are formed from the same face-centered product, so the split
+holds cell by cell; under a volume integral the distinction goes away entirely, since
+``w \, b^\star(z,\, t)`` is a divergence.
 
-The three diagnostics this module defines are built on the reference state of
+Every diagnostic here is built on the reference state of
 [the background potential energy equation](background_potential_energy_equation.md), whose
 [`reference_height`](@ref Oceanostics.BackgroundPotentialEnergyEquation.reference_height) supplies
-``z^\star`` and
+``z^\star``,
 [`reference_buoyancy`](@ref Oceanostics.BackgroundPotentialEnergyEquation.reference_buoyancy) the
-profile ``b^\star``; both are re-exported here, as is
+profile ``b^\star`` paired with it, and
+[`reference_buoyancy_at_height`](@ref Oceanostics.BackgroundPotentialEnergyEquation.reference_buoyancy_at_height)
+the ``b^\star(z,\, t)`` that ``b_r`` is measured against; all three are re-exported here, as is
 [`DiffusiveVerticalBuoyancyFlux`](@ref Oceanostics.PotentialEnergyEquation.DiffusiveVerticalBuoyancyFlux),
 the flux ``\Phi = -q_3`` that ``\varepsilon_a`` leaves out of the diapycnal mixing rate of
 [Winters et al. (1995)](https://doi.org/10.1017/S002211209500125X).
@@ -114,6 +117,8 @@ the flux ``\Phi = -q_3`` that ``\varepsilon_a`` leaves out of the diapycnal mixi
 
 ```@docs
 Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergy
-Oceanostics.AvailablePotentialEnergyEquation.BuoyancyDisplacementPotential
+Oceanostics.AvailablePotentialEnergyEquation.DisplacementPotential
+Oceanostics.AvailablePotentialEnergyEquation.ReferenceBuoyancyAnomaly
+Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialToKineticEnergyConversion
 Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate
 ```

--- a/docs/src/available_potential_energy_equation.md
+++ b/docs/src/available_potential_energy_equation.md
@@ -12,14 +12,76 @@ Oceanostics computes the available potential energy in its *local* form,
 [Holliday & McIntyre (1981)](https://doi.org/10.1017/S0022112081001742):
 
 ```math
-e_a(b, z) = \int_{z^\star}^{z} \left[b^\star(\tilde z) - b\right] \mathrm{d}\tilde z
-          = \frac{g}{\rho_0}\int_{z^\star}^{z} \left[\rho - \rho^\star(\tilde z)\right] \mathrm{d}\tilde z .
+e_a(b, z) = \int_{z^\star(b)}^{z} \left[b^\star(\tilde z,\, t) - b\right] \,\mathrm{d}\tilde z
+          = \frac{g}{\rho_0}\int_{z^\star(\rho)}^{z} \left[\rho - \rho^\star(\tilde z,\, t)\right] \,\mathrm{d}\tilde z .
 ```
 
 In this form ``e_a`` is **non-negative everywhere in space** whenever the reference state is sorted from
-the field itself, so it can be mapped as a field. Its volume integral recovers
-``\int e_p - \int e_b`` in the continuum limit, although at finite ``\Delta z`` the two differ at second
-order.
+the field itself. Its volume integral recovers ``\int e_p - \int e_b`` in the continuum limit, although
+at finite ``\Delta z`` the two differ at second order.
+
+## Deriving the local available potential energy budget
+
+The budget follows from the material derivative of ``e_a(b, z, t)`` along the flow
+([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)):
+
+
+```math
+\frac{D e_a}{D t} = \left.\frac{\partial e_a}{\partial b}\right|_{z,t} \frac{D b}{D t}
+                  + \left.\frac{\partial e_a}{\partial z}\right|_{b,t} \frac{D z}{D t}
+                  + \left.\frac{\partial e_a}{\partial t}\right|_{z,b} \frac{D t}{D t},
+```
+which we can simplify to
+
+```math
+\frac{D e_a}{D t} = \left.\frac{\partial e_a}{\partial b}\right|_{z,t} \frac{D b}{D t}
+                  + \left.\frac{\partial e_a}{\partial z}\right|_{b,t} w
+                  + R ,
+\qquad
+R = \int_{z^\star}^{z} \partial_t b^\star(\tilde z, t) \, \mathrm{d}\tilde z .
+```
+
+Both partial derivatives come straight from the definition of ``e_a``. In the first, the boundary term
+from moving the lower limit ``z^\star(b)`` drops out because ``b^\star(z^\star(b)) = b``, which leaves
+the displacement potential ``\Upsilon``. The second is minus the buoyancy anomaly ``b_r`` the parcel
+carries relative to the reference profile at its own height:
+
+```math
+\left.\frac{\partial e_a}{\partial b}\right|_{z} = z^\star - z = \Upsilon ,
+\qquad
+\left.\frac{\partial e_a}{\partial z}\right|_{b} = b^\star(z) - b = -b_r .
+```
+
+The buoyancy obeys [the tracer equation](tracer_equation.md), ``Db/Dt = -\partial_j q_j`` for an
+unforced tracer with the closure's diffusive flux ``q_j``, so ``\Upsilon\,Db/Dt`` splits into a
+transport divergence plus the contraction ``q_j\,\partial_j\Upsilon``. Writing the advective part as a
+divergence as well (incompressibility), the local APE budget is
+
+```math
+\partial_t e_a = \underbrace{-\partial_j(u_j e_a)}_{\text{advection}}
+                 \underbrace{-\,w b_r}_{\text{APE to KE conversion}}
+                 \underbrace{-\,\partial_j(\Upsilon q_j)}_{\text{diffusive transport}}
+                 \underbrace{-\,\varepsilon_a}_{\text{dissipation}}
+                 + \underbrace{R}_{\text{reference tendency}} ,
+\qquad
+\varepsilon_a = -q_j \, \partial_j \Upsilon = \kappa \, \partial_j b \, \partial_j \Upsilon .
+```
+
+The two divergences redistribute ``e_a`` and vanish when integrated over a periodic or closed domain,
+and so does ``R`` ([Winters et al., 1995](https://doi.org/10.1017/S002211209500125X)), which therefore
+shifts APE around in space without creating or destroying any. The exchange with the kinetic energy
+carries the anomaly ``b_r`` because in this framework the pressure is measured against the hydrostatic
+pressure of the reference profile. Its reference part ``w\,b^\star(z)`` is a divergence in its own
+right, so ``\int w b_r \, \mathrm{d}V = \int w b \, \mathrm{d}V`` and the volume-integrated budget
+reduces to the one the [Lock release](@ref lock_release_example) example closes below.
+
+Repeating these steps with the filtered buoyancy ``\tilde b`` in place of ``b``, and using the filtered
+buoyancy equation, gives the budget for the available potential energy of the filtered field; filtering
+the budget above and subtracting that one gives the sub-filter budget. Those two budgets, and the
+cross-scale flux ``\Pi_a`` that transfers APE between them, are the subject of
+[the filtered](filtered_available_potential_energy_equation.md) and
+[the sub-filter](subfilter_available_potential_energy_equation.md) available potential energy equation
+pages.
 
 ## Available potential energy
 
@@ -29,7 +91,8 @@ Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergy
 
 ## Buoyancy displacement potential
 
-Differentiating ``e_a`` with respect to buoyancy gives the displacement potential
+The factor multiplying ``Db/Dt`` in the budget above, the derivative of ``e_a`` with respect to
+buoyancy, is the displacement potential
 
 ```math
 \Upsilon = \frac{\partial e_a}{\partial b} = z^\star - z ,

--- a/docs/src/available_potential_energy_equation.md
+++ b/docs/src/available_potential_energy_equation.md
@@ -72,6 +72,44 @@ domain ([Winters et al., 1995](https://doi.org/10.1017/S002211209500125X)). See 
 example for an application of this budget.
 
 
+## Terms and what is implemented
+
+Four of the quantities above have diagnostics, one of them defined elsewhere in Oceanostics.
+
+| Quantity | Expression | Diagnostic |
+|:---|:---|:---|
+| Available potential energy | ``e_a = \int_{z^\star(b)}^{z} \left[b^\star(\tilde z,\, t) - b\right] \mathrm{d}\tilde z`` | [`AvailablePotentialEnergy`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergy) |
+| Displacement potential | ``\Upsilon = z^\star - z`` | [`BuoyancyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.BuoyancyDisplacementPotential) |
+| Advection | ``\partial_j(u_j e_a)`` | not implemented |
+| APE to KE conversion | ``w b_r`` | [`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion) |
+| Diffusive transport | ``\partial_j(\Upsilon q_j)`` | not implemented |
+| Dissipation | ``\varepsilon_a = -q_j \, \partial_j \Upsilon`` | [`AvailablePotentialEnergyDissipationRate`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate) |
+| Reference tendency | ``R = \int_{z^\star}^{z} \partial_t b^\star(\tilde z,\, t) \, \mathrm{d}\tilde z`` | not implemented |
+
+The conversion diagnostic computes ``u_j b_j``, which is ``wb`` under the vertical gravity these terms
+require, and not ``w b_r``. The two differ by ``w \, b^\star(z, t)``, itself a divergence, so they agree
+once integrated. It is defined in [the kinetic energy equation](kinetic_energy_equation.md), where
+`PotentialEnergyConversion` names what it does to the kinetic energy, and re-exported here both under
+that name and as the shorter `KineticEnergyConversion`.
+
+What is missing are the two transport terms and ``R``, which integrate to zero over a periodic or
+closed domain, so the integrated budget closes with the diagnostics that do exist:
+
+```math
+\frac{\mathrm{d}}{\mathrm{d}t}\int e_a \, \mathrm{d}V
+    = -\int w b \, \mathrm{d}V - \int \varepsilon_a \, \mathrm{d}V .
+```
+
+The three diagnostics this module defines are built on the reference state of
+[the background potential energy equation](background_potential_energy_equation.md), whose
+[`reference_height`](@ref Oceanostics.BackgroundPotentialEnergyEquation.reference_height) supplies
+``z^\star`` and
+[`reference_buoyancy`](@ref Oceanostics.BackgroundPotentialEnergyEquation.reference_buoyancy) the
+profile ``b^\star``; both are re-exported here, as is
+[`DiffusiveVerticalBuoyancyFlux`](@ref Oceanostics.PotentialEnergyEquation.DiffusiveVerticalBuoyancyFlux),
+the flux ``\Phi = -q_3`` that ``\varepsilon_a`` leaves out of the diapycnal mixing rate of
+[Winters et al. (1995)](https://doi.org/10.1017/S002211209500125X).
+
 ## Summary of ``e_a`` equation terms
 
 

--- a/docs/src/available_potential_energy_equation.md
+++ b/docs/src/available_potential_energy_equation.md
@@ -74,31 +74,30 @@ example for an application of this budget.
 
 ## Terms and what is implemented
 
-Four of the quantities above have diagnostics, one of them defined elsewhere in Oceanostics.
+Three of the quantities above have diagnostics of their own. The conversion has one that matches it
+only under a volume integral, and the two transports and ``R`` have none.
 
 | Quantity | Expression | Diagnostic |
 |:---|:---|:---|
 | Available potential energy | ``e_a = \int_{z^\star(b)}^{z} \left[b^\star(\tilde z,\, t) - b\right] \mathrm{d}\tilde z`` | [`AvailablePotentialEnergy`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergy) |
 | Displacement potential | ``\Upsilon = z^\star - z`` | [`BuoyancyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.BuoyancyDisplacementPotential) |
 | Advection | ``\partial_j(u_j e_a)`` | not implemented |
-| APE to KE conversion | ``w b_r`` | [`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion) |
+| APE to KE conversion | ``w b_r``, with ``b_r = b - b^\star(z,\, t)`` | not implemented |
 | Diffusive transport | ``\partial_j(\Upsilon q_j)`` | not implemented |
 | Dissipation | ``\varepsilon_a = -q_j \, \partial_j \Upsilon`` | [`AvailablePotentialEnergyDissipationRate`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate) |
 | Reference tendency | ``R = \int_{z^\star}^{z} \partial_t b^\star(\tilde z,\, t) \, \mathrm{d}\tilde z`` | not implemented |
 
-The conversion diagnostic computes ``u_j b_j``, which is ``wb`` under the vertical gravity these terms
-require, and not ``w b_r``. The two differ by ``w \, b^\star(z, t)``, itself a divergence, so they agree
-once integrated. It is defined in [the kinetic energy equation](kinetic_energy_equation.md), where
-`PotentialEnergyConversion` names what it does to the kinetic energy, and re-exported here both under
-that name and as the shorter `KineticEnergyConversion`.
-
-What is missing are the two transport terms and ``R``, which integrate to zero over a periodic or
-closed domain, so the integrated budget closes with the diagnostics that do exist:
+The available potential energy converts to kinetic energy at a rate set by the buoyancy anomaly
+``b_r``, not by the buoyancy itself. The remainder ``w \, b^\star(z,\, t)`` exchanges kinetic energy
+with the background state. Their
+sum,
 
 ```math
-\frac{\mathrm{d}}{\mathrm{d}t}\int e_a \, \mathrm{d}V
-    = -\int w b \, \mathrm{d}V - \int \varepsilon_a \, \mathrm{d}V .
+w b = w b_r + w \, b^\star(z,\, t) ,
 ```
+
+is implemented as [`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion).
+Under a volume integral the distinction goes away since ``w \, b^\star(z,\, t)`` is a divergence.
 
 The three diagnostics this module defines are built on the reference state of
 [the background potential energy equation](background_potential_energy_equation.md), whose

--- a/docs/src/available_potential_energy_equation.md
+++ b/docs/src/available_potential_energy_equation.md
@@ -79,13 +79,17 @@ Five of the quantities above have diagnostics; the two transport terms and ``R``
 | Quantity | Expression | Diagnostic |
 |:---|:---|:---|
 | Available potential energy | ``e_a = \int_{z^\star(b)}^{z} \left[b^\star(\tilde z,\, t) - b\right] \mathrm{d}\tilde z`` | [`AvailablePotentialEnergy`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergy) |
-| Displacement potential | ``\Upsilon = z^\star - z`` | [`DisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.DisplacementPotential) |
+| Displacement potential | ``\Upsilon = z^\star - z`` | [`AvailablePotentialEnergyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential) |
 | Advection | ``\partial_j(u_j e_a)`` | not implemented |
 | Buoyancy anomaly | ``b_r = b - b^\star(z,\, t)`` | [`ReferenceBuoyancyAnomaly`](@ref Oceanostics.AvailablePotentialEnergyEquation.ReferenceBuoyancyAnomaly) |
 | APE to KE conversion | ``w b_r`` | [`AvailablePotentialToKineticEnergyConversion`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialToKineticEnergyConversion) |
 | Diffusive transport | ``\partial_j(\Upsilon q_j)`` | not implemented |
 | Dissipation | ``\varepsilon_a = -q_j \, \partial_j \Upsilon`` | [`AvailablePotentialEnergyDissipationRate`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate) |
 | Reference tendency | ``R = \int_{z^\star}^{z} \partial_t b^\star(\tilde z,\, t) \, \mathrm{d}\tilde z`` | not implemented |
+
+``\Upsilon`` also answers to `DisplacementPotential`, and ``\varepsilon_a`` to `DissipationRate`. Both
+aliases are scoped to this module: `using Oceanostics.AvailablePotentialEnergyEquation` brings them in,
+`using Oceanostics` does not, since unprefixed neither name says which budget it belongs to.
 
 The available potential energy converts to kinetic energy at a rate set by the buoyancy anomaly
 ``b_r``, not by the buoyancy itself. The remainder ``w \, b^\star(z,\, t)`` exchanges kinetic energy
@@ -117,7 +121,7 @@ the flux ``\Phi = -q_3`` that ``\varepsilon_a`` leaves out of the diapycnal mixi
 
 ```@docs
 Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergy
-Oceanostics.AvailablePotentialEnergyEquation.DisplacementPotential
+Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential
 Oceanostics.AvailablePotentialEnergyEquation.ReferenceBuoyancyAnomaly
 Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialToKineticEnergyConversion
 Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate

--- a/docs/src/available_potential_energy_equation.md
+++ b/docs/src/available_potential_energy_equation.md
@@ -72,7 +72,7 @@ domain ([Winters et al., 1995](https://doi.org/10.1017/S002211209500125X)). See 
 example for an application of this budget.
 
 
-## Terms and what is implemented
+## Terms and diagnostics
 
 Five of the quantities above have diagnostics; the two transport terms and ``R`` have none.
 
@@ -96,7 +96,7 @@ The available potential energy converts to kinetic energy at a rate set by the b
 with the background state. Their sum,
 
 ```math
-w b = w b_r + w \, b^\star(z,\, t) ,
+w b = w b_r + w \, b^\star,
 ```
 
 is [`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion),

--- a/docs/src/available_potential_energy_equation.md
+++ b/docs/src/available_potential_energy_equation.md
@@ -1,19 +1,15 @@
 # Available potential energy equation
 
 The `AvailablePotentialEnergyEquation` module computes the share of the potential energy
-``e_p = -bz`` of [the potential energy equation](potential_energy_equation.md) that the flow *can*
-release. The other half, the reference state and the background potential energy ``e_b`` it carries,
-lives in [the background potential energy equation](background_potential_energy_equation.md). The
-reference height ``z^\star`` built there is the input to everything below, and this module re-exports
-`reference_height`, `reference_buoyancy` and the reference-height methods so that either module can be
-used on its own.
+``e_p = -bz`` that the flow is capable of releasing. The other part being the
+[background potential energy](background_potential_energy_equation.md) ``e_b``.
 
 Oceanostics computes the available potential energy in its *local* form,
 [Holliday & McIntyre (1981)](https://doi.org/10.1017/S0022112081001742):
 
 ```math
-e_a(b, z) = \int_{z^\star(b)}^{z} \left[b^\star(\tilde z,\, t) - b\right] \,\mathrm{d}\tilde z
-          = \frac{g}{\rho_0}\int_{z^\star(\rho)}^{z} \left[\rho - \rho^\star(\tilde z,\, t)\right] \,\mathrm{d}\tilde z .
+e_a(b, z, t) = \int_{z^\star(b)}^{z} \left[b^\star(\tilde z,\, t) - b\right] \,\mathrm{d}\tilde z
+             = \frac{g}{\rho_0}\int_{z^\star(\rho)}^{z} \left[\rho - \rho^\star(\tilde z,\, t)\right] \,\mathrm{d}\tilde z .
 ```
 
 In this form ``e_a`` is **non-negative everywhere in space** whenever the reference state is sorted from
@@ -52,10 +48,10 @@ carries relative to the reference profile at its own height:
 \left.\frac{\partial e_a}{\partial z}\right|_{b} = b^\star(z, t) - b = -b_r .
 ```
 
-The buoyancy obeys [the tracer equation](tracer_equation.md), ``Db/Dt = -\partial_j q_j`` for an
+The material derivative of buoyancy obeys [the tracer equation](tracer_equation.md), ``Db/Dt = -\partial_j q_j`` for an
 unforced tracer with the closure's diffusive flux ``q_j``, so ``\Upsilon\,Db/Dt`` splits into a
 transport divergence plus the contraction ``q_j\,\partial_j\Upsilon``. Writing the advective part as a
-divergence as well (incompressibility), the local APE budget is
+divergence as well, the local APE budget is
 
 ```math
 \partial_t e_a = \underbrace{-\partial_j(u_j e_a)}_{\text{advection}}
@@ -67,7 +63,7 @@ divergence as well (incompressibility), the local APE budget is
 \varepsilon_a = -q_j \, \partial_j \Upsilon.
 ```
 
-Similar to the two divergences, ``R`` redistribute ``e_a`` and vanish when integrated over a periodic or closed
+Similar to the two divergences, ``R`` redistributes ``e_a`` and vanishes when integrated over a periodic or closed
 domain ([Winters et al., 1995](https://doi.org/10.1017/S002211209500125X)). See the [Lock release](@ref lock_release_example)
 example for an application of this budget.
 
@@ -100,9 +96,7 @@ w b = w b_r + w \, b^\star,
 ```
 
 is [`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion),
-the conversion of the ``e_p`` budget. Both are formed from the same face-centered product, so the split
-holds cell by cell; under a volume integral the distinction goes away entirely, since
-``w \, b^\star(z,\, t)`` is a divergence.
+the conversion of the ``e_p`` budget.
 
 Every diagnostic here is built on the reference state of
 [the background potential energy equation](background_potential_energy_equation.md), whose

--- a/docs/src/available_potential_energy_equation.md
+++ b/docs/src/available_potential_energy_equation.md
@@ -20,7 +20,7 @@ In this form ``e_a`` is **non-negative everywhere in space** whenever the refere
 the field itself. Its volume integral recovers ``\int e_p - \int e_b`` in the continuum limit, although
 at finite ``\Delta z`` the two differ at second order.
 
-## Deriving the local available potential energy budget
+## Deriving the local available potential energy equation
 
 The budget follows from the material derivative of ``e_a(b, z, t)`` along the flow
 ([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)):

--- a/docs/src/available_potential_energy_equation.md
+++ b/docs/src/available_potential_energy_equation.md
@@ -49,7 +49,7 @@ carries relative to the reference profile at its own height:
 ```math
 \left.\frac{\partial e_a}{\partial b}\right|_{z} = z^\star - z = \Upsilon ,
 \qquad
-\left.\frac{\partial e_a}{\partial z}\right|_{b} = b^\star(z) - b = -b_r .
+\left.\frac{\partial e_a}{\partial z}\right|_{b} = b^\star(z, t) - b = -b_r .
 ```
 
 The buoyancy obeys [the tracer equation](tracer_equation.md), ``Db/Dt = -\partial_j q_j`` for an
@@ -64,107 +64,19 @@ divergence as well (incompressibility), the local APE budget is
                  \underbrace{-\,\varepsilon_a}_{\text{dissipation}}
                  + \underbrace{R}_{\text{reference tendency}} ,
 \qquad
-\varepsilon_a = -q_j \, \partial_j \Upsilon = \kappa \, \partial_j b \, \partial_j \Upsilon .
+\varepsilon_a = -q_j \, \partial_j \Upsilon.
 ```
 
-The two divergences redistribute ``e_a`` and vanish when integrated over a periodic or closed domain,
-and so does ``R`` ([Winters et al., 1995](https://doi.org/10.1017/S002211209500125X)), which therefore
-shifts APE around in space without creating or destroying any. The exchange with the kinetic energy
-carries the anomaly ``b_r`` because in this framework the pressure is measured against the hydrostatic
-pressure of the reference profile. Its reference part ``w\,b^\star(z)`` is a divergence in its own
-right, so ``\int w b_r \, \mathrm{d}V = \int w b \, \mathrm{d}V`` and the volume-integrated budget
-reduces to the one the [Lock release](@ref lock_release_example) example closes below.
+Similar to the two divergences, ``R`` redistribute ``e_a`` and vanish when integrated over a periodic or closed
+domain ([Winters et al., 1995](https://doi.org/10.1017/S002211209500125X)). See the [Lock release](@ref lock_release_example)
+example for an application of this budget.
 
-Repeating these steps with the filtered buoyancy ``\tilde b`` in place of ``b``, and using the filtered
-buoyancy equation, gives the budget for the available potential energy of the filtered field; filtering
-the budget above and subtracting that one gives the sub-filter budget. Those two budgets, and the
-cross-scale flux ``\Pi_a`` that transfers APE between them, are the subject of
-[the filtered](filtered_available_potential_energy_equation.md) and
-[the sub-filter](subfilter_available_potential_energy_equation.md) available potential energy equation
-pages.
 
-## Available potential energy
+## Summary of ``e_a`` equation terms
+
 
 ```@docs
 Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergy
-```
-
-## Buoyancy displacement potential
-
-The factor multiplying ``Db/Dt`` in the budget above, the derivative of ``e_a`` with respect to
-buoyancy, is the displacement potential
-
-```math
-\Upsilon = \frac{\partial e_a}{\partial b} = z^\star - z ,
-```
-
-the natural conjugate of ``b``: contracting it with a buoyancy gradient gives an APE dissipation rate,
-and contracting it with a sub-filter buoyancy flux gives a cross-scale APE flux
-([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879), who write it for density as
-``\Upsilon(\rho, z) = g(z - z^\star)/\rho_0``; the two differ by ``-g/\rho_0``, which cancels in either
-contraction).
-
-```@docs
 Oceanostics.AvailablePotentialEnergyEquation.BuoyancyDisplacementPotential
-```
-
-## Available potential energy dissipation
-
-```math
-\varepsilon_a = \kappa \, \partial_i b \, \partial_i \Upsilon
-              = \kappa \left[\frac{\partial z^\star}{\partial b}\left|\nabla b\right|^2
-                             - \frac{\partial b}{\partial z}\right]
-```
-
-is the sink of the local ``e_a`` equation: the diapycnal mixing rate of
-[Winters et al. (1995)](https://doi.org/10.1017/S002211209500125X), less the diffusion the reference
-state undergoes on its own and which carries no available energy with it. The two cancel exactly for a
-statically stable, horizontally uniform stratification, so ``\varepsilon_a`` measures only the APE
-actually lost and is **not** the sign-definite ``\kappa|\nabla b|^2`` the name might suggest.
-
-```@docs
 Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate
 ```
-
-## Diffusive buoyancy flux
-
-The second of those two parts,
-
-```math
-\Phi = \kappa \frac{\partial b}{\partial z} ,
-```
-
-is the work diffusion does against gravity as it smooths the stratification. It is available separately
-because it is what separates ``\varepsilon_a`` from the diapycnal mixing rate: adding it back gives that
-rate, and hence the growth rate of the total ``E_b = \int e_b \, \mathrm{d}V``,
-
-```math
-\frac{d}{dt}\int e_b\, dV = \int \left(\varepsilon_a + \Phi\right) dV \geq 0 ,
-```
-
-so the three of them close the background potential energy budget the way ``\varepsilon_a`` and the
-buoyancy production close the available one. Neither ``\varepsilon_a`` nor ``\Phi`` is sign-definite on
-its own; their sum is.
-
-``\Phi`` needs no reference state of its own, and it is a term of the ``e_p`` equation before it is
-anything to do with ``e_a``, so it is defined in
-[the potential energy equation](potential_energy_equation.md) and re-exported
-here. See [`PotentialEnergyDiffusiveVerticalBuoyancyFlux`](@ref Oceanostics.PotentialEnergyEquation.DiffusiveVerticalBuoyancyFlux).
-
-The [Lock release](@ref lock_release_example) example closes
-
-```math
-\frac{d}{dt}\int e_a\, dV = -\int u_j b_j\, dV - \int \varepsilon_a\, dV
-```
-
-alongside the matching kinetic energy budget, and shows ``\varepsilon_a`` changing sign as the flow
-alternates between stirring and settling.
-
-The ``u_j b_j`` in that budget is the term the two exchange, the same conversion
-[the potential energy equation](potential_energy_equation.md) derives, so this module re-exports
-[`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion) from
-[the kinetic energy equation](kinetic_energy_equation.md), under that name and under the shorter alias
-`KineticEnergyConversion`, which is scoped to this module and to
-that page. It computes ``u_j b_j``, the source of kinetic energy, so this budget takes it with a minus
-sign. With the vertical gravity these modules require it reduces to ``wb``, but the diagnostic keeps
-all three components.

--- a/docs/src/background_potential_energy_equation.md
+++ b/docs/src/background_potential_energy_equation.md
@@ -87,7 +87,7 @@ available energy with it. So
 Neither term is sign-definite on its own; their sum is, which is the sharpest check available on either
 of them.
 
-### Terms and what is implemented
+### Terms and diagnostics
 
 | Quantity | Expression | Diagnostic |
 |:---|:---|:---|

--- a/docs/src/background_potential_energy_equation.md
+++ b/docs/src/background_potential_energy_equation.md
@@ -66,7 +66,7 @@ survives in a simulation with no explicit diffusion came from the advection sche
 
 ``\phi_d`` has no diagnostic of its own, and needs none, because it splits into two that do. Writing it
 as ``\kappa \nabla b \cdot \nabla z^\star`` and substituting ``z^\star = z + \Upsilon``, with
-``\Upsilon`` the [buoyancy displacement potential](available_potential_energy_equation.md),
+``\Upsilon`` the [displacement potential](available_potential_energy_equation.md),
 
 ```math
 \phi_d = \kappa \nabla b \cdot \nabla z^\star
@@ -257,6 +257,7 @@ Oceanostics.BackgroundPotentialEnergyEquation.BackgroundPotentialEnergy
 ```@docs
 Oceanostics.BackgroundPotentialEnergyEquation.reference_height
 Oceanostics.BackgroundPotentialEnergyEquation.reference_buoyancy
+Oceanostics.BackgroundPotentialEnergyEquation.reference_buoyancy_at_height
 Oceanostics.BackgroundPotentialEnergyEquation.AbstractReferenceHeightMethod
 Oceanostics.BackgroundPotentialEnergyEquation.ThreeDimensionalSort
 Oceanostics.BackgroundPotentialEnergyEquation.HeavisideIntegral

--- a/docs/src/filtered_available_potential_energy_equation.md
+++ b/docs/src/filtered_available_potential_energy_equation.md
@@ -47,7 +47,7 @@ computed by [`FilteredAvailablePotentialEnergyDissipationRate`](@ref): the full-
 ([`AvailablePotentialEnergyDissipationRate`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate))
 evaluated on the filtered state, with ``\tilde q_i`` the closure's diffusive buoyancy flux low-pass
 filtered and ``\Upsilon^l`` the displacement potential
-([`BuoyancyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.BuoyancyDisplacementPotential))
+([`DisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.DisplacementPotential))
 of the filtered buoyancy. The flux is filtered, not recomputed from ``\tilde b``: the filtered buoyancy
 equation carries the divergence of the filtered flux, so ``-\tilde q_i \partial_i \Upsilon^l`` is the
 dissipation that appears in the filtered-state budget. The two forms agree for a constant diffusivity

--- a/docs/src/filtered_available_potential_energy_equation.md
+++ b/docs/src/filtered_available_potential_energy_equation.md
@@ -47,7 +47,7 @@ computed by [`FilteredAvailablePotentialEnergyDissipationRate`](@ref): the full-
 ([`AvailablePotentialEnergyDissipationRate`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate))
 evaluated on the filtered state, with ``\tilde q_i`` the closure's diffusive buoyancy flux low-pass
 filtered and ``\Upsilon^l`` the displacement potential
-([`DisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.DisplacementPotential))
+([`DisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential))
 of the filtered buoyancy. The flux is filtered, not recomputed from ``\tilde b``: the filtered buoyancy
 equation carries the divergence of the filtered flux, so ``-\tilde q_i \partial_i \Upsilon^l`` is the
 dissipation that appears in the filtered-state budget. The two forms agree for a constant diffusivity

--- a/docs/src/potential_energy_equation.md
+++ b/docs/src/potential_energy_equation.md
@@ -54,7 +54,7 @@ vertical, the product rule gives
 The two terms written as divergences transport ``e_p`` and vanish when integrated over a periodic or closed domain
 (with impermeable, insulating walls).
 
-## Terms and what is implemented
+## Terms and diagnostics
 
 Every term above is implemented, two of them elsewhere in Oceanostics.
 

--- a/src/AvailablePotentialEnergyEquation.jl
+++ b/src/AvailablePotentialEnergyEquation.jl
@@ -2,7 +2,8 @@ module AvailablePotentialEnergyEquation
 
 using DocStringExtensions
 
-export AvailablePotentialEnergy, BuoyancyDisplacementPotential
+export AvailablePotentialEnergy, DisplacementPotential
+export ReferenceBuoyancyAnomaly, AvailablePotentialToKineticEnergyConversion
 export AvailablePotentialEnergyDissipationRate, DissipationRate
 # `Φ` is a term of the `eₚ` equation and lives in `PotentialEnergyEquation`; re-exported here because
 # `εₐ` is defined as the diapycnal mixing rate less `Φ`, so the two are almost always wanted together.
@@ -11,7 +12,7 @@ export PotentialEnergyDiffusiveVerticalBuoyancyFlux
 export PotentialToKineticEnergyConversion, KineticEnergyConversion
 # The reference state lives in `BackgroundPotentialEnergyEquation`; re-exported here so either module
 # can be used on its own without reaching across for the pieces that build `z✶`.
-export BackgroundPotentialEnergy, reference_height, reference_buoyancy
+export BackgroundPotentialEnergy, reference_height, reference_buoyancy, reference_buoyancy_at_height
 export ThreeDimensionalSort, HeavisideIntegral, VerticalSort, ProfileLookup
 
 using Oceananigans.AbstractOperations: KernelFunctionOperation
@@ -31,7 +32,8 @@ using ..PotentialEnergyEquation: PotentialEnergy, PotentialEnergyDiffusiveVertic
                                  buoyancy_diffusive_flux_arguments
 using ..BackgroundPotentialEnergyEquation: BackgroundPotentialEnergy, SortedReferenceHeightField,
                                            AbstractReferenceHeightMethod, reference_height,
-                                           reference_buoyancy, sorted_height, ThreeDimensionalSort,
+                                           reference_buoyancy, reference_buoyancy_at_height,
+                                           sorted_height, ThreeDimensionalSort,
                                            HeavisideIntegral, VerticalSort, ProfileLookup
 
 #+++ Available potential energy
@@ -125,12 +127,12 @@ validate_reference_height_grid(diagnostic, model, z✶) =
 #+++ Buoyancy displacement potential
 @inline upsilon_ccc(i, j, k, grid, z✶) = @inbounds z✶[i, j, k] - Zᶜᶜᶜ(i, j, k, grid)
 
-const BuoyancyDisplacementPotential = CustomKFO{<:typeof(upsilon_ccc)}
+const DisplacementPotential = CustomKFO{<:typeof(upsilon_ccc)}
 
 """
     $(SIGNATURES)
 
-Return a `KernelFunctionOperation` computing the buoyancy displacement potential
+Return a `KernelFunctionOperation` computing the displacement potential
 
 ```
     Υ = z✶ - z
@@ -166,28 +168,174 @@ using Oceananigans, Oceanostics
 grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1), topology=(Periodic, Periodic, Bounded))
 model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
 
-BuoyancyDisplacementPotential(model)
+DisplacementPotential(model)
 
 # output
 
-BuoyancyDisplacementPotential KernelFunctionOperation at (Center, Center, Center)
+DisplacementPotential KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: upsilon_ccc (generic function with 1 method)
 └── arguments: ("Field",)
-└── computes: buoyancy displacement potential  Υ = z✶ - z
+└── computes: displacement potential  Υ = z✶ - z
 ```
 """
-function BuoyancyDisplacementPotential(model; method = HeavisideIntegral(),
+function DisplacementPotential(model; method = HeavisideIntegral(),
                                        geopotential_height = model_geopotential_height(model),
                                        location = (Center, Center, Center))
-    validate_location(location, "BuoyancyDisplacementPotential")
-    return BuoyancyDisplacementPotential(model, reference_height(model; method, geopotential_height))
+    validate_location(location, "DisplacementPotential")
+    return DisplacementPotential(model, reference_height(model; method, geopotential_height))
 end
 
-function BuoyancyDisplacementPotential(model, z✶::SortedReferenceHeightField)
-    validate_gravity_is_z_aligned("BuoyancyDisplacementPotential", model)
-    validate_reference_height_grid("BuoyancyDisplacementPotential", model, z✶)
+function DisplacementPotential(model, z✶::SortedReferenceHeightField)
+    validate_gravity_is_z_aligned("DisplacementPotential", model)
+    validate_reference_height_grid("DisplacementPotential", model, z✶)
     return KernelFunctionOperation{Center, Center, Center}(upsilon_ccc, z✶.grid, z✶)
+end
+#---
+
+#+++ Reference buoyancy anomaly
+@inline reference_buoyancy_anomaly_ccc(i, j, k, grid, b, b✶ᶻ) = @inbounds b[i, j, k] - b✶ᶻ[i, j, k]
+
+const ReferenceBuoyancyAnomaly = CustomKFO{<:typeof(reference_buoyancy_anomaly_ccc)}
+
+"""
+    $(SIGNATURES)
+
+Return a `KernelFunctionOperation` computing the buoyancy anomaly a parcel carries relative to the
+adiabatically sorted reference profile taken at the parcel's **own** height,
+
+```
+    bᵣ = b - b✶(z) ,
+```
+
+the buoyancy form of `b_r(ρ, z) = -g(ρ - ρ✶(z))/ρ₀` in
+[Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879), their Eq. (8). It is what the
+available potential energy exchanges with the kinetic energy
+([`AvailablePotentialToKineticEnergyConversion`](@ref)), and the buoyancy-space counterpart of
+[`DisplacementPotential`](@ref): `Υ = z✶ - z` measures a parcel's displacement from the reference state
+as a height, `bᵣ` measures it as a buoyancy, and both vanish exactly where the fluid is already sorted.
+
+Note that `b✶(z)` is the reference profile at the height the parcel actually occupies, which is not
+[`reference_buoyancy`](@ref): that pairs the profile with `z✶` instead, and `b✶(z✶)` is the parcel's own
+buoyancy, so the anomaly built from it would be zero everywhere. The profile is sampled by
+[`reference_buoyancy_at_height`](@ref), which reads it off the sort rather than repeating it.
+
+The result lives at `(Center, Center, Center)` and is a buoyancy (units `m s⁻²`). `z✶` is the reference
+height computed by [`reference_height`](@ref); pass one explicitly to share a single sort with the
+other reference-state diagnostics, or pass `method` through to choose how it is built. It has to be one
+that lives on the model grid, so [`VerticalSort`](@ref) is rejected.
+
+```jldoctest
+using Oceananigans, Oceanostics
+
+grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1), topology=(Periodic, Periodic, Bounded))
+model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
+
+ReferenceBuoyancyAnomaly(model)
+
+# output
+
+ReferenceBuoyancyAnomaly KernelFunctionOperation at (Center, Center, Center)
+├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── kernel_function: reference_buoyancy_anomaly_ccc (generic function with 1 method)
+└── arguments: ("Field", "Field")
+└── computes: reference buoyancy anomaly  bᵣ = b - b✶(z)
+```
+"""
+function ReferenceBuoyancyAnomaly(model; method = HeavisideIntegral(),
+                                  geopotential_height = model_geopotential_height(model),
+                                  location = (Center, Center, Center))
+    validate_location(location, "ReferenceBuoyancyAnomaly")
+    return ReferenceBuoyancyAnomaly(model, reference_height(model; method, geopotential_height))
+end
+
+function ReferenceBuoyancyAnomaly(model, z✶::SortedReferenceHeightField)
+    validate_gravity_is_z_aligned("ReferenceBuoyancyAnomaly", model)
+    validate_reference_height_grid("ReferenceBuoyancyAnomaly", model, z✶)
+
+    return KernelFunctionOperation{Center, Center, Center}(reference_buoyancy_anomaly_ccc, z✶.grid,
+                                                           reference_buoyancy(z✶.operand),
+                                                           reference_buoyancy_at_height(z✶))
+end
+#---
+
+#+++ Available potential to kinetic energy conversion
+# The product is formed on the face where `w` lives and only then interpolated to the cell center,
+# which is the discretization `PotentialToKineticEnergyConversion` uses for `wb` (its `z_dot_g_bᶜᶜᶠ` is
+# the same `ℑzᵃᵃᶠ` of a cell-centered buoyancy). Since `bᵣ = b - b✶(z)` and interpolation is linear,
+# the two conversions then differ by exactly `w b✶(z)` cell by cell rather than only in the mean.
+@inline w_bᵣᶜᶜᶠ(i, j, k, grid, w, bᵣ) = @inbounds w[i, j, k] * ℑzᵃᵃᶠ(i, j, k, grid, bᵣ)
+
+@inline ape_to_ke_conversion_ccc(i, j, k, grid, w, bᵣ) = ℑzᵃᵃᶜ(i, j, k, grid, w_bᵣᶜᶜᶠ, w, bᵣ)
+
+const AvailablePotentialToKineticEnergyConversion = CustomKFO{<:typeof(ape_to_ke_conversion_ccc)}
+
+"""
+    $(SIGNATURES)
+
+Return a `KernelFunctionOperation` computing the rate at which available potential energy is converted
+into kinetic energy,
+
+```
+    w bᵣ = w [b - b✶(z)] ,
+```
+
+the exchange term of the local available potential energy equation of
+[Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879), which the `eₐ` budget takes with a
+minus sign and the kinetic energy budget with a plus.
+
+This is **not** [`PotentialToKineticEnergyConversion`](@ref), which computes `uᵢbᵢ` over the total
+buoyancy (`wb` under the vertical gravity these diagnostics require) and belongs to the `eₚ` budget.
+The two differ by `w b✶(z)`, the exchange between the kinetic energy and the background state, and that
+difference is why the pressure that goes with this budget is the deviation from the hydrostatic
+pressure of the reference profile. As fields they are different maps; `w b✶(z)` is a flux divergence,
+so the two only agree once integrated over a periodic or closed domain:
+
+```
+    ∫ w bᵣ dV = ∫ w b dV .
+```
+
+The anomaly `bᵣ` is [`ReferenceBuoyancyAnomaly`](@ref), built here unless one is passed as `anomaly`,
+which is worth doing when both are wanted, since a `Field` of it is then computed once. `z✶` is the
+reference height computed by [`reference_height`](@ref); it has to be one that lives on the model grid,
+so [`VerticalSort`](@ref) is rejected. The result lives at `(Center, Center, Center)` and is a
+conversion rate per unit mass (units `m² s⁻³`).
+
+```jldoctest
+using Oceananigans, Oceanostics
+
+grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1), topology=(Periodic, Periodic, Bounded))
+model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
+
+z✶ = reference_height(model, method=HeavisideIntegral())
+bᵣ = Field(ReferenceBuoyancyAnomaly(model, z✶))   # share the anomaly between the two
+AvailablePotentialToKineticEnergyConversion(model, z✶; anomaly=bᵣ)
+
+# output
+
+AvailablePotentialToKineticEnergyConversion KernelFunctionOperation at (Center, Center, Center)
+├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── kernel_function: ape_to_ke_conversion_ccc (generic function with 1 method)
+└── arguments: ("Field", "Field")
+└── computes: available potential to kinetic energy conversion  wbᵣ
+```
+"""
+function AvailablePotentialToKineticEnergyConversion(model; method = HeavisideIntegral(),
+                                                     geopotential_height = model_geopotential_height(model),
+                                                     location = (Center, Center, Center))
+    validate_location(location, "AvailablePotentialToKineticEnergyConversion")
+    return AvailablePotentialToKineticEnergyConversion(model, reference_height(model; method, geopotential_height))
+end
+
+function AvailablePotentialToKineticEnergyConversion(model, z✶::SortedReferenceHeightField; anomaly = nothing)
+
+    validate_gravity_is_z_aligned("AvailablePotentialToKineticEnergyConversion", model)
+    validate_reference_height_grid("AvailablePotentialToKineticEnergyConversion", model, z✶)
+
+    bᵣ = isnothing(anomaly) ? ReferenceBuoyancyAnomaly(model, z✶) : anomaly
+
+    return KernelFunctionOperation{Center, Center, Center}(ape_to_ke_conversion_ccc, z✶.grid,
+                                                           model.velocities.w, bᵣ)
 end
 #---
 
@@ -229,7 +377,7 @@ energy,
 
 the sink of the local available potential energy equation of
 [Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879) (their Eqs. 11 and 14, where it
-appears as `-εₐ`), with `Υ` the [`BuoyancyDisplacementPotential`](@ref). It follows from
+appears as `-εₐ`), with `Υ` the [`DisplacementPotential`](@ref). It follows from
 `∂eₐ/∂b = Υ`, which makes the diffusive part of `Deₐ/Dt` equal to `Υκ∇²b = ∇·(κΥ∇b) - κ∇Υ·∇b`: once
 the flux divergence is set aside, `εₐ = κ∇Υ·∇b` is what remains.
 
@@ -257,7 +405,7 @@ to build a `z✶` it then uses for nothing but a grid check.
 
 `z✶` is the reference height computed by [`reference_height`](@ref), and has to be one that lives on
 the model grid, since `∇b` is taken there; [`HeavisideIntegral`](@ref) is the default for the reason
-[`BuoyancyDisplacementPotential`](@ref) gives. `upsilon` takes a `Υ` you already have, so that writing
+[`DisplacementPotential`](@ref) gives. `upsilon` takes a `Υ` you already have, so that writing
 both out costs one sort and one `Υ` rather than two of each:
 
 ```jldoctest
@@ -267,7 +415,7 @@ grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1), topology=(Periodic, Per
 model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b, closure=ScalarDiffusivity(κ=1e-4))
 
 z✶ = reference_height(model, method=HeavisideIntegral())
-Υ = Field(BuoyancyDisplacementPotential(model, z✶))
+Υ = Field(DisplacementPotential(model, z✶))
 AvailablePotentialEnergyDissipationRate(model, z✶; upsilon=Υ)
 
 # output
@@ -293,7 +441,7 @@ function AvailablePotentialEnergyDissipationRate(model, z✶::SortedReferenceHei
     validate_gravity_is_z_aligned("AvailablePotentialEnergyDissipationRate", model)
     validate_reference_height_grid("AvailablePotentialEnergyDissipationRate", model, z✶)
 
-    Υ = isnothing(upsilon) ? Field(BuoyancyDisplacementPotential(model, z✶)) : upsilon
+    Υ = isnothing(upsilon) ? Field(DisplacementPotential(model, z✶)) : upsilon
 
     return KernelFunctionOperation{Center, Center, Center}(ape_dissipation_rate_ccc, model.grid,
                                                            Υ, buoyancy_diffusive_flux_arguments(model)...)

--- a/src/AvailablePotentialEnergyEquation.jl
+++ b/src/AvailablePotentialEnergyEquation.jl
@@ -349,7 +349,8 @@ end
 #---
 
 #+++ Available potential energy dissipation rate
-# `εₐ = κ ∂ᵢb ∂ᵢΥ = -qᵢ ∂ᵢΥ`, where `qᵢ = -κ ∂ᵢb` is the buoyancy tracer's diffusive flux. Taking it
+# `εₐ = -qᵢ ∂ᵢΥ`, where `qᵢ` is the buoyancy tracer's diffusive flux (`-κ ∂ᵢb` for Fickian diffusion,
+# but the form is never assumed: an LES closure's flux goes through unchanged). Taking it
 # from the closure's own `diffusive_flux_*` rather than from a diffusivity of our own makes this follow
 # whatever closure the model runs with, and keeps the dissipation consistent with the diffusion the
 # model actually applied — the same conservative formulation `TracerVarianceDissipationRate` uses for
@@ -381,14 +382,16 @@ Return a `KernelFunctionOperation` computing the rate at which diffusion destroy
 energy,
 
 ```
-    εₐ = κ ∂ᵢb ∂ᵢΥ = κ [(∂z✶/∂b)|∇b|² - ∂b/∂z] ,
+    εₐ = -qᵢ ∂ᵢΥ = -(∂z✶/∂b) qᵢ ∂ᵢb + q₃ ,
 ```
 
 the sink of the local available potential energy equation of
 [Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879) (their Eqs. 11 and 14, where it
-appears as `-εₐ`), with `Υ` the [`AvailablePotentialEnergyDisplacementPotential`](@ref). It follows from
-`∂eₐ/∂b = Υ`, which makes the diffusive part of `Deₐ/Dt` equal to `Υκ∇²b = ∇·(κΥ∇b) - κ∇Υ·∇b`: once
-the flux divergence is set aside, `εₐ = κ∇Υ·∇b` is what remains.
+appears as `-εₐ`), with `Υ` the [`AvailablePotentialEnergyDisplacementPotential`](@ref) and `qᵢ` the
+diffusive buoyancy flux the closure supplies. It follows from `∂eₐ/∂b = Υ`, which makes the diffusive
+part of `Deₐ/Dt` equal to `-Υ ∂ᵢqᵢ = -∂ᵢ(Υqᵢ) + qᵢ∂ᵢΥ`: once the flux divergence is set aside,
+`εₐ = -qᵢ∂ᵢΥ` is what remains. Nothing here assumes a form for `qᵢ`: it is `-κ∂ᵢb` for Fickian
+diffusion, and whatever an LES closure returns otherwise.
 
 Written out, the first part is the diapycnal mixing rate of
 [Winters et al. (1995)](https://doi.org/10.1017/S002211209500125X), the work done rearranging the
@@ -396,10 +399,10 @@ reference state, and the second is
 [`PotentialEnergyDiffusiveVerticalBuoyancyFlux`](@ref Oceanostics.PotentialEnergyEquation.DiffusiveVerticalBuoyancyFlux), the diffusion that state
 undergoes on its own, which carries no APE with it. The two cancel exactly for a statically stable,
 horizontally uniform stratification, where `z✶ = z` and there is no available energy to destroy, so
-`εₐ` measures only the APE actually lost — it is not the sign-definite `κ|∇b|²`-like quantity the name
-might suggest.
+`εₐ` measures only the APE actually lost — it is not the sign-definite buoyancy-variance-like quantity
+the name might suggest.
 
-`κ ∂ᵢb` is taken from the closure's own diffusive flux rather than from a diffusivity supplied here, so
+`qᵢ` is taken from the closure's own diffusive flux rather than from a diffusivity supplied here, so
 this follows whatever closure the model runs with, and is written in the same conservative form
 [`TracerVarianceDissipationRate`](@ref Oceanostics.TracerVarianceEquation.TracerVarianceDissipationRate) uses. The
 result lives at `(Center, Center, Center)`, per unit mass (units `m² s⁻³`).
@@ -433,7 +436,7 @@ AvailablePotentialEnergyDissipationRate KernelFunctionOperation at (Center, Cent
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: ape_dissipation_rate_ccc (generic function with 1 method)
 └── arguments: ("Field", "ScalarDiffusivity", "Nothing", "Val", "Field", "Clock", "NamedTuple", "BuoyancyForce")
-└── computes: available potential energy dissipation rate  εₐ = κ ∂ᵢb ∂ᵢΥ
+└── computes: available potential energy dissipation rate  εₐ = -qᵢ∂ᵢΥ
 ```
 """
 function AvailablePotentialEnergyDissipationRate(model; method = HeavisideIntegral(),

--- a/src/AvailablePotentialEnergyEquation.jl
+++ b/src/AvailablePotentialEnergyEquation.jl
@@ -427,7 +427,7 @@ grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1), topology=(Periodic, Per
 model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b, closure=ScalarDiffusivity(κ=1e-4))
 
 z✶ = reference_height(model, method=HeavisideIntegral())
-Υ = Field(DisplacementPotential(model, z✶))
+Υ = Field(AvailablePotentialEnergyDisplacementPotential(model, z✶))
 AvailablePotentialEnergyDissipationRate(model, z✶; upsilon=Υ)
 
 # output

--- a/src/AvailablePotentialEnergyEquation.jl
+++ b/src/AvailablePotentialEnergyEquation.jl
@@ -2,7 +2,7 @@ module AvailablePotentialEnergyEquation
 
 using DocStringExtensions
 
-export AvailablePotentialEnergy, DisplacementPotential
+export AvailablePotentialEnergy, AvailablePotentialEnergyDisplacementPotential, DisplacementPotential
 export ReferenceBuoyancyAnomaly, AvailablePotentialToKineticEnergyConversion
 export AvailablePotentialEnergyDissipationRate, DissipationRate
 # `Φ` is a term of the `eₚ` equation and lives in `PotentialEnergyEquation`; re-exported here because
@@ -124,10 +124,14 @@ validate_reference_height_grid(diagnostic, model, z✶) =
                              `ProfileLookup()` rather than `VerticalSort()`."))
 #---
 
-#+++ Buoyancy displacement potential
+#+++ Displacement potential
 @inline upsilon_ccc(i, j, k, grid, z✶) = @inbounds z✶[i, j, k] - Zᶜᶜᶜ(i, j, k, grid)
 
-const DisplacementPotential = CustomKFO{<:typeof(upsilon_ccc)}
+const AvailablePotentialEnergyDisplacementPotential = CustomKFO{<:typeof(upsilon_ccc)}
+# Short enough to read beside the other terms of an `eₐ` budget, and scoped to this module the way
+# `DissipationRate` is: `using Oceanostics` does not bring it in, since unprefixed it says nothing
+# about which budget's displacement it is.
+const DisplacementPotential = AvailablePotentialEnergyDisplacementPotential
 
 """
     $(SIGNATURES)
@@ -155,6 +159,11 @@ is a length (units `m`).
 single sort with the other reference-state diagnostics, or pass `method` through to choose how it is
 built. It has to be one that lives on the model grid, so [`VerticalSort`](@ref) is rejected.
 
+`using Oceanostics.AvailablePotentialEnergyEquation` additionally brings in `DisplacementPotential`,
+short enough to read beside the other terms of an `eₐ` budget. That alias is scoped to this module, as
+`DissipationRate` is: `using Oceanostics` does not bring it in, since unprefixed it says nothing about
+which budget's displacement it names.
+
 [`HeavisideIntegral`](@ref) is the default here rather than the package-wide
 [`ThreeDimensionalSort`](@ref) because `Υ` is a map, and every use of it differentiates that map. Only
 Eq. (11) of Winters et al. makes `z✶` a function of buoyancy alone, so tied cells share one reference
@@ -168,27 +177,27 @@ using Oceananigans, Oceanostics
 grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1), topology=(Periodic, Periodic, Bounded))
 model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
 
-DisplacementPotential(model)
+AvailablePotentialEnergyDisplacementPotential(model)
 
 # output
 
-DisplacementPotential KernelFunctionOperation at (Center, Center, Center)
+AvailablePotentialEnergyDisplacementPotential KernelFunctionOperation at (Center, Center, Center)
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: upsilon_ccc (generic function with 1 method)
 └── arguments: ("Field",)
 └── computes: displacement potential  Υ = z✶ - z
 ```
 """
-function DisplacementPotential(model; method = HeavisideIntegral(),
-                                       geopotential_height = model_geopotential_height(model),
-                                       location = (Center, Center, Center))
-    validate_location(location, "DisplacementPotential")
-    return DisplacementPotential(model, reference_height(model; method, geopotential_height))
+function AvailablePotentialEnergyDisplacementPotential(model; method = HeavisideIntegral(),
+                                                       geopotential_height = model_geopotential_height(model),
+                                                       location = (Center, Center, Center))
+    validate_location(location, "AvailablePotentialEnergyDisplacementPotential")
+    return AvailablePotentialEnergyDisplacementPotential(model, reference_height(model; method, geopotential_height))
 end
 
-function DisplacementPotential(model, z✶::SortedReferenceHeightField)
-    validate_gravity_is_z_aligned("DisplacementPotential", model)
-    validate_reference_height_grid("DisplacementPotential", model, z✶)
+function AvailablePotentialEnergyDisplacementPotential(model, z✶::SortedReferenceHeightField)
+    validate_gravity_is_z_aligned("AvailablePotentialEnergyDisplacementPotential", model)
+    validate_reference_height_grid("AvailablePotentialEnergyDisplacementPotential", model, z✶)
     return KernelFunctionOperation{Center, Center, Center}(upsilon_ccc, z✶.grid, z✶)
 end
 #---
@@ -212,7 +221,7 @@ the buoyancy form of `b_r(ρ, z) = -g(ρ - ρ✶(z))/ρ₀` in
 [Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879), their Eq. (8). It is what the
 available potential energy exchanges with the kinetic energy
 ([`AvailablePotentialToKineticEnergyConversion`](@ref)), and the buoyancy-space counterpart of
-[`DisplacementPotential`](@ref): `Υ = z✶ - z` measures a parcel's displacement from the reference state
+[`AvailablePotentialEnergyDisplacementPotential`](@ref): `Υ = z✶ - z` measures a parcel's displacement from the reference state
 as a height, `bᵣ` measures it as a buoyancy, and both vanish exactly where the fluid is already sorted.
 
 Note that `b✶(z)` is the reference profile at the height the parcel actually occupies, which is not
@@ -377,7 +386,7 @@ energy,
 
 the sink of the local available potential energy equation of
 [Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879) (their Eqs. 11 and 14, where it
-appears as `-εₐ`), with `Υ` the [`DisplacementPotential`](@ref). It follows from
+appears as `-εₐ`), with `Υ` the [`AvailablePotentialEnergyDisplacementPotential`](@ref). It follows from
 `∂eₐ/∂b = Υ`, which makes the diffusive part of `Deₐ/Dt` equal to `Υκ∇²b = ∇·(κΥ∇b) - κ∇Υ·∇b`: once
 the flux divergence is set aside, `εₐ = κ∇Υ·∇b` is what remains.
 
@@ -405,7 +414,7 @@ to build a `z✶` it then uses for nothing but a grid check.
 
 `z✶` is the reference height computed by [`reference_height`](@ref), and has to be one that lives on
 the model grid, since `∇b` is taken there; [`HeavisideIntegral`](@ref) is the default for the reason
-[`DisplacementPotential`](@ref) gives. `upsilon` takes a `Υ` you already have, so that writing
+[`AvailablePotentialEnergyDisplacementPotential`](@ref) gives. `upsilon` takes a `Υ` you already have, so that writing
 both out costs one sort and one `Υ` rather than two of each:
 
 ```jldoctest

--- a/src/AvailablePotentialEnergyEquation.jl
+++ b/src/AvailablePotentialEnergyEquation.jl
@@ -293,7 +293,9 @@ the exchange term of the local available potential energy equation of
 [Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879), which the `eₐ` budget takes with a
 minus sign and the kinetic energy budget with a plus.
 
-This is **not** [`PotentialToKineticEnergyConversion`](@ref), which computes `uᵢbᵢ` over the total
+This is **not**
+[`PotentialToKineticEnergyConversion`](@ref Oceanostics.KineticEnergyEquation.PotentialEnergyConversion),
+which computes `uᵢbᵢ` over the total
 buoyancy (`wb` under the vertical gravity these diagnostics require) and belongs to the `eₚ` budget.
 The two differ by `w b✶(z)`, the exchange between the kinetic energy and the background state, and that
 difference is why the pressure that goes with this budget is the deviation from the hydrostatic

--- a/src/BackgroundPotentialEnergyEquation.jl
+++ b/src/BackgroundPotentialEnergyEquation.jl
@@ -2,7 +2,7 @@ module BackgroundPotentialEnergyEquation
 
 using DocStringExtensions
 
-export BackgroundPotentialEnergy, reference_height, reference_buoyancy
+export BackgroundPotentialEnergy, reference_height, reference_buoyancy, reference_buoyancy_at_height
 export ThreeDimensionalSort, HeavisideIntegral, VerticalSort, ProfileLookup
 
 using Oceananigans.AbstractOperations: KernelFunctionOperation
@@ -617,6 +617,108 @@ function compute!(z✶_field::SortedReferenceHeightField, time=nothing)
 
     return z✶_field
 end
+
+#+++ Reference buoyancy at a parcel's own height
+"""
+    $(SIGNATURES)
+
+The reference profile the last sort left behind, as `(faces, b✶)`: the slot faces from the bottom of
+the domain up, and the piecewise-constant buoyancy each slot holds. This is the same profile
+`reference_potential_function` integrates into `Ψ`, so a buoyancy read off it and the `Ψ` the available
+potential energy is built from describe one profile rather than two.
+
+The three sorting methods keep their ranking in `s.permutation`, so the profile is gathered through it
+rather than sorted a second time; a [`ProfileLookup`](@ref) hands back the profile it was given, and
+sorts only in the default case, which has none of its own.
+"""
+reference_profile(s::SortedReferenceState) = reference_profile(s, s.method)
+
+function reference_profile(s::SortedReferenceState, ::AbstractReferenceHeightMethod)
+    work = s.workspace   # whatever the sort left here is scratch by now
+    reshape(work, size(s.buoyancy)) .= interior(s.buoyancy)
+
+    return slot_faces(s, s.cell_volume[s.permutation]), work[s.permutation]
+end
+
+function reference_profile(s::SortedReferenceState, method::ProfileLookup)
+    b✶, _, faces = lookup_profile(s, method)
+
+    return faces, b✶
+end
+
+"""
+    $(SIGNATURES)
+
+Build `b✶(z)`, the buoyancy the reference profile holds at a height `z`, from the profile's slot
+`faces` and the buoyancies `b` it carries, and return it as a callable. `b✶` is piecewise constant on
+the slots, which is exactly the profile `reference_potential_function` integrates, so this is the
+derivative of that `Ψ` rather than an independent reconstruction of the same thing.
+"""
+function reference_buoyancy_function(faces, b)
+    N = length(b)
+
+    return z -> (k = clamp(searchsortedlast(faces, z), 1, N); @inbounds b[k])
+end
+
+"""
+    $(TYPEDEF)
+
+Operand of the `Field` [`reference_buoyancy_at_height`](@ref) returns. It carries the reference height
+the profile is read off, so that `compute!` sorts that first and then samples it, the way
+[`SortedBuoyancyState`](@ref) makes the sorted column's buoyancy depend on its parent.
+"""
+struct ReferenceBuoyancyAtHeightState{Z}
+    reference_height :: Z
+end
+
+Base.summary(s::ReferenceBuoyancyAtHeightState) =
+    string("ReferenceBuoyancyAtHeightState of ", summary(s.reference_height))
+
+const ReferenceBuoyancyAtHeightField = Field{<:Any, <:Any, <:Any, <:ReferenceBuoyancyAtHeightState}
+
+# Where each cell of the output sits: its own height on the model grid, and the height its parcel came
+# from on a `VerticalSort` column, which is the same choice `fill_reference_potential!` makes.
+profile_heights(s::SortedReferenceState, ::Nothing) = s.source_height
+profile_heights(s::SortedReferenceState, sorted_height) = s.source_height[s.permutation]
+
+function compute!(b✶ᶻ::ReferenceBuoyancyAtHeightField, time=nothing)
+    z✶ = b✶ᶻ.operand.reference_height
+
+    # Status-gated, so a `z✶` already sorted at this `time` is not sorted twice, and the profile below
+    # is the one that sort produced.
+    compute_at!(z✶, time)
+    s = z✶.operand
+
+    faces, b✶ = reference_profile(s)
+    interior(b✶ᶻ) .= reshape(reference_buoyancy_function(faces, b✶).(profile_heights(s, sorted_height(s))), size(b✶ᶻ))
+
+    fill_halo_regions!(b✶ᶻ)
+    set_status!(b✶ᶻ.status, time)
+
+    return b✶ᶻ
+end
+
+"""
+    $(SIGNATURES)
+
+Return a `Field` holding `b✶(z)`, the buoyancy the adiabatically sorted reference profile carries at
+each cell's **own** height. It is what a parcel would have to be to sit where it does without any
+available potential energy, so the difference from the buoyancy it actually carries is the anomaly
+[`ReferenceBuoyancyAnomaly`](@ref Oceanostics.AvailablePotentialEnergyEquation.ReferenceBuoyancyAnomaly)
+returns.
+
+This is a different quantity from [`reference_buoyancy`](@ref), which pairs the profile with the
+reference height `z✶` instead: `b✶(z✶)` is the parcel's own buoyancy, and on the model grid
+`reference_buoyancy` hands back the buoyancy field itself.
+
+The returned field recomputes itself, so it is safe to hand straight to an output writer: computing it
+sorts the parent `z✶` if that has not already happened at this time, and then reads the profile off
+that sort rather than repeating it.
+"""
+reference_buoyancy_at_height(z✶::SortedReferenceHeightField) =
+    compute!(Field{Center, Center, Center}(z✶.grid; operand = ReferenceBuoyancyAtHeightState(z✶),
+                                           status = FieldStatus()))
+#---
 
 """
     $(SIGNATURES)

--- a/src/BackgroundPotentialEnergyEquation.jl
+++ b/src/BackgroundPotentialEnergyEquation.jl
@@ -627,23 +627,32 @@ the domain up, and the piecewise-constant buoyancy each slot holds. This is the 
 `reference_potential_function` integrates into `Ψ`, so a buoyancy read off it and the `Ψ` the available
 potential energy is built from describe one profile rather than two.
 
-The three sorting methods keep their ranking in `s.permutation`, so the profile is gathered through it
-rather than sorted a second time; a [`ProfileLookup`](@ref) hands back the profile it was given, and
-sorts only in the default case, which has none of its own.
+Every method that ranks the field leaves that ranking in `s.permutation`, so the profile is gathered
+through it rather than sorted a second time. Only a [`ProfileLookup`](@ref) carrying a profile of its
+own was never sorted here, and that one is read back the way `assign_reference_height!` reads it.
 """
 reference_profile(s::SortedReferenceState) = reference_profile(s, s.method)
 
-function reference_profile(s::SortedReferenceState, ::AbstractReferenceHeightMethod)
-    work = s.workspace   # whatever the sort left here is scratch by now
-    reshape(work, size(s.buoyancy)) .= interior(s.buoyancy)
+reference_profile(s::SortedReferenceState, ::AbstractReferenceHeightMethod) = sorted_profile(s)
 
-    return slot_faces(s, s.cell_volume[s.permutation]), work[s.permutation]
-end
+# The profile-less lookup ranks the field itself, exactly as the stacking methods do, so its profile is
+# in `s.permutation` too and rebuilding it through `lookup_profile` would repeat the whole `O(N log N)`
+# sort that `compute!` has just done.
+reference_profile(s::SortedReferenceState, ::ProfileLookup{Nothing}) = sorted_profile(s)
 
 function reference_profile(s::SortedReferenceState, method::ProfileLookup)
     b✶, _, faces = lookup_profile(s, method)
 
     return faces, b✶
+end
+
+# `s.workspace` holds whatever the sort left there, which is scratch by now; every caller that needs it
+# re-fills it first, as this does.
+function sorted_profile(s::SortedReferenceState)
+    work = s.workspace
+    reshape(work, size(s.buoyancy)) .= interior(s.buoyancy)
+
+    return slot_faces(s, s.cell_volume[s.permutation]), work[s.permutation]
 end
 
 """

--- a/src/FilteredAvailablePotentialEnergyEquation.jl
+++ b/src/FilteredAvailablePotentialEnergyEquation.jl
@@ -24,7 +24,7 @@ using ..PotentialEnergyEquation: validate_buoyancy_is_a_diffused_tracer, validat
                                  validate_gravity_is_z_aligned, buoyancy_diffusive_flux_arguments
 using ..BackgroundPotentialEnergyEquation: SortedReferenceHeightField, reference_height, reference_buoyancy,
                                            VerticalSort, ProfileLookup, buoyancy_field
-using ..AvailablePotentialEnergyEquation: AvailablePotentialEnergy, DisplacementPotential,
+using ..AvailablePotentialEnergyEquation: AvailablePotentialEnergy, AvailablePotentialEnergyDisplacementPotential,
                                           AvailablePotentialEnergyDissipationRate, local_ape_ccc,
                                           validate_reference_height_grid
 # `GaussianFilter` builds the convenience methods' filter; `BoxFilter` is imported only so its docstring
@@ -197,7 +197,7 @@ which diffusion removes APE from the scales a low-pass `filter` keeps:
 
 It is the full-field contraction `εₐ = -qᵢ∂ᵢΥ` ([`AvailablePotentialEnergyDissipationRate`](@ref))
 evaluated on the filtered state: the closure's diffusive buoyancy flux `qᵢ` low-pass filtered, against
-the displacement potential `Υˡ` ([`DisplacementPotential`](@ref)) of the filtered buoyancy.
+the displacement potential `Υˡ` ([`AvailablePotentialEnergyDisplacementPotential`](@ref)) of the filtered buoyancy.
 It is the diffusive sink of the budget of [`FilteredAvailablePotentialEnergy`](@ref)
 ([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)), and it mirrors what
 [`FilteredKineticEnergyDissipationRate`](@ref Oceanostics.FilteredKineticEnergyEquation.FilteredKineticEnergyDissipationRate)
@@ -213,7 +213,7 @@ draws for the viscous flux.
 
 `method` has to be a [`ProfileLookup`](@ref), for the reason [`FilteredAvailablePotentialEnergy`](@ref)
 gives, and the lookup also makes `z✶ˡ` a function of buoyancy alone — the property that differentiating
-`Υˡ` needs (see [`DisplacementPotential`](@ref)). Like
+`Υˡ` needs (see [`AvailablePotentialEnergyDisplacementPotential`](@ref)). Like
 [`AvailablePotentialEnergyDissipationRate`](@ref), this diagnostic needs the buoyancy to be a tracer
 the closure diffuses (`BuoyancyTracer` only) and a closure that supplies a diffusive flux.
 
@@ -264,7 +264,7 @@ function FilteredAvailablePotentialEnergyDissipationRate(model, filter, z✶ˡ::
     validate_gravity_is_z_aligned("FilteredAvailablePotentialEnergyDissipationRate", model)
     validate_reference_height_grid("FilteredAvailablePotentialEnergyDissipationRate", model, z✶ˡ)
 
-    Υˡ = isnothing(upsilon) ? Field(DisplacementPotential(model, z✶ˡ)) : upsilon
+    Υˡ = isnothing(upsilon) ? Field(AvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)) : upsilon
 
     # q̄ᵢ = filter(qᵢ(b)): the closure's diffusive fluxes of the FULL buoyancy, each low-pass filtered and
     # materialized at its staggered location. The flux operation reads the live model fields, so the
@@ -324,7 +324,7 @@ low-pass `filter` transfers available potential energy from the filtered to the 
 ```
 
 where `τᵢ` is the sub-filter buoyancy flux and `Υˡ` is the
-[`DisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.DisplacementPotential)
+[`AvailablePotentialEnergyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential)
 of the filtered buoyancy. It is the APE analogue of
 [`KineticEnergyCrossScaleFlux`](@ref Oceanostics.FilteredKineticEnergyEquation.KineticEnergyCrossScaleFlux),
 with the sub-filter buoyancy flux in place of the sub-filter stress and `∇Υˡ` in place of the resolved
@@ -388,7 +388,7 @@ function AvailablePotentialEnergyCrossScaleFlux(model, filter, z✶ˡ::SortedRef
     validate_gravity_is_z_aligned("AvailablePotentialEnergyCrossScaleFlux", model)
     validate_reference_height_grid("AvailablePotentialEnergyCrossScaleFlux", model, z✶ˡ)
 
-    Υˡ = isnothing(upsilon) ? Field(DisplacementPotential(model, z✶ˡ)) : upsilon
+    Υˡ = isnothing(upsilon) ? Field(AvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)) : upsilon
 
     # The filtered buoyancy is `z✶ˡ`'s own (the field the caller filtered and looked up), so the one `b̄`
     # serves both the reference height — and so `Υˡ` — and the sub-filter buoyancy flux: the buoyancy is

--- a/src/FilteredAvailablePotentialEnergyEquation.jl
+++ b/src/FilteredAvailablePotentialEnergyEquation.jl
@@ -24,7 +24,7 @@ using ..PotentialEnergyEquation: validate_buoyancy_is_a_diffused_tracer, validat
                                  validate_gravity_is_z_aligned, buoyancy_diffusive_flux_arguments
 using ..BackgroundPotentialEnergyEquation: SortedReferenceHeightField, reference_height, reference_buoyancy,
                                            VerticalSort, ProfileLookup, buoyancy_field
-using ..AvailablePotentialEnergyEquation: AvailablePotentialEnergy, BuoyancyDisplacementPotential,
+using ..AvailablePotentialEnergyEquation: AvailablePotentialEnergy, DisplacementPotential,
                                           AvailablePotentialEnergyDissipationRate, local_ape_ccc,
                                           validate_reference_height_grid
 # `GaussianFilter` builds the convenience methods' filter; `BoxFilter` is imported only so its docstring
@@ -197,7 +197,7 @@ which diffusion removes APE from the scales a low-pass `filter` keeps:
 
 It is the full-field contraction `εₐ = -qᵢ∂ᵢΥ` ([`AvailablePotentialEnergyDissipationRate`](@ref))
 evaluated on the filtered state: the closure's diffusive buoyancy flux `qᵢ` low-pass filtered, against
-the displacement potential `Υˡ` ([`BuoyancyDisplacementPotential`](@ref)) of the filtered buoyancy.
+the displacement potential `Υˡ` ([`DisplacementPotential`](@ref)) of the filtered buoyancy.
 It is the diffusive sink of the budget of [`FilteredAvailablePotentialEnergy`](@ref)
 ([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)), and it mirrors what
 [`FilteredKineticEnergyDissipationRate`](@ref Oceanostics.FilteredKineticEnergyEquation.FilteredKineticEnergyDissipationRate)
@@ -213,7 +213,7 @@ draws for the viscous flux.
 
 `method` has to be a [`ProfileLookup`](@ref), for the reason [`FilteredAvailablePotentialEnergy`](@ref)
 gives, and the lookup also makes `z✶ˡ` a function of buoyancy alone — the property that differentiating
-`Υˡ` needs (see [`BuoyancyDisplacementPotential`](@ref)). Like
+`Υˡ` needs (see [`DisplacementPotential`](@ref)). Like
 [`AvailablePotentialEnergyDissipationRate`](@ref), this diagnostic needs the buoyancy to be a tracer
 the closure diffuses (`BuoyancyTracer` only) and a closure that supplies a diffusive flux.
 
@@ -264,7 +264,7 @@ function FilteredAvailablePotentialEnergyDissipationRate(model, filter, z✶ˡ::
     validate_gravity_is_z_aligned("FilteredAvailablePotentialEnergyDissipationRate", model)
     validate_reference_height_grid("FilteredAvailablePotentialEnergyDissipationRate", model, z✶ˡ)
 
-    Υˡ = isnothing(upsilon) ? Field(BuoyancyDisplacementPotential(model, z✶ˡ)) : upsilon
+    Υˡ = isnothing(upsilon) ? Field(DisplacementPotential(model, z✶ˡ)) : upsilon
 
     # q̄ᵢ = filter(qᵢ(b)): the closure's diffusive fluxes of the FULL buoyancy, each low-pass filtered and
     # materialized at its staggered location. The flux operation reads the live model fields, so the
@@ -324,7 +324,7 @@ low-pass `filter` transfers available potential energy from the filtered to the 
 ```
 
 where `τᵢ` is the sub-filter buoyancy flux and `Υˡ` is the
-[`BuoyancyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.BuoyancyDisplacementPotential)
+[`DisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.DisplacementPotential)
 of the filtered buoyancy. It is the APE analogue of
 [`KineticEnergyCrossScaleFlux`](@ref Oceanostics.FilteredKineticEnergyEquation.KineticEnergyCrossScaleFlux),
 with the sub-filter buoyancy flux in place of the sub-filter stress and `∇Υˡ` in place of the resolved
@@ -388,7 +388,7 @@ function AvailablePotentialEnergyCrossScaleFlux(model, filter, z✶ˡ::SortedRef
     validate_gravity_is_z_aligned("AvailablePotentialEnergyCrossScaleFlux", model)
     validate_reference_height_grid("AvailablePotentialEnergyCrossScaleFlux", model, z✶ˡ)
 
-    Υˡ = isnothing(upsilon) ? Field(BuoyancyDisplacementPotential(model, z✶ˡ)) : upsilon
+    Υˡ = isnothing(upsilon) ? Field(DisplacementPotential(model, z✶ˡ)) : upsilon
 
     # The filtered buoyancy is `z✶ˡ`'s own (the field the caller filtered and looked up), so the one `b̄`
     # serves both the reference height — and so `Υˡ` — and the sub-filter buoyancy flux: the buoyancy is

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -85,12 +85,13 @@ export PotentialEnergyTendency, PotentialEnergyAdvection, PotentialEnergyBuoyanc
 #+++ BackgroundPotentialEnergyEquation exports
 # `reference_height`, `reference_buoyancy` and the reference-height methods are defined here and
 # re-exported by `AvailablePotentialEnergyEquation`, since both budgets are built on them.
-export BackgroundPotentialEnergy, reference_height, reference_buoyancy
+export BackgroundPotentialEnergy, reference_height, reference_buoyancy, reference_buoyancy_at_height
 export ThreeDimensionalSort, HeavisideIntegral, VerticalSort, ProfileLookup
 #---
 
 #+++ AvailablePotentialEnergyEquation exports
-export AvailablePotentialEnergy, BuoyancyDisplacementPotential, AvailablePotentialEnergyDissipationRate
+export AvailablePotentialEnergy, DisplacementPotential, AvailablePotentialEnergyDissipationRate
+export ReferenceBuoyancyAnomaly, AvailablePotentialToKineticEnergyConversion
 #---
 
 #+++ FilteredAvailablePotentialEnergyEquation exports
@@ -455,8 +456,10 @@ end
 
 #+++ AvailablePotentialEnergyEquation
 @diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialEnergy                "AvailablePotentialEnergy"                "local available potential energy density  eₐ = ∫[b✶(z̃) - b]dz̃ ≥ 0"
-@diagnostic_show AvailablePotentialEnergyEquation.BuoyancyDisplacementPotential           "BuoyancyDisplacementPotential"           "buoyancy displacement potential  Υ = z✶ - z"
+@diagnostic_show AvailablePotentialEnergyEquation.DisplacementPotential           "DisplacementPotential"           "displacement potential  Υ = z✶ - z"
 @diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate "AvailablePotentialEnergyDissipationRate" "available potential energy dissipation rate  εₐ = κ ∂ᵢb ∂ᵢΥ"
+@diagnostic_show AvailablePotentialEnergyEquation.ReferenceBuoyancyAnomaly                "ReferenceBuoyancyAnomaly"                "reference buoyancy anomaly  bᵣ = b - b✶(z)"
+@diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialToKineticEnergyConversion "AvailablePotentialToKineticEnergyConversion" "available potential to kinetic energy conversion  wbᵣ"
 #---
 
 #+++ FilteredAvailablePotentialEnergyEquation

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -90,7 +90,7 @@ export ThreeDimensionalSort, HeavisideIntegral, VerticalSort, ProfileLookup
 #---
 
 #+++ AvailablePotentialEnergyEquation exports
-export AvailablePotentialEnergy, DisplacementPotential, AvailablePotentialEnergyDissipationRate
+export AvailablePotentialEnergy, AvailablePotentialEnergyDisplacementPotential, AvailablePotentialEnergyDissipationRate
 export ReferenceBuoyancyAnomaly, AvailablePotentialToKineticEnergyConversion
 #---
 
@@ -456,7 +456,7 @@ end
 
 #+++ AvailablePotentialEnergyEquation
 @diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialEnergy                "AvailablePotentialEnergy"                "local available potential energy density  eₐ = ∫[b✶(z̃) - b]dz̃ ≥ 0"
-@diagnostic_show AvailablePotentialEnergyEquation.DisplacementPotential           "DisplacementPotential"           "displacement potential  Υ = z✶ - z"
+@diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential "AvailablePotentialEnergyDisplacementPotential" "displacement potential  Υ = z✶ - z"
 @diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate "AvailablePotentialEnergyDissipationRate" "available potential energy dissipation rate  εₐ = κ ∂ᵢb ∂ᵢΥ"
 @diagnostic_show AvailablePotentialEnergyEquation.ReferenceBuoyancyAnomaly                "ReferenceBuoyancyAnomaly"                "reference buoyancy anomaly  bᵣ = b - b✶(z)"
 @diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialToKineticEnergyConversion "AvailablePotentialToKineticEnergyConversion" "available potential to kinetic energy conversion  wbᵣ"

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -457,7 +457,7 @@ end
 #+++ AvailablePotentialEnergyEquation
 @diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialEnergy                "AvailablePotentialEnergy"                "local available potential energy density  eₐ = ∫[b✶(z̃) - b]dz̃ ≥ 0"
 @diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential "AvailablePotentialEnergyDisplacementPotential" "displacement potential  Υ = z✶ - z"
-@diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate "AvailablePotentialEnergyDissipationRate" "available potential energy dissipation rate  εₐ = κ ∂ᵢb ∂ᵢΥ"
+@diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate "AvailablePotentialEnergyDissipationRate" "available potential energy dissipation rate  εₐ = -qᵢ∂ᵢΥ"
 @diagnostic_show AvailablePotentialEnergyEquation.ReferenceBuoyancyAnomaly                "ReferenceBuoyancyAnomaly"                "reference buoyancy anomaly  bᵣ = b - b✶(z)"
 @diagnostic_show AvailablePotentialEnergyEquation.AvailablePotentialToKineticEnergyConversion "AvailablePotentialToKineticEnergyConversion" "available potential to kinetic energy conversion  wbᵣ"
 #---

--- a/src/PotentialEnergyEquation.jl
+++ b/src/PotentialEnergyEquation.jl
@@ -304,7 +304,7 @@ result lives at `(Center, Center, Center)`, per unit mass (units `m² s⁻³`).
 is written out of,
 
 ```
-    εₐ = κ (∂z✶/∂b) |∇b|² - Φ ,
+    εₐ = -(∂z✶/∂b) qᵢ ∂ᵢb - Φ ,
 ```
 
 and it is the part that carries no available energy with it: `Φ` enters the `Eₚ` and `E_b` budgets

--- a/src/SubFilterAvailablePotentialEnergyEquation.jl
+++ b/src/SubFilterAvailablePotentialEnergyEquation.jl
@@ -168,7 +168,7 @@ is to the sub-filter kinetic energy.
 `method` has to be a [`ProfileLookup`](@ref), for the reason
 [`SubFilterAvailablePotentialEnergy`](@ref) gives, and the lookup also makes each `z✶` a function of
 buoyancy alone — the property that differentiating `Υ` and `Υˡ` needs (see
-[`DisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.DisplacementPotential)).
+[`AvailablePotentialEnergyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential)).
 Like [`AvailablePotentialEnergyDissipationRate`](@ref), this diagnostic needs the buoyancy to be a
 tracer the closure diffuses (`BuoyancyTracer` only) and a closure that supplies a diffusive flux.
 

--- a/src/SubFilterAvailablePotentialEnergyEquation.jl
+++ b/src/SubFilterAvailablePotentialEnergyEquation.jl
@@ -168,7 +168,7 @@ is to the sub-filter kinetic energy.
 `method` has to be a [`ProfileLookup`](@ref), for the reason
 [`SubFilterAvailablePotentialEnergy`](@ref) gives, and the lookup also makes each `z✶` a function of
 buoyancy alone — the property that differentiating `Υ` and `Υˡ` needs (see
-[`BuoyancyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.BuoyancyDisplacementPotential)).
+[`DisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.DisplacementPotential)).
 Like [`AvailablePotentialEnergyDissipationRate`](@ref), this diagnostic needs the buoyancy to be a
 tracer the closure diffuses (`BuoyancyTracer` only) and a closure that supplies a diffusive flux.
 

--- a/test/test_ape_diagnostics.jl
+++ b/test/test_ape_diagnostics.jl
@@ -549,17 +549,94 @@ fixed by `z✶` and the grid alone. Checking it against that difference pins the
 thing about `Υ` a reader cannot verify from the result. Sorting moves cells between heights but no
 volume, so `Υ` also has to average to zero over the domain.
 """
-function test_buoyancy_displacement_potential(grid; method = HeavisideIntegral())
+function test_displacement_potential(grid; method = HeavisideIntegral())
 
     model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
     set!(model, b = grid_noise)
 
     z✶ = AvailablePotentialEnergyEquation.reference_height(model; method)
-    Υ  = BuoyancyDisplacementPotential(model, z✶)
-    @test Υ isa BuoyancyDisplacementPotential
+    Υ  = DisplacementPotential(model, z✶)
+    @test Υ isa DisplacementPotential
 
     @test interior(Field(Υ)) ≈ interior(z✶) .- interior(Field(height_operation(grid)))
     @test volume_mean(Υ) ≈ 0 atol = sqrt(eps(eltype(grid))) * grid.Lz
+
+    return nothing
+end
+
+"""
+`bᵣ` is the buoyancy a parcel carries relative to the reference profile at its *own* height, so the
+sharp check is against that profile rather than against the anomaly's own kernel: `b✶(z)` is the
+buoyancy of whichever slot of the sorted column contains `z`, which for a horizontally uniform
+stratification is the parcel's own level. Sorting cannot move fluid between levels there, so `bᵣ`
+vanishes cell by cell — the same statement `Υ = 0` makes about the displacement, in buoyancy rather
+than in height.
+"""
+function test_reference_buoyancy_anomaly(grid; method = HeavisideIntegral())
+
+    model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
+    set!(model, b = grid_noise)
+
+    z✶  = AvailablePotentialEnergyEquation.reference_height(model; method)
+    b✶ᶻ = BackgroundPotentialEnergyEquation.reference_buoyancy_at_height(z✶)
+    bᵣ  = ReferenceBuoyancyAnomaly(model, z✶)
+    @test bᵣ isa ReferenceBuoyancyAnomaly
+
+    @test interior(Field(bᵣ)) ≈ interior(model.tracers.b) .- interior(b✶ᶻ)
+
+    # Every cell's `b✶(z)` is one of the buoyancies the field holds, since the profile is the sorted
+    # field itself: reading it off any other profile would show up here.
+    @test all(b -> b ∈ interior(model.tracers.b), interior(b✶ᶻ))
+
+    sorted = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
+    set!(sorted, b = (x, y, z) -> 3z)
+    @test maximum(abs, interior(Field(ReferenceBuoyancyAnomaly(sorted; method)))) == 0
+
+    return nothing
+end
+
+"""
+The `eₐ` budget converts at `w bᵣ` while the `eₚ` budget converts at `wb`, and the two differ by
+`w b✶(z)`. Both products are formed on the same face and interpolated the same way, so that difference
+is exact cell by cell rather than approximate, which is what this pins down: the conversion is fed the
+reference profile itself in place of the anomaly to compute `w b✶(z)`.
+
+`w b✶(z)` is a flux divergence, so it integrates away and leaves `∫w bᵣ dV = ∫wb dV` — the identity the
+lock release example's integrated budget rests on, and the reason `PotentialToKineticEnergyConversion`
+closes it despite not being this quantity.
+"""
+function test_ape_to_ke_conversion(grid; method = HeavisideIntegral())
+
+    model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
+    set!(model, b = (x, y, z) -> z + 0.3sin(6x)*cos(4y)*z, w = (x, y, z) -> 0.2sin(3x)*sin(2y)*sin(π*z/grid.Lz))
+
+    z✶  = AvailablePotentialEnergyEquation.reference_height(model; method)
+    b✶ᶻ = BackgroundPotentialEnergyEquation.reference_buoyancy_at_height(z✶)
+    bᵣ  = Field(ReferenceBuoyancyAnomaly(model, z✶))
+
+    wbᵣ = AvailablePotentialToKineticEnergyConversion(model, z✶; anomaly = bᵣ)
+    wb✶ = AvailablePotentialToKineticEnergyConversion(model, z✶; anomaly = b✶ᶻ)
+    wb  = PotentialToKineticEnergyConversion(model)
+    @test wbᵣ isa AvailablePotentialToKineticEnergyConversion
+
+    @test interior(Field(wb)) ≈ interior(Field(wbᵣ)) .+ interior(Field(wb✶))
+
+    # The two conversions are different fields, so the identity above is a statement about the split
+    # and not about them being the same thing.
+    @test !(interior(Field(wbᵣ)) ≈ interior(Field(wb)))
+
+    FT = eltype(grid)
+    scale = maximum(abs, interior(Field(wb)))
+    @test volume_mean(wb✶) ≈ 0 atol = sqrt(eps(FT)) * scale
+    @test volume_mean(wbᵣ) ≈ volume_mean(wb)
+
+    # Built without a prebuilt anomaly it has to give the same answer, sorting on its own.
+    @test interior(Field(AvailablePotentialToKineticEnergyConversion(model; method))) ≈ interior(Field(wbᵣ))
+
+    # A sorted field has no available energy to release, whatever the velocity does.
+    sorted = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
+    set!(sorted, b = (x, y, z) -> 3z, w = (x, y, z) -> 0.2sin(3x)*sin(π*z/grid.Lz))
+    @test maximum(abs, interior(Field(AvailablePotentialToKineticEnergyConversion(sorted; method)))) == 0
 
     return nothing
 end
@@ -603,7 +680,7 @@ function test_ape_dissipation_vanishes_when_sorted(grid)
     scale = maximum(abs, interior(Field(TracerVarianceEquation.TracerVarianceDissipationRate(model, :b)))) / 2
     @test scale > 0   # otherwise the assertion below would hold for any implementation
 
-    @test maximum(abs, interior(Field(BuoyancyDisplacementPotential(model)))) < sqrt(eps(FT)) * grid.Lz
+    @test maximum(abs, interior(Field(DisplacementPotential(model)))) < sqrt(eps(FT)) * grid.Lz
     @test maximum(abs, interior(Field(AvailablePotentialEnergyDissipationRate(model)))) < sqrt(eps(FT)) * scale
 
     return nothing
@@ -634,7 +711,7 @@ function test_ape_dissipation_is_recomputed(grid)
     @test interior(εₐ) ≈ interior(Field(AvailablePotentialEnergyDissipationRate(model)))
 
     z✶ = AvailablePotentialEnergyEquation.reference_height(model, method=HeavisideIntegral())
-    shared = Field(BuoyancyDisplacementPotential(model, z✶))
+    shared = Field(DisplacementPotential(model, z✶))
     @test interior(Field(AvailablePotentialEnergyDissipationRate(model, z✶; upsilon = shared))) ≈ interior(εₐ)
 
     return nothing
@@ -653,7 +730,7 @@ function test_ape_dissipation_plus_diffusive_flux_is_the_mixing_rate(grid)
     set!(model, b = (x, y, z) -> 2z + 0.4 * sin(7x) * cos(5z))
 
     z✶  = AvailablePotentialEnergyEquation.reference_height(model, method=HeavisideIntegral())
-    Υ   = Field(BuoyancyDisplacementPotential(model, z✶))
+    Υ   = Field(DisplacementPotential(model, z✶))
     εₐ = AvailablePotentialEnergyDissipationRate(model, z✶; upsilon = Υ)
     Φ   = PotentialEnergyDiffusiveVerticalBuoyancyFlux(model)
 
@@ -692,8 +769,10 @@ function test_upsilon_and_ape_dissipation_errors(grid)
     set!(model, b = grid_noise)
     column = AvailablePotentialEnergyEquation.reference_height(model, method=VerticalSort())
 
-    @test_throws "model grid" BuoyancyDisplacementPotential(model, column)
+    @test_throws "model grid" DisplacementPotential(model, column)
     @test_throws "model grid" AvailablePotentialEnergyDissipationRate(model, column)
+    @test_throws "model grid" ReferenceBuoyancyAnomaly(model, column)
+    @test_throws "model grid" AvailablePotentialToKineticEnergyConversion(model, column)
 
     return nothing
 end
@@ -722,8 +801,10 @@ function test_tilted_gravity_is_rejected(grid)
     z✶ = AvailablePotentialEnergyEquation.reference_height(model.tracers.b; method = HeavisideIntegral())
     @test_throws "`BackgroundPotentialEnergy`" BackgroundPotentialEnergy(model, z✶)
     @test_throws "`AvailablePotentialEnergy`" AvailablePotentialEnergy(model, z✶)
-    @test_throws "`BuoyancyDisplacementPotential`" BuoyancyDisplacementPotential(model, z✶)
+    @test_throws "`DisplacementPotential`" DisplacementPotential(model, z✶)
     @test_throws "`AvailablePotentialEnergyDissipationRate`" AvailablePotentialEnergyDissipationRate(model, z✶)
+    @test_throws "`ReferenceBuoyancyAnomaly`" ReferenceBuoyancyAnomaly(model, z✶)
+    @test_throws "`AvailablePotentialToKineticEnergyConversion`" AvailablePotentialToKineticEnergyConversion(model, z✶)
 
     return nothing
 end
@@ -765,8 +846,12 @@ end
         @info "      Testing that the local available potential energy is non-negative"
         test_local_ape_is_non_negative(grid)
 
-        @info "      Testing the buoyancy displacement potential and the APE dissipation rate"
-        test_buoyancy_displacement_potential(grid; method = grid_method)
+        @info "      Testing the displacement potential and the APE dissipation rate"
+        test_displacement_potential(grid; method = grid_method)
+
+        @info "      Testing the reference buoyancy anomaly and the APE to KE conversion"
+        test_reference_buoyancy_anomaly(grid; method = grid_method)
+        test_ape_to_ke_conversion(grid; method = grid_method)
         test_ape_dissipation_matches_tracer_variance_discretization(grid)
         test_ape_dissipation_vanishes_when_sorted(grid)
         test_ape_dissipation_is_recomputed(grid)

--- a/test/test_ape_diagnostics.jl
+++ b/test/test_ape_diagnostics.jl
@@ -587,8 +587,11 @@ function test_reference_buoyancy_anomaly(grid; method = HeavisideIntegral())
     @test interior(Field(bᵣ)) ≈ interior(model.tracers.b) .- interior(b✶ᶻ)
 
     # Every cell's `b✶(z)` is one of the buoyancies the field holds, since the profile is the sorted
-    # field itself: reading it off any other profile would show up here.
-    @test all(b -> b ∈ interior(model.tracers.b), interior(b✶ᶻ))
+    # field itself: reading it off any other profile would show up here. Both sides come to the host
+    # first: `∈` over one array inside a reduction over another is a nested reduction, which a GPU
+    # cannot run (`mapreduce cannot figure the output element type`), and a `Set` keeps it linear.
+    buoyancies = Set(Array(interior(model.tracers.b)))
+    @test all(b -> b ∈ buoyancies, Array(interior(b✶ᶻ)))
 
     sorted = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
     set!(sorted, b = (x, y, z) -> 3z)

--- a/test/test_ape_diagnostics.jl
+++ b/test/test_ape_diagnostics.jl
@@ -8,6 +8,8 @@ using Oceananigans.Grids: topology
 using SeawaterPolynomials: RoquetEquationOfState, TEOS10EquationOfState
 
 using Oceanostics
+# `DisplacementPotential` is scoped to its own module, so it is imported rather than exported here
+using Oceanostics.AvailablePotentialEnergyEquation: DisplacementPotential
 
 # Include common test utilities
 include("test_utils.jl")
@@ -801,7 +803,7 @@ function test_tilted_gravity_is_rejected(grid)
     z✶ = AvailablePotentialEnergyEquation.reference_height(model.tracers.b; method = HeavisideIntegral())
     @test_throws "`BackgroundPotentialEnergy`" BackgroundPotentialEnergy(model, z✶)
     @test_throws "`AvailablePotentialEnergy`" AvailablePotentialEnergy(model, z✶)
-    @test_throws "`DisplacementPotential`" DisplacementPotential(model, z✶)
+    @test_throws "`AvailablePotentialEnergyDisplacementPotential`" DisplacementPotential(model, z✶)
     @test_throws "`AvailablePotentialEnergyDissipationRate`" AvailablePotentialEnergyDissipationRate(model, z✶)
     @test_throws "`ReferenceBuoyancyAnomaly`" ReferenceBuoyancyAnomaly(model, z✶)
     @test_throws "`AvailablePotentialToKineticEnergyConversion`" AvailablePotentialToKineticEnergyConversion(model, z✶)

--- a/test/test_ape_diagnostics.jl
+++ b/test/test_ape_diagnostics.jl
@@ -594,6 +594,15 @@ function test_reference_buoyancy_anomaly(grid; method = HeavisideIntegral())
     set!(sorted, b = (x, y, z) -> 3z)
     @test maximum(abs, interior(Field(ReferenceBuoyancyAnomaly(sorted; method)))) == 0
 
+    # A profile-less `ProfileLookup` ranks the field itself, so it describes the same profile the
+    # stacking methods do and has to give the same anomaly. It reaches that profile through the ranking
+    # the sort already left behind rather than repeating the sort, which is what `reference_profile`
+    # specializes on. (`ProfileLookup` stacks cells, so it needs uniform cell volumes.)
+    if !BackgroundPotentialEnergyEquation.stretched_grid(grid)
+        z✶_lookup = AvailablePotentialEnergyEquation.reference_height(model, method = ProfileLookup())
+        @test interior(Field(ReferenceBuoyancyAnomaly(model, z✶_lookup))) ≈ interior(Field(bᵣ))
+    end
+
     return nothing
 end
 

--- a/test/test_filtered_ape_diagnostics.jl
+++ b/test/test_filtered_ape_diagnostics.jl
@@ -6,7 +6,8 @@ using Oceananigans.Fields: location, compute_at!
 using Oceanostics
 using Oceanostics: FilteredAvailablePotentialEnergy, FilteredAvailablePotentialEnergyDissipationRate
 using Oceanostics: AvailablePotentialEnergyCrossScaleFlux, subfilter_covariance
-using Oceanostics: AvailablePotentialEnergy, AvailablePotentialEnergyDissipationRate, DisplacementPotential,
+using Oceanostics.AvailablePotentialEnergyEquation: DisplacementPotential
+using Oceanostics: AvailablePotentialEnergy, AvailablePotentialEnergyDissipationRate,
                    reference_height, reference_buoyancy, VerticalSort, ProfileLookup, HeavisideIntegral,
                    GaussianFilter
 

--- a/test/test_filtered_ape_diagnostics.jl
+++ b/test/test_filtered_ape_diagnostics.jl
@@ -6,7 +6,7 @@ using Oceananigans.Fields: location, compute_at!
 using Oceanostics
 using Oceanostics: FilteredAvailablePotentialEnergy, FilteredAvailablePotentialEnergyDissipationRate
 using Oceanostics: AvailablePotentialEnergyCrossScaleFlux, subfilter_covariance
-using Oceanostics: AvailablePotentialEnergy, AvailablePotentialEnergyDissipationRate, BuoyancyDisplacementPotential,
+using Oceanostics: AvailablePotentialEnergy, AvailablePotentialEnergyDissipationRate, DisplacementPotential,
                    reference_height, reference_buoyancy, VerticalSort, ProfileLookup, HeavisideIntegral,
                    GaussianFilter
 
@@ -92,7 +92,7 @@ function test_filtered_ape_nonnegative(grid, filt_horizontal)
     compute!(col)
     b✶  = Array(vec(interior(reference_buoyancy(col))))
     z✶ˡ = reference_height(b̄; method=ProfileLookup(col))
-    Υˡ  = Field(BuoyancyDisplacementPotential(model, z✶ˡ))
+    Υˡ  = Field(DisplacementPotential(model, z✶ˡ))
     eₐˡ = Field(FilteredAvailablePotentialEnergy(model, z✶ˡ))
     @test minimum(interior(eₐˡ)) ≥ -0.5 * maximum(diff(b✶)) * maximum(abs, interior(Υˡ))
 
@@ -138,7 +138,7 @@ function test_filtered_ape_dissipation_basics(model, filt)
 
     lookup = shared_lookup(model)
     z✶ˡ = reference_height(Field(filt(model.tracers.b)); method=lookup)
-    Υˡ  = Field(BuoyancyDisplacementPotential(model, z✶ˡ))
+    Υˡ  = Field(DisplacementPotential(model, z✶ˡ))
     @test interior(Field(FilteredAvailablePotentialEnergyDissipationRate(model, filt, z✶ˡ; upsilon=Υˡ))) ≈
           interior(Field(FilteredAvailablePotentialEnergyDissipationRate(model, filt; method=lookup)))
     return nothing
@@ -229,7 +229,7 @@ function test_ape_cross_scale_flux_matches_manual(model, filt)
     b = model.tracers.b
     u, v, w = model.velocities
     z✶ˡ = reference_height(Field(filt(b)); method = lookup)
-    Υˡ = Field(BuoyancyDisplacementPotential(model, z✶ˡ))
+    Υˡ = Field(DisplacementPotential(model, z✶ˡ))
 
     ccc = (Center, Center, Center)
     b̄ = Field(filt(b))
@@ -258,7 +258,7 @@ function test_ape_cross_scale_flux_vanishes_without_motion(grid, filt)
     set!(model, b = random_stratified_b)   # velocities left at zero
 
     Πₐ = Field(AvailablePotentialEnergyCrossScaleFlux(model, filt))
-    Υˡ = Field(BuoyancyDisplacementPotential(model, reference_height(Field(filt(model.tracers.b)); method = shared_lookup(model))))
+    Υˡ = Field(DisplacementPotential(model, reference_height(Field(filt(model.tracers.b)); method = shared_lookup(model))))
 
     @test maximum(abs, interior(Υˡ)) > 0   # otherwise the assertion below would hold trivially
     @test maximum(abs, interior(Πₐ)) == 0
@@ -277,7 +277,7 @@ function test_ape_cross_scale_flux_dims(model, filt)
     xz   = Field(AvailablePotentialEnergyCrossScaleFlux(model, filt; dims = (1, 3), method = lookup))
 
     b = model.tracers.b
-    Υˡ = Field(BuoyancyDisplacementPotential(model, reference_height(Field(filt(b)); method = lookup)))
+    Υˡ = Field(DisplacementPotential(model, reference_height(Field(filt(b)); method = lookup)))
     y_term = Field(@at (Center, Center, Center) -subfilter_covariance(b, model.velocities[2], filt) * ∂y(Υˡ))
 
     @test interior(xz) ≈ interior(full) .- interior(y_term)

--- a/test/test_perf_invariants.jl
+++ b/test/test_perf_invariants.jl
@@ -188,11 +188,22 @@ end
 
         # The three that read `κ∇b` off the closure, so they run its `diffusive_flux_*` per cell.
         z✶ₕ = AvailablePotentialEnergyEquation.reference_height(model, method=HeavisideIntegral())
-        Υ   = Field(AvailablePotentialEnergyEquation.BuoyancyDisplacementPotential(model, z✶ₕ))
-        test_kfo_invariants("BuoyancyDisplacementPotential", BuoyancyDisplacementPotential(model, z✶ₕ))
+        Υ   = Field(AvailablePotentialEnergyEquation.DisplacementPotential(model, z✶ₕ))
+        test_kfo_invariants("DisplacementPotential", DisplacementPotential(model, z✶ₕ))
         test_kfo_invariants("AvailablePotentialEnergyDissipationRate",
                             AvailablePotentialEnergyDissipationRate(model, z✶ₕ; upsilon = Υ))
         test_kfo_invariants("DiffusiveVerticalBuoyancyFlux", DiffusiveVerticalBuoyancyFlux(model))  # short name, via `using ...PotentialEnergyEquation`
+
+        # `wbᵣ` reads its anomaly through whatever it was handed, so it is probed both ways: over a
+        # materialized `Field` and over the `ReferenceBuoyancyAnomaly` operation it builds by default,
+        # which is a `KernelFunctionOperation` indexed from inside another kernel and so the one place
+        # in this module where a nested operation could box.
+        bᵣ = Field(ReferenceBuoyancyAnomaly(model, z✶ₕ))
+        test_kfo_invariants("ReferenceBuoyancyAnomaly", ReferenceBuoyancyAnomaly(model, z✶ₕ))
+        test_kfo_invariants("AvailablePotentialToKineticEnergyConversion (shared anomaly)",
+                            AvailablePotentialToKineticEnergyConversion(model, z✶ₕ; anomaly = bᵣ))
+        test_kfo_invariants("AvailablePotentialToKineticEnergyConversion (nested anomaly)",
+                            AvailablePotentialToKineticEnergyConversion(model, z✶ₕ))
     end
 
     @testset "FilteredAvailablePotentialEnergyEquation" begin

--- a/test/test_perf_invariants.jl
+++ b/test/test_perf_invariants.jl
@@ -188,8 +188,8 @@ end
 
         # The three that read `κ∇b` off the closure, so they run its `diffusive_flux_*` per cell.
         z✶ₕ = AvailablePotentialEnergyEquation.reference_height(model, method=HeavisideIntegral())
-        Υ   = Field(AvailablePotentialEnergyEquation.DisplacementPotential(model, z✶ₕ))
-        test_kfo_invariants("DisplacementPotential", DisplacementPotential(model, z✶ₕ))
+        Υ   = Field(AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential(model, z✶ₕ))
+        test_kfo_invariants("AvailablePotentialEnergyDisplacementPotential", AvailablePotentialEnergyDisplacementPotential(model, z✶ₕ))
         test_kfo_invariants("AvailablePotentialEnergyDissipationRate",
                             AvailablePotentialEnergyDissipationRate(model, z✶ₕ; upsilon = Υ))
         test_kfo_invariants("DiffusiveVerticalBuoyancyFlux", DiffusiveVerticalBuoyancyFlux(model))  # short name, via `using ...PotentialEnergyEquation`


### PR DESCRIPTION
## What this does

Documents the derivation of the local available potential energy budget on the `AvailablePotentialEnergyEquation` docs page, following [Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879), and then implements the two terms of that budget that turned out to be missing.

The derivation takes the material derivative of `eₐ(b, z, t)`, which splits into the displacement potential `Υ = ∂eₐ/∂b` multiplying `Db/Dt`, the buoyancy anomaly `bᵣ = -∂eₐ/∂z` multiplying `w`, and the reference-tendency term `R`. Substituting the buoyancy equation gives the budget, and a "Terms and what is implemented" table (in the style of the potential energy page) maps each term onto its diagnostic.

Writing that table is what surfaced the gap: the conversion term of the `eₐ` budget is `w bᵣ`, not `wb`.

## `wb` is not `w bᵣ`

`PotentialToKineticEnergyConversion` computes `uᵢbᵢ` over the total buoyancy, which is the conversion of the `eₚ` budget. The `eₐ` budget converts at the rate set by the anomaly relative to the reference profile at the parcel's *own* height, `bᵣ = b - b✶(z)`. The remainder `w b✶(z)` exchanges kinetic energy with the background state, which is also why the pressure belonging to this budget is the deviation from the reference profile's hydrostatic pressure.

The two are different fields. They agree only once integrated, since `w b✶(z)` is a flux divergence — which is what makes the lock release example's integrated budget correct as it stands, despite closing it with `∫wb`.

Two new diagnostics:

- `ReferenceBuoyancyAnomaly` — `bᵣ = b - b✶(z)`
- `AvailablePotentialToKineticEnergyConversion` — `w bᵣ`, taking its anomaly as an argument so one computed `bᵣ` can be shared, the way `upsilon` shares one `Υ`

## Implementation notes

`b✶(z)` is a new sampling of the reference profile, `reference_buoyancy_at_height`. It is distinct from `reference_buoyancy`, which pairs the profile with `z✶` instead and so returns the parcel's own buoyancy — an anomaly built from that would be zero everywhere. Its field reads the profile off the ranking the sort already produced (`s.permutation`) rather than sorting a second time, and is piecewise constant on the same slots `Ψ` integrates, so it is that `Ψ`'s derivative rather than a second reconstruction of the same profile.

Both conversions form their product on the face where `w` lives and interpolate to the center, so `wb = w bᵣ + w b✶` holds cell by cell to roundoff (measured at 1.4e-17) rather than only in the volume integral.

Like `Υ` and `εₐ`, both new diagnostics are maps on the model grid, so they reject `VerticalSort` and default to `HeavisideIntegral`.

## Breaking change

`BuoyancyDisplacementPotential` is now `AvailablePotentialEnergyDisplacementPotential`, which is the name `using Oceanostics` exports. `DisplacementPotential` exists as a shorter alias, but it is scoped to the module that owns it: `using Oceanostics.AvailablePotentialEnergyEquation` brings it in and `using Oceanostics` does not, the same arrangement `AvailablePotentialEnergyDissipationRate` and its `DissipationRate` alias already have. There is no deprecation for the old name, hence the minor bump to 0.20.0.

## Also here

`docs/build_single_page.jl`, a REPL loop for rendering one docs page at a time: it stages the page into a source directory of its own and rebuilds in about a second, instead of the minutes a full `make.jl` spends running the examples.

## Testing

`ape_diagnostics` (428), `filtered_ape_diagnostics` (43), `subfilter_ape_diagnostics` (38) and `perf_invariants` (102) all pass locally. New coverage: `bᵣ` against the profile directly, the cell-by-cell split of `wb`, `∫w bᵣ dV = ∫wb dV`, both quantities vanishing identically on an already-sorted field, the `VerticalSort` and tilted-gravity rejections, and zero-allocation/type-stable evaluation of the conversion both over a materialized anomaly and over the nested `ReferenceBuoyancyAnomaly` operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTFiG2Cno7ZCV21cPUmwMS
