### PR TITLE
Add the sub-filter APE to KE conversion τ(w, bᵣ)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ All kernel functions use Oceananigans' staggered grid conventions with location 
   `filtered_buoyancy_and_lookup`, which is what makes the difference a decomposition). Both are
   `KernelFunctionOperation`s wrapping the underlying `BinaryOperation` (à la
   `SubFilterKineticEnergyDissipationRate`). It also owns `SubFilterAvailablePotentialToKineticEnergyConversion`
-  (τ(w, bᵣ) = filter(wbᵣ) − w̄b_rˡ, the term the sub-filter APE and sub-filter KE budgets exchange): both
+  (τˡ(w, bᵣ) = filter(wbᵣ) − w̄b_rˡ, the term the sub-filter APE and sub-filter KE budgets exchange): both
   halves go through `FilteredAvailablePotentialEnergyEquation`'s conversion kernel on one shared b✶(z), so
   they are one discretization split in two rather than two separately built terms, and the reference stays
   unfiltered in both — which is what makes it *not* `subfilter_covariance(w, bᵣ, filter)`. It is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,13 @@ All kernel functions use Oceananigans' staggered grid conventions with location 
   profile (`subfilter_reference_heights` builds `z✶` and `z✶ˡ` from that module's
   `filtered_buoyancy_and_lookup`, which is what makes the difference a decomposition). Both are
   `KernelFunctionOperation`s wrapping the underlying `BinaryOperation` (à la
-  `SubFilterKineticEnergyDissipationRate`), and the module re-exports `FilteredAvailablePotentialEnergy`,
+  `SubFilterKineticEnergyDissipationRate`). It also owns `SubFilterAvailablePotentialToKineticEnergyConversion`
+  (τ(w, bᵣ) = filter(wbᵣ) − w̄b_rˡ, the term the sub-filter APE and sub-filter KE budgets exchange): both
+  halves go through `FilteredAvailablePotentialEnergyEquation`'s conversion kernel on one shared b✶(z), so
+  they are one discretization split in two rather than two separately built terms, and the reference stays
+  unfiltered in both — which is what makes it *not* `subfilter_covariance(w, bᵣ, filter)`. It is
+  re-exported by `SubFilterKineticEnergyEquation` (a source of that budget), which is why that module is
+  now included *after* this one. The module re-exports `FilteredAvailablePotentialEnergy`,
   `FilteredAvailablePotentialEnergyDissipationRate` and `AvailablePotentialEnergyCrossScaleFlux` (a
   source term of this budget; as `SubFilterKineticEnergyEquation` re-exports
   `KineticEnergyCrossScaleFlux`). `method` must be a `ProfileLookup`: the default builds a

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceanostics"
 uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["tomchor <tomaschor@gmail.com>"]
 
 [deps]

--- a/docs/src/subfilter_available_potential_energy_equation.md
+++ b/docs/src/subfilter_available_potential_energy_equation.md
@@ -72,7 +72,7 @@ Oceanostics.SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentia
 ## The sub-filter conversion to kinetic energy
 
 ```math
-\tau(w, b_r) = \widetilde{w b_r} - \bar w \, b_r^l ,
+\tau^l(w, b_r) = \widetilde{w b_r} - \bar w \, b_r^l ,
 \qquad
 b_r = b - b^\star(z) ,
 \qquad
@@ -83,8 +83,8 @@ is the rate at which the sub-filter scales release their available potential ene
 flow, computed by [`SubFilterAvailablePotentialToKineticEnergyConversion`](@ref). It is the sub-filter
 half of the split whose filtered half is
 [`FilteredAvailablePotentialToKineticEnergyConversion`](@ref Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialToKineticEnergyConversion),
-the two summing to ``\widetilde{w b_r}``. It enters this budget as ``-\tau(w, b_r)`` and the
-[Sub-filter kinetic energy equation](@ref) as ``+\tau(w, b_r)``, so it is a reversible exchange rather
+the two summing to ``\widetilde{w b_r}``. It enters this budget as ``-\tau^l(w, b_r)`` and the
+[Sub-filter kinetic energy equation](@ref) as ``+\tau^l(w, b_r)``, so it is a reversible exchange rather
 than a source or a sink. The reference profile is not filtered in either half, which is what
 distinguishes it from a plain `subfilter_covariance` of ``w`` and ``b_r``.
 

--- a/docs/src/subfilter_available_potential_energy_equation.md
+++ b/docs/src/subfilter_available_potential_energy_equation.md
@@ -63,12 +63,35 @@ flux; the [Filtered available potential energy equation](@ref) has the details.
 The cross-scale APE flux ``\Pi_a``, which enters this budget as a source (``+\Pi_a``) and the
 filtered one as a sink, is
 [`AvailablePotentialEnergyCrossScaleFlux`](@ref Oceanostics.FilteredAvailablePotentialEnergyEquation.AvailablePotentialEnergyCrossScaleFlux),
-defined in the [Filtered available potential energy equation](@ref) and re-exported here. The remaining
-terms of the ``e_a^s`` budget — the sub-filter buoyancy-flux exchange with the kinetic energy, and the
-reference-tendency correction that appears when the reference profile evolves in time — do not have
-named diagnostics yet. With a fixed reference profile the correction vanishes identically, so that is
-the configuration in which the budget can be closed from what is currently available.
+defined in the [Filtered available potential energy equation](@ref) and re-exported here.
 
 ```@docs
 Oceanostics.SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialEnergyDissipationRate
 ```
+
+## The sub-filter conversion to kinetic energy
+
+```math
+\tau(w, b_r) = \widetilde{w b_r} - \bar w \, b_r^l ,
+\qquad
+b_r = b - b^\star(z) ,
+\qquad
+b_r^l = \bar b - b^\star(z)
+```
+
+is the rate at which the sub-filter scales release their available potential energy to the sub-filter
+flow, computed by [`SubFilterAvailablePotentialToKineticEnergyConversion`](@ref). It is the sub-filter
+half of the split whose filtered half is
+[`FilteredAvailablePotentialToKineticEnergyConversion`](@ref Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialToKineticEnergyConversion),
+the two summing to ``\widetilde{w b_r}``. It enters this budget as ``-\tau(w, b_r)`` and the
+[Sub-filter kinetic energy equation](@ref) as ``+\tau(w, b_r)``, so it is a reversible exchange rather
+than a source or a sink. The reference profile is not filtered in either half, which is what
+distinguishes it from a plain `subfilter_covariance` of ``w`` and ``b_r``.
+
+```@docs
+Oceanostics.SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialToKineticEnergyConversion
+```
+
+The one term of the ``e_a^s`` budget still without a diagnostic is the reference-tendency correction
+that appears when the reference profile evolves in time; with a fixed reference profile it vanishes
+identically.

--- a/docs/src/subfilter_kinetic_energy_equation.md
+++ b/docs/src/subfilter_kinetic_energy_equation.md
@@ -22,7 +22,7 @@ transport terms vanishing over a closed or periodic domain) reads
 ```math
 \frac{d}{dt} \int K^s\, dV
     = \int \Pi_K\, dV
-    + \int \tau(w, b_r)\, dV
+    + \int \tau^l(w, b_r)\, dV
     - \int \varepsilon^s\, dV ,
 ```
 
@@ -31,7 +31,7 @@ with two sources and one sink:
   - ``\Pi_K`` ([`KineticEnergyCrossScaleFlux`](@ref)) is the cross-scale kinetic-energy flux, the rate at
     which the filtered scales hand kinetic energy down to the sub-filter scales. It is the sink of the
     filtered-flow budget and the source of this one.
-  - ``\tau(w, b_r) = \widetilde{w b_r} - \bar w\,b_r^l``
+  - ``\tau^l(w, b_r) = \widetilde{w b_r} - \bar w\,b_r^l``
     ([`SubFilterAvailablePotentialToKineticEnergyConversion`](@ref Oceanostics.SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialToKineticEnergyConversion))
     is the sub-filter buoyancy flux, which converts sub-filter available potential energy into
     sub-filter kinetic energy. It is defined in the

--- a/docs/src/subfilter_kinetic_energy_equation.md
+++ b/docs/src/subfilter_kinetic_energy_equation.md
@@ -22,7 +22,7 @@ transport terms vanishing over a closed or periodic domain) reads
 ```math
 \frac{d}{dt} \int K^s\, dV
     = \int \Pi_K\, dV
-    + \int \tau(w, b)\, dV
+    + \int \tau(w, b_r)\, dV
     - \int \varepsilon^s\, dV ,
 ```
 
@@ -31,8 +31,12 @@ with two sources and one sink:
   - ``\Pi_K`` ([`KineticEnergyCrossScaleFlux`](@ref)) is the cross-scale kinetic-energy flux, the rate at
     which the filtered scales hand kinetic energy down to the sub-filter scales. It is the sink of the
     filtered-flow budget and the source of this one.
-  - ``\tau(w, b) = \widetilde{wb} - \tilde w\,\tilde b`` is the sub-filter buoyancy flux (a
-    `subfilter_covariance`), which converts sub-filter potential energy into sub-filter kinetic energy.
+  - ``\tau(w, b_r) = \widetilde{w b_r} - \bar w\,b_r^l``
+    ([`SubFilterAvailablePotentialToKineticEnergyConversion`](@ref Oceanostics.SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialToKineticEnergyConversion))
+    is the sub-filter buoyancy flux, which converts sub-filter available potential energy into
+    sub-filter kinetic energy. It is defined in the
+    [Sub-filter available potential energy equation](@ref), whose budget it is the sink of, and is
+    re-exported here.
   - ``\varepsilon^s = \widetilde{\varepsilon} - \varepsilon^l`` is the sub-filter dissipation
     ([`SubFilterKineticEnergyDissipationRate`](@ref)): the filtered total dissipation
     ``\widetilde{\varepsilon}``

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -101,6 +101,7 @@ export AvailablePotentialEnergyCrossScaleFlux, FilteredAvailablePotentialToKinet
 
 #+++ SubFilterAvailablePotentialEnergyEquation exports
 export SubFilterAvailablePotentialEnergy, SubFilterAvailablePotentialEnergyDissipationRate
+export SubFilterAvailablePotentialToKineticEnergyConversion
 #---
 
 #+++ ProgressMessengers
@@ -222,9 +223,9 @@ include("AvailablePotentialEnergyEquation.jl")
 include("FlowDiagnostics.jl")
 include("SpatialFilters/SpatialFilters.jl")
 include("FilteredKineticEnergyEquation.jl")
-include("SubFilterKineticEnergyEquation.jl")
 include("FilteredAvailablePotentialEnergyEquation.jl")
 include("SubFilterAvailablePotentialEnergyEquation.jl")
+include("SubFilterKineticEnergyEquation.jl")
 include("ProgressMessengers/ProgressMessengers.jl")
 
 using .TracerEquation, .UMomentumEquation, .VMomentumEquation, .WMomentumEquation, .TracerVarianceEquation, .KineticEnergyEquation, .TurbulentKineticEnergyEquation, .PotentialEnergyEquation
@@ -232,9 +233,9 @@ using .BackgroundPotentialEnergyEquation, .AvailablePotentialEnergyEquation
 using .FlowDiagnostics
 using .SpatialFilters
 using .FilteredKineticEnergyEquation
-using .SubFilterKineticEnergyEquation
 using .FilteredAvailablePotentialEnergyEquation
 using .SubFilterAvailablePotentialEnergyEquation
+using .SubFilterKineticEnergyEquation
 using .ProgressMessengers
 
 #+++ Deprecated bindings
@@ -472,6 +473,7 @@ end
 #+++ SubFilterAvailablePotentialEnergyEquation
 @diagnostic_show SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialEnergy                "SubFilterAvailablePotentialEnergy"                "sub-filter available potential energy  eₐˢ = filter(eₐ) - eₐˡ"
 @diagnostic_show SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialEnergyDissipationRate "SubFilterAvailablePotentialEnergyDissipationRate" "sub-filter available potential energy dissipation rate  εₐˢ = filter(εₐ) - εₐˡ"
+@diagnostic_show SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialToKineticEnergyConversion "SubFilterAvailablePotentialToKineticEnergyConversion" "sub-filter APE to KE conversion  τ(w, bᵣ) = filter(wbᵣ) - w̄b_rˡ"
 #---
 
 #+++ FlowDiagnostics

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -473,7 +473,7 @@ end
 #+++ SubFilterAvailablePotentialEnergyEquation
 @diagnostic_show SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialEnergy                "SubFilterAvailablePotentialEnergy"                "sub-filter available potential energy  eₐˢ = filter(eₐ) - eₐˡ"
 @diagnostic_show SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialEnergyDissipationRate "SubFilterAvailablePotentialEnergyDissipationRate" "sub-filter available potential energy dissipation rate  εₐˢ = filter(εₐ) - εₐˡ"
-@diagnostic_show SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialToKineticEnergyConversion "SubFilterAvailablePotentialToKineticEnergyConversion" "sub-filter APE to KE conversion  τ(w, bᵣ) = filter(wbᵣ) - w̄b_rˡ"
+@diagnostic_show SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialToKineticEnergyConversion "SubFilterAvailablePotentialToKineticEnergyConversion" "sub-filter APE to KE conversion  τˡ(w, bᵣ) = filter(wbᵣ) - w̄b_rˡ"
 #---
 
 #+++ FlowDiagnostics

--- a/src/SubFilterAvailablePotentialEnergyEquation.jl
+++ b/src/SubFilterAvailablePotentialEnergyEquation.jl
@@ -225,7 +225,7 @@ SubFilterAvailablePotentialEnergyDissipationRate(model; σ, dims = (1, 2, 3), bo
 #---
 
 #+++ Sub-filter available-potential-to-kinetic-energy conversion
-# τ(w, bᵣ) = filter(wbᵣ) - w̄b_rˡ, the same wrapper trick as the two diagnostics above.
+# τˡ(w, bᵣ) = filter(wbᵣ) - w̄b_rˡ, the same wrapper trick as the two diagnostics above.
 @inline subfilter_ape_to_ke_conversion_ccc(i, j, k, grid, wbᵣˢ) = @inbounds wbᵣˢ[i, j, k]
 
 const SubFilterAvailablePotentialToKineticEnergyConversion = CustomKFO{<:typeof(subfilter_ape_to_ke_conversion_ccc)}
@@ -234,20 +234,20 @@ const SubFilterAvailablePotentialToKineticEnergyConversion = CustomKFO{<:typeof(
     $(SIGNATURES)
 
 Return the sub-filter-scale (SFS) conversion of available potential energy into kinetic energy
-`τ(w, bᵣ)`, the rate at which the scales a low-pass `filter` removes release their APE to the
+`τˡ(w, bᵣ)`, the rate at which the scales a low-pass `filter` removes release their APE to the
 sub-filter flow:
 
 ```
-    τ(w, bᵣ) = filter(w bᵣ) - w̄ b_rˡ ,   bᵣ = b - b✶(z) ,   b_rˡ = b̄ - b✶(z)
+    τˡ(w, bᵣ) = filter(w bᵣ) - w̄ b_rˡ ,   bᵣ = b - b✶(z) ,   b_rˡ = b̄ - b✶(z)
 ```
 
 It is the sub-filter half of the split whose filtered half is
 [`FilteredAvailablePotentialToKineticEnergyConversion`](@ref) `w̄b_rˡ`: the two sum to `filter(w bᵣ)`,
 so the sub-filter and filtered budgets between them exchange exactly what the full field converts
 ([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)). It enters this budget as
-`-τ(w, bᵣ)` and the sub-filter kinetic energy budget
+`-τˡ(w, bᵣ)` and the sub-filter kinetic energy budget
 ([`SubFilterKineticEnergy`](@ref Oceanostics.SubFilterKineticEnergyEquation.SubFilterKineticEnergy))
-as `+τ(w, bᵣ)`, so it is a reversible exchange rather than a source or a sink.
+as `+τˡ(w, bᵣ)`, so it is a reversible exchange rather than a source or a sink.
 
 The reference profile is **not** filtered in either half — `b_rˡ` is `b̄ - b✶(z)`, not `filter(bᵣ)`,
 which would filter the reference along with the buoyancy. That is what makes the two halves an exact
@@ -276,7 +276,7 @@ SubFilterAvailablePotentialToKineticEnergyConversion KernelFunctionOperation at 
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: subfilter_ape_to_ke_conversion_ccc (generic function with 1 method)
 └── arguments: ("Oceananigans.AbstractOperations.BinaryOperation",)
-└── computes: sub-filter APE to KE conversion  τ(w, bᵣ) = filter(wbᵣ) - w̄b_rˡ
+└── computes: sub-filter APE to KE conversion  τˡ(w, bᵣ) = filter(wbᵣ) - w̄b_rˡ
 ```
 
 A convenience method `SubFilterAvailablePotentialToKineticEnergyConversion(model; σ, dims, boundary, N)`
@@ -292,7 +292,7 @@ function SubFilterAvailablePotentialToKineticEnergyConversion(model, filter; met
     # Both halves are the same contraction — a vertical velocity against a buoyancy anomaly measured from
     # the *unfiltered* reference profile — so they go through one kernel, the filtered conversion's,
     # differing only in whether they read the full or the filtered fields. Sharing the kernel and the one
-    # `b✶(z)` is what leaves `filter(wbᵣ) = w̄b_rˡ + τ(w, bᵣ)` a decomposition of one discretization
+    # `b✶(z)` is what leaves `filter(wbᵣ) = w̄b_rˡ + τˡ(w, bᵣ)` a decomposition of one discretization
     # rather than a difference of two.
     b✶ᶻ = reference_buoyancy_at_height(model.grid, lookup.profile)
     w_bᵣ(w, b) = KernelFunctionOperation{Center, Center, Center}(filtered_ape_to_ke_conversion_ccc, model.grid, w, b, b✶ᶻ)

--- a/src/SubFilterAvailablePotentialEnergyEquation.jl
+++ b/src/SubFilterAvailablePotentialEnergyEquation.jl
@@ -11,6 +11,7 @@ export FilteredAvailablePotentialEnergy, FilteredAvailablePotentialEnergyDissipa
 # Πₐ is a source term of the sub-filter APE budget (and a sink of the filtered one), so it is
 # re-exported from the same module.
 export AvailablePotentialEnergyCrossScaleFlux
+export SubFilterAvailablePotentialToKineticEnergyConversion
 # The shared reference profile both states are measured against is built with
 # `BackgroundPotentialEnergyEquation`'s machinery, so the pieces needed to construct and share one are
 # re-exported here and this module can be used on its own.
@@ -25,11 +26,14 @@ using Oceanostics: CustomKFO
 
 using ..PotentialEnergyEquation: validate_buoyancy_is_a_diffused_tracer, validate_closure_supplies_a_flux,
                                  validate_gravity_is_z_aligned
-using ..BackgroundPotentialEnergyEquation: reference_height, reference_buoyancy, VerticalSort, ProfileLookup
+using ..BackgroundPotentialEnergyEquation: reference_height, reference_buoyancy, reference_buoyancy_at_height,
+                                           VerticalSort, ProfileLookup
 using ..AvailablePotentialEnergyEquation: AvailablePotentialEnergy, AvailablePotentialEnergyDissipationRate
 using ..FilteredAvailablePotentialEnergyEquation: FilteredAvailablePotentialEnergy,
                                                   FilteredAvailablePotentialEnergyDissipationRate,
                                                   AvailablePotentialEnergyCrossScaleFlux,
+                                                  FilteredAvailablePotentialToKineticEnergyConversion,
+                                                  filtered_ape_to_ke_conversion_ccc,
                                                   filtered_buoyancy_and_lookup
 # `GaussianFilter` builds the convenience methods' filter; `BoxFilter` is imported only so its docstring
 # `@ref` resolves in-module.
@@ -218,6 +222,88 @@ end
 
 SubFilterAvailablePotentialEnergyDissipationRate(model; σ, dims = (1, 2, 3), boundary = :shrink, N = nothing, kwargs...) =
     SubFilterAvailablePotentialEnergyDissipationRate(model, GaussianFilter(; dims, σ, boundary, N); kwargs...)
+#---
+
+#+++ Sub-filter available-potential-to-kinetic-energy conversion
+# τ(w, bᵣ) = filter(wbᵣ) - w̄b_rˡ, the same wrapper trick as the two diagnostics above.
+@inline subfilter_ape_to_ke_conversion_ccc(i, j, k, grid, wbᵣˢ) = @inbounds wbᵣˢ[i, j, k]
+
+const SubFilterAvailablePotentialToKineticEnergyConversion = CustomKFO{<:typeof(subfilter_ape_to_ke_conversion_ccc)}
+
+"""
+    $(SIGNATURES)
+
+Return the sub-filter-scale (SFS) conversion of available potential energy into kinetic energy
+`τ(w, bᵣ)`, the rate at which the scales a low-pass `filter` removes release their APE to the
+sub-filter flow:
+
+```
+    τ(w, bᵣ) = filter(w bᵣ) - w̄ b_rˡ ,   bᵣ = b - b✶(z) ,   b_rˡ = b̄ - b✶(z)
+```
+
+It is the sub-filter half of the split whose filtered half is
+[`FilteredAvailablePotentialToKineticEnergyConversion`](@ref) `w̄b_rˡ`: the two sum to `filter(w bᵣ)`,
+so the sub-filter and filtered budgets between them exchange exactly what the full field converts
+([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)). It enters this budget as
+`-τ(w, bᵣ)` and the sub-filter kinetic energy budget
+([`SubFilterKineticEnergy`](@ref Oceanostics.SubFilterKineticEnergyEquation.SubFilterKineticEnergy))
+as `+τ(w, bᵣ)`, so it is a reversible exchange rather than a source or a sink.
+
+The reference profile is **not** filtered in either half — `b_rˡ` is `b̄ - b✶(z)`, not `filter(bᵣ)`,
+which would filter the reference along with the buoyancy. That is what makes the two halves an exact
+decomposition; [`FilteredAvailablePotentialToKineticEnergyConversion`](@ref) gives the reason. The two
+choices differ once the filter acts in the vertical and coincide for a purely horizontal one, `b✶` being
+a function of `z` alone.
+
+`method` has to be a [`ProfileLookup`](@ref), for the reason
+[`SubFilterAvailablePotentialEnergy`](@ref) gives, and both halves are built on the one profile it
+supplies. `filter` is any callable mapping a field to its low-pass-filtered counterpart, e.g. a
+reusable [`GaussianFilter`](@ref) or [`BoxFilter`](@ref). The result lives at
+`(Center, Center, Center)`, per unit mass (units `m² s⁻³`):
+
+```jldoctest
+using Oceananigans, Oceanostics
+
+grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1), topology=(Periodic, Periodic, Bounded))
+model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
+
+filter = GaussianFilter(; dims=(1, 2, 3), σ=0.1)
+SubFilterAvailablePotentialToKineticEnergyConversion(model, filter)
+
+# output
+
+SubFilterAvailablePotentialToKineticEnergyConversion KernelFunctionOperation at (Center, Center, Center)
+├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── kernel_function: subfilter_ape_to_ke_conversion_ccc (generic function with 1 method)
+└── arguments: ("Oceananigans.AbstractOperations.BinaryOperation",)
+└── computes: sub-filter APE to KE conversion  τ(w, bᵣ) = filter(wbᵣ) - w̄b_rˡ
+```
+
+A convenience method `SubFilterAvailablePotentialToKineticEnergyConversion(model; σ, dims, boundary, N)`
+builds the Gaussian `filter` for you from a standard deviation `σ` (with `σ = ℓ / (2√(2 ln 2))` for a
+FWHM `ℓ`).
+"""
+function SubFilterAvailablePotentialToKineticEnergyConversion(model, filter; method = ProfileLookup(),
+                                                              geopotential_height = model_geopotential_height(model))
+    validate_gravity_is_z_aligned("SubFilterAvailablePotentialToKineticEnergyConversion", model)
+    b, b̄, lookup = filtered_buoyancy_and_lookup("SubFilterAvailablePotentialToKineticEnergyConversion", model, filter,
+                                                method, geopotential_height)
+
+    # Both halves are the same contraction — a vertical velocity against a buoyancy anomaly measured from
+    # the *unfiltered* reference profile — so they go through one kernel, the filtered conversion's,
+    # differing only in whether they read the full or the filtered fields. Sharing the kernel and the one
+    # `b✶(z)` is what leaves `filter(wbᵣ) = w̄b_rˡ + τ(w, bᵣ)` a decomposition of one discretization
+    # rather than a difference of two.
+    b✶ᶻ = reference_buoyancy_at_height(model.grid, lookup.profile)
+    w_bᵣ(w, b) = KernelFunctionOperation{Center, Center, Center}(filtered_ape_to_ke_conversion_ccc, model.grid, w, b, b✶ᶻ)
+
+    wbᵣˢ = Field(filter(Field(w_bᵣ(model.velocities.w, b)))) - w_bᵣ(Field(filter(model.velocities.w)), b̄)
+
+    return KernelFunctionOperation{Center, Center, Center}(subfilter_ape_to_ke_conversion_ccc, model.grid, wbᵣˢ)
+end
+
+SubFilterAvailablePotentialToKineticEnergyConversion(model; σ, dims = (1, 2, 3), boundary = :shrink, N = nothing, kwargs...) =
+    SubFilterAvailablePotentialToKineticEnergyConversion(model, GaussianFilter(; dims, σ, boundary, N); kwargs...)
 #---
 
 end # module

--- a/src/SubFilterKineticEnergyEquation.jl
+++ b/src/SubFilterKineticEnergyEquation.jl
@@ -6,6 +6,9 @@ export SubFilterKineticEnergy, SubFilterKineticEnergyDissipationRate, Dissipatio
 # Πₖ is a source term of the sub-filter KE budget (and a sink of the filtered budget), so it is
 # re-exported here from `FilteredKineticEnergyEquation`, where it is defined.
 export KineticEnergyCrossScaleFlux
+# τ(w, bᵣ) is the other source of this budget — the APE the sub-filter scales release to it — and a sink
+# of the sub-filter APE one, so it is re-exported here from `SubFilterAvailablePotentialEnergyEquation`.
+export SubFilterAvailablePotentialToKineticEnergyConversion
 
 using Oceananigans.Fields: Field
 using Oceananigans.Grids: Center
@@ -19,6 +22,7 @@ using ..FilteredKineticEnergyEquation: subfilter_stress_tensor # re-exported for
 # `GaussianFilter` is used by the convenience methods; `BoxFilter` is imported only so its docstring
 # `@ref` resolves in-module.
 using ..SpatialFilters: GaussianFilter, BoxFilter
+using ..SubFilterAvailablePotentialEnergyEquation: SubFilterAvailablePotentialToKineticEnergyConversion
 
 #+++ Sub-filter kinetic energy
 # Kˢ = filter(K) - Kˡ: the filtered full kinetic energy minus the kinetic energy of the filtered flow.

--- a/src/SubFilterKineticEnergyEquation.jl
+++ b/src/SubFilterKineticEnergyEquation.jl
@@ -6,7 +6,7 @@ export SubFilterKineticEnergy, SubFilterKineticEnergyDissipationRate, Dissipatio
 # Πₖ is a source term of the sub-filter KE budget (and a sink of the filtered budget), so it is
 # re-exported here from `FilteredKineticEnergyEquation`, where it is defined.
 export KineticEnergyCrossScaleFlux
-# τ(w, bᵣ) is the other source of this budget — the APE the sub-filter scales release to it — and a sink
+# τˡ(w, bᵣ) is the other source of this budget — the APE the sub-filter scales release to it — and a sink
 # of the sub-filter APE one, so it is re-exported here from `SubFilterAvailablePotentialEnergyEquation`.
 export SubFilterAvailablePotentialToKineticEnergyConversion
 

--- a/test/test_subfilter_ape_diagnostics.jl
+++ b/test/test_subfilter_ape_diagnostics.jl
@@ -188,7 +188,7 @@ function test_subfilter_ape_module_reexports()
     @test :FilteredAvailablePotentialEnergy in names(SubFilterAvailablePotentialEnergyEquation)
     @test :FilteredAvailablePotentialEnergyDissipationRate in names(SubFilterAvailablePotentialEnergyEquation)
     @test :AvailablePotentialEnergyCrossScaleFlux in names(SubFilterAvailablePotentialEnergyEquation)
-    # τ(w, bᵣ) is a source of the sub-filter KE budget too, so that module re-exports it from here
+    # τˡ(w, bᵣ) is a source of the sub-filter KE budget too, so that module re-exports it from here
     @test SubFilterKineticEnergyEquation.SubFilterAvailablePotentialToKineticEnergyConversion === SubFilterAvailablePotentialToKineticEnergyConversion
     @test :SubFilterAvailablePotentialToKineticEnergyConversion in names(SubFilterKineticEnergyEquation)
     @test SubFilterAvailablePotentialEnergyEquation.DissipationRate === SubFilterAvailablePotentialEnergyDissipationRate
@@ -200,7 +200,7 @@ function test_subfilter_ape_module_reexports()
 end
 #---
 
-# τ(w, bᵣ) is defined as filter(wbᵣ) - w̄b_rˡ, so the two halves have to add back up to the filtered
+# τˡ(w, bᵣ) is defined as filter(wbᵣ) - w̄b_rˡ, so the two halves have to add back up to the filtered
 # full-field conversion. That is the decomposition claim, and it pins the shared b✶(z) and the shared
 # discretization: were either half built against a different reference or collocated differently, the
 # sum would drift from filter(wbᵣ).
@@ -331,7 +331,7 @@ end
     @info "    Validation errors (method, buoyancy, closure)"
     test_subfilter_ape_errors(grid, filt)
 
-    @info "    Sub-filter APE to KE conversion τ(w, bᵣ)"
+    @info "    Sub-filter APE to KE conversion τˡ(w, bᵣ)"
     # The shared model is buoyancy-only, and the conversion is carried by the vertical velocity, so
     # without this every assertion below would hold trivially on a field of zeros.
     set!(model, u=(x, y, z) -> 1e-2 * randn(), w=(x, y, z) -> 1e-2 * randn())

--- a/test/test_subfilter_ape_diagnostics.jl
+++ b/test/test_subfilter_ape_diagnostics.jl
@@ -6,7 +6,9 @@ using Oceananigans.Fields: location, compute_at!
 using Oceanostics
 using Oceanostics: SubFilterAvailablePotentialEnergy, SubFilterAvailablePotentialEnergyDissipationRate
 using Oceanostics: FilteredAvailablePotentialEnergy, FilteredAvailablePotentialEnergyDissipationRate,
-                   AvailablePotentialEnergyCrossScaleFlux
+                   AvailablePotentialEnergyCrossScaleFlux, FilteredAvailablePotentialToKineticEnergyConversion
+using Oceanostics: SubFilterAvailablePotentialToKineticEnergyConversion, AvailablePotentialToKineticEnergyConversion,
+                   reference_buoyancy_at_height
 using Oceanostics: AvailablePotentialEnergy, AvailablePotentialEnergyDissipationRate,
                    reference_height, reference_buoyancy, VerticalSort, ProfileLookup, HeavisideIntegral,
                    GaussianFilter
@@ -186,6 +188,9 @@ function test_subfilter_ape_module_reexports()
     @test :FilteredAvailablePotentialEnergy in names(SubFilterAvailablePotentialEnergyEquation)
     @test :FilteredAvailablePotentialEnergyDissipationRate in names(SubFilterAvailablePotentialEnergyEquation)
     @test :AvailablePotentialEnergyCrossScaleFlux in names(SubFilterAvailablePotentialEnergyEquation)
+    # τ(w, bᵣ) is a source of the sub-filter KE budget too, so that module re-exports it from here
+    @test SubFilterKineticEnergyEquation.SubFilterAvailablePotentialToKineticEnergyConversion === SubFilterAvailablePotentialToKineticEnergyConversion
+    @test :SubFilterAvailablePotentialToKineticEnergyConversion in names(SubFilterKineticEnergyEquation)
     @test SubFilterAvailablePotentialEnergyEquation.DissipationRate === SubFilterAvailablePotentialEnergyDissipationRate
     @test SubFilterAvailablePotentialEnergyEquation.ProfileLookup === ProfileLookup
     @test SubFilterAvailablePotentialEnergyEquation.VerticalSort === VerticalSort
@@ -194,6 +199,99 @@ function test_subfilter_ape_module_reexports()
     return nothing
 end
 #---
+
+# τ(w, bᵣ) is defined as filter(wbᵣ) - w̄b_rˡ, so the two halves have to add back up to the filtered
+# full-field conversion. That is the decomposition claim, and it pins the shared b✶(z) and the shared
+# discretization: were either half built against a different reference or collocated differently, the
+# sum would drift from filter(wbᵣ).
+function test_subfilter_ape_ke_conversion_decomposition(model, filt)
+    lookup = ProfileLookup(reference_height(model, method=VerticalSort()))
+    z✶ = reference_height(model.tracers.b; method=lookup)
+
+    τ  = Field(SubFilterAvailablePotentialToKineticEnergyConversion(model, filt; method=lookup))
+    wl = Field(FilteredAvailablePotentialToKineticEnergyConversion(model, filt; method=lookup))
+    filtered_full = Field(filt(Field(AvailablePotentialToKineticEnergyConversion(model, z✶))))
+
+    @test location(τ) == (Center, Center, Center)
+    @test maximum(abs, interior(τ)) > 0   # otherwise the sum below would hold trivially
+    @test interior(filtered_full) ≈ interior(wl) .+ interior(τ)
+
+    @test occursin("SubFilterAvailablePotentialToKineticEnergyConversion", sprint(show, τ.operand))
+    @test occursin("computes:", sprint(show, MIME("text/plain"), τ.operand))
+    return nothing
+end
+
+# An identity-scale filter makes both halves the full-field conversion, so their difference vanishes to
+# the bit — the check that the two are the same expression evaluated on different fields, not two
+# separately built ones.
+function test_subfilter_ape_ke_conversion_identity_filter_vanishes(model)
+    identity_filter = ψ -> GaussianFilter(ψ; dims=(1, 2, 3), σ=1e-4, N=3)
+    @test all(interior(Field(SubFilterAvailablePotentialToKineticEnergyConversion(model, identity_filter))) .== 0)
+    return nothing
+end
+
+# The conversion is carried by the vertical velocity, so with no motion it vanishes identically however
+# sharp the buoyancy.
+function test_subfilter_ape_ke_conversion_vanishes_without_motion(grid, filt)
+    model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
+    set!(model, b=random_stratified_b)   # velocities left at zero
+    @test maximum(abs, interior(Field(SubFilterAvailablePotentialToKineticEnergyConversion(model, filt)))) == 0
+    return nothing
+end
+
+# Both halves measure the buoyancy against the *unfiltered* reference profile, so the filtered half uses
+# b_rˡ = b̄ - b✶(z) rather than filter(bᵣ) = filter(b - b✶(z)), which filters the reference too. The two
+# differ once the filter acts in the vertical and coincide for a purely horizontal one, b✶ being a
+# function of z alone — the convention that makes the two halves an exact decomposition.
+function test_subfilter_ape_ke_conversion_unfiltered_reference(model, filt, filt_horizontal)
+    lookup = ProfileLookup(reference_height(model, method=VerticalSort()))
+    b   = model.tracers.b
+    b✶ᶻ = reference_buoyancy_at_height(model.grid, lookup.profile)
+
+    for (filter, coincide) in ((filt, false), (filt_horizontal, true))
+        b_rˡ        = Field(Field(filter(b)) - b✶ᶻ)   # filtered buoyancy, unfiltered reference
+        filtered_bᵣ = Field(filter(Field(b - b✶ᶻ)))   # filters the reference too
+        @test (interior(b_rˡ) ≈ interior(filtered_bᵣ)) == coincide
+    end
+    return nothing
+end
+
+# The Gaussian convenience method must reproduce the explicit filter-factory call with matching kwargs.
+function test_subfilter_ape_ke_conversion_convenience(model)
+    σ = 0.12
+    filt = ψ -> GaussianFilter(ψ; dims=(1, 2, 3), σ, boundary=:shrink) # :shrink is the convenience default
+    @test interior(Field(SubFilterAvailablePotentialToKineticEnergyConversion(model; σ))) ≈
+          interior(Field(SubFilterAvailablePotentialToKineticEnergyConversion(model, filt)))
+    return nothing
+end
+
+# Like its siblings, it measures the filtered buoyancy against a profile it did not produce, so anything
+# but a `ProfileLookup` has to be refused.
+function test_subfilter_ape_ke_conversion_errors(grid, filt)
+    model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
+    set!(model, b=random_stratified_b)
+    @test_throws "ProfileLookup" SubFilterAvailablePotentialToKineticEnergyConversion(model, filt; method=HeavisideIntegral())
+    @test_throws ArgumentError SubFilterAvailablePotentialToKineticEnergyConversion(NonhydrostaticModel(grid), filt)
+    return nothing
+end
+
+# It holds filtered `Field`s and a profile re-sorted on every `compute!`, so it has to track the flow.
+# This mutates the model, so it runs last.
+function test_subfilter_ape_ke_conversion_recomputes(model, filt)
+    cf = Field(SubFilterAvailablePotentialToKineticEnergyConversion(model, filt))
+    compute_at!(cf, 0.0)
+    snapshot = Array(interior(cf))
+
+    set!(model, b=(x, y, z) -> 1e-2 * z + 2e-3 * randn(), w=(x, y, z) -> 2e-2 * randn())
+    compute_at!(cf, 1.0)
+
+    fresh = Field(SubFilterAvailablePotentialToKineticEnergyConversion(model, filt))
+    compute_at!(fresh, 2.0)
+
+    @test !(Array(interior(cf)) ≈ snapshot)   # tracked the change in the flow
+    @test interior(cf) ≈ interior(fresh)      # equals a conversion built fresh on the new state
+    return nothing
+end
 
 @testset "Sub-filter available potential energy equation" begin
     @info "  Testing sub-filter available potential energy diagnostics"
@@ -232,6 +330,18 @@ end
 
     @info "    Validation errors (method, buoyancy, closure)"
     test_subfilter_ape_errors(grid, filt)
+
+    @info "    Sub-filter APE to KE conversion τ(w, bᵣ)"
+    # The shared model is buoyancy-only, and the conversion is carried by the vertical velocity, so
+    # without this every assertion below would hold trivially on a field of zeros.
+    set!(model, u=(x, y, z) -> 1e-2 * randn(), w=(x, y, z) -> 1e-2 * randn())
+    test_subfilter_ape_ke_conversion_decomposition(model, filt)
+    test_subfilter_ape_ke_conversion_identity_filter_vanishes(model)
+    test_subfilter_ape_ke_conversion_unfiltered_reference(model, filt, filt_horizontal)
+    test_subfilter_ape_ke_conversion_convenience(model)
+    test_subfilter_ape_ke_conversion_vanishes_without_motion(grid, filt)
+    test_subfilter_ape_ke_conversion_errors(grid, filt)
+    test_subfilter_ape_ke_conversion_recomputes(model, filt)   # mutates model; keep last of the `model` tests
 
     @info "    Module re-exports and aliases"
     test_subfilter_ape_module_reexports()


### PR DESCRIPTION
Adds `SubFilterAvailablePotentialToKineticEnergyConversion`:

```
τ(w, bᵣ) = filter(w bᵣ) − w̄ b_rˡ ,   bᵣ = b − b✶(z) ,   b_rˡ = b̄ − b✶(z)
```

the sub-filter half of the split whose filtered half landed in #298. The two sum to `filter(w bᵣ)`, so the sub-filter and filtered budgets between them exchange exactly what the full field converts. It enters the sub-filter APE budget as `−τ(w, bᵣ)` and the sub-filter KE budget as `+τ(w, bᵣ)`.

Both halves go through `FilteredAvailablePotentialEnergyEquation`'s conversion kernel on one shared `b✶(z)`, differing only in whether they read the full or the filtered fields, so the pair is one discretization split in two rather than two separately built terms. The reference profile stays unfiltered in both, matching the convention #298 established (and tomchor/CoarseGrainedKHAPE#53).

Since the term is a source of the sub-filter kinetic energy budget too, `SubFilterKineticEnergyEquation` re-exports it, as it already does for `KineticEnergyCrossScaleFlux`. That required moving its `include` after `SubFilterAvailablePotentialEnergyEquation`; nothing imports from it, so the order was free to change.

Both docs pages get a brief description of the term and no derivation. The sub-filter KE page's budget also had the exchange written as `τ(w, b)` with a `subfilter_covariance`; it now names `τ(w, bᵣ)` and links to the diagnostic.

Sharpest checks: `filter(wbᵣ) = w̄b_rˡ + τ` to roundoff on a random stratified field; an identity-scale filter makes τ vanish to the bit; τ ≡ 0 exactly with no motion; and `b_rˡ` differs from `filter(bᵣ)` for a 3D filter and coincides for a horizontal one. The first three are guarded against going vacuous — the shared test model is buoyancy-only, so it now gets velocities before the conversion block.

Verified against Oceananigans 0.110.19: `subfilter_ape_diagnostics` 54/54, `subfilter_ke_diagnostics` 20/20, `filtered_ape_diagnostics` 63/63.

With this, the volume-integrated sub-filter APE budget of Wenegrat, Chor & Barkan (2026) has four of its five terms in Oceanostics (`Eₐˢ`, `Π_A`, `ε_Aˢ`, `τ(w, bᵣ)`); the reference-tendency correction `Rˢ` remains, and needs `TimeDerivative` from CliMA/Oceananigans.jl#5823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
