### PR TITLE
Derive the filtered APE budget in the docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ All kernel functions use Oceananigans' staggered grid conventions with location 
   (`FilteredAvailablePotentialEnergy(model, z✶ˡ)`,
   `FilteredAvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)`,
   `FilteredAvailablePotentialEnergyDissipationRate(model, filter, z✶ˡ; upsilon)`) so one lookup / one Υˡ
-  can be shared. Also owns `AvailablePotentialEnergyCrossScaleFlux` (Πₐ = −τᵢ∂ᵢΥˡ, the subfilter
+  can be shared. Also owns `AvailablePotentialEnergyCrossScaleFlux` (Πₐ = −τ(uᵢ, b)∂ᵢΥˡ, the subfilter
   buoyancy flux — `subfilter_covariance` per direction with one shared b̄ — contracted with ∇Υˡ, the APE
   analogue of `KineticEnergyCrossScaleFlux`), with the same high-level/low-level constructor pair, and
   `FilteredAvailablePotentialToKineticEnergyConversion` (w̄b_rˡ, the term the filtered APE and filtered

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,14 @@ All kernel functions use Oceananigans' staggered grid conventions with location 
   `kinetic_energy_ccc`) and `FilteredAvailablePotentialEnergyDissipationRate` (εₐˡ = −q̄ᵢ∂ᵢΥˡ, the
   closure's diffusive flux *low-pass filtered* — the same filtered-flux choice
   `FilteredKineticEnergyDissipationRate` makes for the viscous flux, exact for constant κ — against the
-  displacement potential Υˡ of b̄). Both take `(model, filter; method, geopotential_height)` and a
-  low-level form on a prebuilt `z✶ˡ` (`FilteredAvailablePotentialEnergy(model, z✶ˡ)`,
+  displacement potential Υˡ of b̄) — plus that Υˡ itself, `FilteredAvailablePotentialEnergyDisplacementPotential`
+  (Υˡ = z✶(b̄) − z, aliased `DisplacementPotential` inside the module the way the dissipation rate is
+  aliased `DissipationRate`; its kernel `filtered_upsilon_ccc` forwards to `upsilon_ccc` for the same
+  type-alias/display reason `filtered_ape_ccc` forwards to `local_ape_ccc`, and it is what the
+  dissipation rate and the cross-scale flux build internally when handed no `upsilon`). All three take
+  `(model, filter; method, geopotential_height)` and a low-level form on a prebuilt `z✶ˡ`
+  (`FilteredAvailablePotentialEnergy(model, z✶ˡ)`,
+  `FilteredAvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)`,
   `FilteredAvailablePotentialEnergyDissipationRate(model, filter, z✶ˡ; upsilon)`) so one lookup / one Υˡ
   can be shared. Also owns `AvailablePotentialEnergyCrossScaleFlux` (Πₐ = −τᵢ∂ᵢΥˡ, the sub-filter
   buoyancy flux — `subfilter_covariance` per direction with one shared b̄ — contracted with ∇Υˡ, the APE

--- a/docs/src/available_potential_energy_equation.md
+++ b/docs/src/available_potential_energy_equation.md
@@ -37,10 +37,9 @@ which we can simplify to
 R = \int_{z^\star}^{z} \partial_t b^\star(\tilde z, t) \, \mathrm{d}\tilde z .
 ```
 
-Both partial derivatives come straight from the definition of ``e_a``. In the first, the boundary term
-from moving the lower limit ``z^\star(b)`` drops out because ``b^\star(z^\star(b)) = b``, which leaves
-the displacement potential ``\Upsilon``. The second is minus the buoyancy anomaly ``b_r`` the parcel
-carries relative to the reference profile at its own height:
+Both partial derivatives come straight from the definition of ``e_a``. In the first we get an "empty"
+integral from ``z^\star`` to ``z``, which leaves the displacement potential ``\Upsilon``. The second
+is just the integrand of ``e_a``, leaving the buoyancy anomaly ``b_r``:
 
 ```math
 \left.\frac{\partial e_a}{\partial b}\right|_{z} = z^\star - z = \Upsilon ,

--- a/docs/src/filtered_available_potential_energy_equation.md
+++ b/docs/src/filtered_available_potential_energy_equation.md
@@ -1,36 +1,21 @@
 # Filtered available potential energy equation
 
 The `FilteredAvailablePotentialEnergyEquation` module provides diagnostics for the available potential
-energy of the *filtered* buoyancy field: the share of the local APE ``e_a`` of
-[the available potential energy equation](available_potential_energy_equation.md) that the scales a
-low-pass spatial filter ``\overline{(\,\cdot\,)}`` keeps would carry on their own, following the
-filtered APE framework of [Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879). It is
-the potential-energy counterpart of the [Filtered kinetic energy equation](@ref), and the
-[Sub-filter available potential energy equation](@ref) budgets what the filter removes.
-
-## The available potential energy of the filtered buoyancy
-
-With ``\bar b`` the filtered buoyancy, the APE of the filtered field is the local APE functional
-evaluated on ``\bar b`` rather than on ``b``,
+energy of the *filtered* buoyancy field. It is the potential-energy counterpart of the
+[Filtered kinetic energy equation](@ref). Following the filtered APE framework of
+[Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879), we define the APE
+of the filtered flow as
 
 ```math
-e_a^l = e_a(\bar b, z) = \int_{z^\star(\bar b)}^{z} \left[b^\star(\tilde z) - \bar b\right] \mathrm{d}\tilde z ,
+e_a^l = e_a(\bar b, z, t) = \int_{z^\star(\bar b, t)}^{z} \left[b^\star(\tilde z, t) - \bar b\right] \mathrm{d}\tilde z ,
 ```
+computed by [`FilteredAvailablePotentialEnergy`](@ref). Note that the reference profile ``b^\star(z^\star)``
+is the reference state of the *full buoyancy* ``b``, rather than sorted from ``\bar b`` itself.
+Because of this, it is necessary to look up the position of a buoyancy parcel in the filtered fields
+in the full reference profile ``b^\star(z^\star)`` in calculating some terms, which makes it necessary
+to use [`ProfileLookup`](@ref Oceanostics.BackgroundPotentialEnergyEquation.ProfileLookup), since it's
+the only method of obtaining the reference height that has this capability.
 
-computed by [`FilteredAvailablePotentialEnergy`](@ref). The reference profile ``(b^\star, z^\star)`` it
-is measured against is **shared with the full field**, ordinarily the sorted state of the full buoyancy
-``b``, rather than sorted from ``\bar b`` itself: only then are ``e_a(\bar b, z)`` and
-``e_a(b, z)`` comparable, and their difference the sub-filter APE. Looking a field up in a profile it
-did not produce is exactly what
-[`ProfileLookup`](@ref Oceanostics.BackgroundPotentialEnergyEquation.ProfileLookup) was built for, so
-these diagnostics accept only that reference-height method: the default sorts the model's own buoyancy
-into a [`VerticalSort`](@ref Oceanostics.BackgroundPotentialEnergyEquation.VerticalSort) column on
-every `compute!`, a column you built yourself can be shared across diagnostics, and a profile given as
-plain arrays holds the reference state fixed in time (which also makes the diagnostics sort-free).
-
-```@docs
-Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergy
-```
 
 ## Deriving the filtered available potential energy equation
 

--- a/docs/src/filtered_available_potential_energy_equation.md
+++ b/docs/src/filtered_available_potential_energy_equation.md
@@ -3,23 +3,23 @@
 The `FilteredAvailablePotentialEnergyEquation` module provides diagnostics for the available potential
 energy of the *filtered* buoyancy field: the share of the local APE ``e_a`` of
 [the available potential energy equation](available_potential_energy_equation.md) that the scales a
-low-pass spatial filter ``\widetilde{(\,\cdot\,)}`` keeps would carry on their own, following the
+low-pass spatial filter ``\overline{(\,\cdot\,)}`` keeps would carry on their own, following the
 filtered APE framework of [Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879). It is
 the potential-energy counterpart of the [Filtered kinetic energy equation](@ref), and the
 [Sub-filter available potential energy equation](@ref) budgets what the filter removes.
 
 ## The available potential energy of the filtered buoyancy
 
-With ``\tilde b`` the filtered buoyancy, the APE of the filtered field is the local APE functional
-evaluated on ``\tilde b`` rather than on ``b``,
+With ``\bar b`` the filtered buoyancy, the APE of the filtered field is the local APE functional
+evaluated on ``\bar b`` rather than on ``b``,
 
 ```math
-e_a^l = e_a(\tilde b, z) = \int_{z^\star(\tilde b)}^{z} \left[b^\star(\tilde z) - \tilde b\right] \mathrm{d}\tilde z ,
+e_a^l = e_a(\bar b, z) = \int_{z^\star(\bar b)}^{z} \left[b^\star(\tilde z) - \bar b\right] \mathrm{d}\tilde z ,
 ```
 
 computed by [`FilteredAvailablePotentialEnergy`](@ref). The reference profile ``(b^\star, z^\star)`` it
 is measured against is **shared with the full field**, ordinarily the sorted state of the full buoyancy
-``b``, rather than sorted from ``\tilde b`` itself: only then are ``e_a(\tilde b, z)`` and
+``b``, rather than sorted from ``\bar b`` itself: only then are ``e_a(\bar b, z)`` and
 ``e_a(b, z)`` comparable, and their difference the sub-filter APE. Looking a field up in a profile it
 did not produce is exactly what
 [`ProfileLookup`](@ref Oceanostics.BackgroundPotentialEnergyEquation.ProfileLookup) was built for, so
@@ -32,24 +32,138 @@ plain arrays holds the reference state fixed in time (which also makes the diagn
 Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergy
 ```
 
+## Deriving the filtered available potential energy equation
+
+The budget of ``e_a^l`` retraces the
+[full-field derivation](@ref "Deriving the local available potential energy equation") with the
+filtered buoyancy taking the place of ``b`` and the material derivative taken along the *filtered*
+flow, ``D^l/Dt = \partial_t + \bar u_i \partial_i``
+([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)):
+
+```math
+\frac{D^l e_a^l}{D t} = \left.\frac{\partial e_a^l}{\partial \bar b}\right|_{z,t} \frac{D^l \bar b}{D t}
+                      + \left.\frac{\partial e_a^l}{\partial z}\right|_{\bar b,t} \frac{D^l z}{D t}
+                      + \left.\frac{\partial e_a^l}{\partial t}\right|_{z,\bar b} \frac{D^l t}{D t} ,
+```
+
+which we can simplify to
+
+```math
+\frac{D^l e_a^l}{D t} = \left.\frac{\partial e_a^l}{\partial \bar b}\right|_{z,t} \frac{D^l \bar b}{D t}
+                      + \left.\frac{\partial e_a^l}{\partial z}\right|_{\bar b,t} \bar w
+                      + R^l ,
+\qquad
+R^l = \int_{z^\star(\bar b)}^{z} \partial_t b^\star(\tilde z, t) \, \mathrm{d}\tilde z .
+```
+
+Since ``e_a^l`` is the function ``e_a`` evaluated at ``(\bar b, z)``, both partial derivatives are
+the full-field ones taken at the filtered state; in the first, the boundary term from moving the
+lower limit ``z^\star(\bar b)`` again drops out, now because ``b^\star(z^\star(\bar b)) = \bar b``.
+They give the displacement potential and the buoyancy anomaly *of the filtered buoyancy*:
+
+```math
+\left.\frac{\partial e_a^l}{\partial \bar b}\right|_{z} = z^\star(\bar b) - z = \Upsilon^l ,
+\qquad
+\left.\frac{\partial e_a^l}{\partial z}\right|_{\bar b} = b^\star(z, t) - \bar b = -b_r^l .
+```
+
+Differentiating in ``z`` at fixed ``\bar b`` never touches the reference profile, so the anomaly
+that appears is ``b_r^l = \bar b - b^\star(z, t)``, the filtered buoyancy against the *unfiltered*
+profile, and not ``\overline{b_r}``; the note in
+[Conversion to filtered kinetic energy](@ref) below returns to this distinction.
+
+The material derivative of the filtered buoyancy comes from filtering
+[the tracer equation](tracer_equation.md) of ``b`` (the filter commutes with derivatives) and
+splitting the filtered advective flux into a resolved and a sub-filter part,
+``\overline{u_i b} = \bar u_i \, \bar b + \tau_i``:
+
+```math
+\frac{D^l \bar b}{D t} = -\partial_i \tau_i - \partial_i \bar q_i ,
+\qquad
+\tau_i = \overline{b u_i} - \bar b \, \bar u_i ,
+```
+
+where ``\tau_i`` is the sub-filter buoyancy flux and ``\bar q_i`` the closure's diffusive flux
+low-pass filtered, not recomputed from ``\bar b`` (the
+[dissipation section](@ref "The available potential energy dissipation of the filtered buoyancy")
+draws that distinction), so ``\Upsilon^l \, D^l \bar b / D t`` splits into two transport divergences
+plus the contractions ``\tau_i \, \partial_i \Upsilon^l`` and ``\bar q_i \, \partial_i \Upsilon^l``.
+Writing the advective part as a divergence as well (``\partial_i \bar u_i = 0``, since filtering
+preserves incompressibility), the filtered APE budget is
+
+```math
+\partial_t e_a^l = \underbrace{-\partial_i(\bar u_i e_a^l)}_{\text{advection}}
+                   \underbrace{-\,\bar w \, b_r^l}_{\text{APE to KE conversion}}
+                   \underbrace{-\,\Pi_a}_{\text{cross-scale flux}}
+                   \underbrace{-\,\partial_i\!\left[\Upsilon^l \left(\tau_i + \bar q_i\right)\right]}_{\text{sub-filter and diffusive transport}}
+                   \underbrace{-\,\varepsilon_a^l}_{\text{dissipation}}
+                   + \underbrace{R^l}_{\text{reference tendency}} ,
+```
+
+with
+
+```math
+\Pi_a = -\tau_i \, \partial_i \Upsilon^l ,
+\qquad
+\varepsilon_a^l = -\bar q_i \, \partial_i \Upsilon^l .
+```
+
+Term by term this is the full-field budget evaluated on the filtered state, plus one genuinely new
+term: the cross-scale flux ``\Pi_a``, which vanishes together with ``\tau_i`` as the filter tends to
+the identity while every other term collapses onto its full-field counterpart. ``\Pi_a`` reappears
+with the opposite sign in the [Sub-filter available potential energy equation](@ref), which is what
+makes it a transfer across the filter scale rather than a source or a sink. The conversion
+``\bar w \, b_r^l`` likewise reappears with the opposite sign in the
+[filtered kinetic energy](@ref "Filtered kinetic energy equation") budget, where it and
+``\bar w \, b^\star(z)``, the exchange with the background state, make up the buoyancy production
+``\bar w \bar b = \bar w \, b_r^l + \bar w \, b^\star``, mirroring the split
+``w b = w b_r + w \, b^\star`` of the full-field budget.
+
+The advective and transport divergences again redistribute ``e_a^l`` and integrate to zero over a
+periodic or closed domain. The reference tendency does not inherit that property:
+``\int R \, \mathrm{d}V = 0`` ([Winters et al., 1995](https://doi.org/10.1017/S002211209500125X))
+constrains only the sum of ``R^l`` and its sub-filter counterpart ``R^s = \overline{R} - R^l``, that
+is, ``\int R^l \, \mathrm{d}V = -\int R^s \, \mathrm{d}V``, so an evolving reference profile
+redistributes APE across the filter scale as well as in space
+([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)). With a reference profile held
+fixed in time (a [`ProfileLookup`](@ref Oceanostics.BackgroundPotentialEnergyEquation.ProfileLookup)
+holding plain arrays) ``R^l`` vanishes identically.
+
+## Terms and diagnostics
+
+Five of the quantities above have diagnostics; the two transport divergences, the anomaly
+``b_r^l``, and the reference tendency have none.
+
+| Quantity | Expression | Diagnostic |
+|:---|:---|:---|
+| Filtered available potential energy | ``e_a^l = e_a(\bar b, z)`` | [`FilteredAvailablePotentialEnergy`](@ref) |
+| Displacement potential | ``\Upsilon^l = z^\star(\bar b) - z`` | [`AvailablePotentialEnergyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential) on a reference height built from ``\bar b`` |
+| Advection | ``\partial_i(\bar u_i e_a^l)`` | not implemented |
+| Buoyancy anomaly | ``b_r^l = \bar b - b^\star(z, t)`` | not implemented |
+| APE to KE conversion | ``\bar w \, b_r^l`` | [`FilteredAvailablePotentialToKineticEnergyConversion`](@ref) |
+| Cross-scale flux | ``\Pi_a = -\tau_i \, \partial_i \Upsilon^l`` | [`AvailablePotentialEnergyCrossScaleFlux`](@ref) |
+| Sub-filter and diffusive transport | ``\partial_i\left[\Upsilon^l (\tau_i + \bar q_i)\right]`` | not implemented |
+| Dissipation | ``\varepsilon_a^l = -\bar q_i \, \partial_i \Upsilon^l`` | [`FilteredAvailablePotentialEnergyDissipationRate`](@ref) |
+| Reference tendency | ``R^l = \int_{z^\star(\bar b)}^{z} \partial_t b^\star(\tilde z, t) \, \mathrm{d}\tilde z`` | not implemented |
+
 ## The available potential energy dissipation of the filtered buoyancy
 
 The diffusive sink of the ``e_a^l`` budget is
 
 ```math
-\varepsilon_a^l = -\tilde q_i \, \partial_i \Upsilon^l ,
+\varepsilon_a^l = -\bar q_i \, \partial_i \Upsilon^l ,
 \qquad
-\Upsilon^l = z^\star(\tilde b) - z ,
+\Upsilon^l = z^\star(\bar b) - z ,
 ```
 
 computed by [`FilteredAvailablePotentialEnergyDissipationRate`](@ref): the full-field contraction
 ``\varepsilon_a = -q_i \partial_i \Upsilon``
 ([`AvailablePotentialEnergyDissipationRate`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate))
-evaluated on the filtered state, with ``\tilde q_i`` the closure's diffusive buoyancy flux low-pass
+evaluated on the filtered state, with ``\bar q_i`` the closure's diffusive buoyancy flux low-pass
 filtered and ``\Upsilon^l`` the displacement potential
 ([`DisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential))
-of the filtered buoyancy. The flux is filtered, not recomputed from ``\tilde b``: the filtered buoyancy
-equation carries the divergence of the filtered flux, so ``-\tilde q_i \partial_i \Upsilon^l`` is the
+of the filtered buoyancy. The flux is filtered, not recomputed from ``\bar b``: the filtered buoyancy
+equation carries the divergence of the filtered flux, so ``-\bar q_i \partial_i \Upsilon^l`` is the
 dissipation that appears in the filtered-state budget. The two forms agree for a constant diffusivity
 and differ once ``\kappa`` varies in space, the same distinction the
 [Filtered kinetic energy equation](@ref) draws for the viscous flux.

--- a/docs/src/filtered_available_potential_energy_equation.md
+++ b/docs/src/filtered_available_potential_energy_equation.md
@@ -20,7 +20,7 @@ the only method of obtaining the reference height that has this capability.
 ## Deriving the filtered available potential energy equation
 
 The budget of ``e_a^l`` retraces the
-[full-field derivation](@ref "Deriving the local available potential energy equation") with the
+[full-APE derivation](@ref "Deriving the local available potential energy equation") with the
 filtered buoyancy taking the place of ``b`` and the material derivative taken along the *filtered*
 flow, ``D^l/Dt = \partial_t + \bar u_i \partial_i``
 ([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)):
@@ -41,38 +41,37 @@ which we can simplify to
 R^l = \int_{z^\star(\bar b)}^{z} \partial_t b^\star(\tilde z, t) \, \mathrm{d}\tilde z .
 ```
 
-Since ``e_a^l`` is the function ``e_a`` evaluated at ``(\bar b, z)``, both partial derivatives are
-the full-field ones taken at the filtered state; in the first, the boundary term from moving the
-lower limit ``z^\star(\bar b)`` again drops out, now because ``b^\star(z^\star(\bar b)) = \bar b``.
-They give the displacement potential and the buoyancy anomaly *of the filtered buoyancy*:
+We can then evaluate the partial derivatives above from the definition of ``e_a^l``, similarly to the
+``e_a`` derivation. In the first we get an "empty" integral from ``z^\star`` to ``z``, which produces
+the displacement potential of the filtered buoyancy ``\Upsilon^l``. The second simplifies to the integrand of ``e_a^l``, producing
+the buoyancy anomaly ``b_r^l``:
 
 ```math
-\left.\frac{\partial e_a^l}{\partial \bar b}\right|_{z} = z^\star(\bar b) - z = \Upsilon^l ,
+\left.\frac{\partial e_a^l}{\partial \bar b}\right|_{z} = z^\star(\bar b, t) - z = \Upsilon^l ,
 \qquad
 \left.\frac{\partial e_a^l}{\partial z}\right|_{\bar b} = b^\star(z, t) - \bar b = -b_r^l .
 ```
 
-Differentiating in ``z`` at fixed ``\bar b`` never touches the reference profile, so the anomaly
-that appears is ``b_r^l = \bar b - b^\star(z, t)``, the filtered buoyancy against the *unfiltered*
-profile, and not ``\overline{b_r}``; the note in
-[Conversion to filtered kinetic energy](@ref) below returns to this distinction.
+Note that ``\Upsilon^l`` is different from ``\Upsilon`` since it includes ``z^\star(\bar b, t)`` and *not*
+``z^\star(b, t)``. The former is the reference height of the filtered buoyancy: the height at which a parcel
+of the _filtered_ buoyancy would sit in the reference profile _unfiltered_ buoyancy.
+Similarly, the buoyancy anomaly ``b_r^l`` is measured against the reference profile of the full, unfiltered
+buoyancy ``b^\star(z, t)`` -- the reference profile of the _filtered_ buoyancy does not appear anywhere in this equation.
 
 The material derivative of the filtered buoyancy comes from filtering
 [the tracer equation](tracer_equation.md) of ``b`` (the filter commutes with derivatives) and
 splitting the filtered advective flux into a resolved and a sub-filter part,
-``\overline{u_i b} = \bar u_i \, \bar b + \tau_i``:
+``\overline{u_i b} = \bar u_i \, \bar b + \tau(u_i, b)``:
 
 ```math
-\frac{D^l \bar b}{D t} = -\partial_i \tau_i - \partial_i \bar q_i ,
+\frac{D^l \bar b}{D t} = -\partial_i \tau(u_i, b) - \partial_i \bar q_i ,
 \qquad
-\tau_i = \overline{b u_i} - \bar b \, \bar u_i ,
+\tau(u_i, b) = \overline{b u_i} - \bar b \, \bar u_i ,
 ```
 
-where ``\tau_i`` is the sub-filter buoyancy flux and ``\bar q_i`` the closure's diffusive flux
-low-pass filtered, not recomputed from ``\bar b`` (the
-[dissipation section](@ref "The available potential energy dissipation of the filtered buoyancy")
-draws that distinction), so ``\Upsilon^l \, D^l \bar b / D t`` splits into two transport divergences
-plus the contractions ``\tau_i \, \partial_i \Upsilon^l`` and ``\bar q_i \, \partial_i \Upsilon^l``.
+where ``\tau(u_i, b)`` is the sub-filter buoyancy flux and ``\bar q_i`` is the filtered closure's diffusive flux
+low-pass filtered. The term ``\Upsilon^l \, D^l \bar b / D t`` splits into two transport divergences
+plus the contractions ``\tau(u_i, b) \, \partial_i \Upsilon^l`` and ``\bar q_i \, \partial_i \Upsilon^l``.
 Writing the advective part as a divergence as well (``\partial_i \bar u_i = 0``, since filtering
 preserves incompressibility), the filtered APE budget is
 
@@ -80,7 +79,7 @@ preserves incompressibility), the filtered APE budget is
 \partial_t e_a^l = \underbrace{-\partial_i(\bar u_i e_a^l)}_{\text{advection}}
                    \underbrace{-\,\bar w \, b_r^l}_{\text{APE to KE conversion}}
                    \underbrace{-\,\Pi_a}_{\text{cross-scale flux}}
-                   \underbrace{-\,\partial_i\!\left[\Upsilon^l \left(\tau_i + \bar q_i\right)\right]}_{\text{sub-filter and diffusive transport}}
+                   \underbrace{-\,\partial_i\!\left[\Upsilon^l \left(\tau(u_i, b) + \bar q_i\right)\right]}_{\text{sub-filter and diffusive transport}}
                    \underbrace{-\,\varepsilon_a^l}_{\text{dissipation}}
                    + \underbrace{R^l}_{\text{reference tendency}} ,
 ```
@@ -88,30 +87,25 @@ preserves incompressibility), the filtered APE budget is
 with
 
 ```math
-\Pi_a = -\tau_i \, \partial_i \Upsilon^l ,
+\Pi_a = -\tau(u_i, b) \, \partial_i \Upsilon^l ,
 \qquad
 \varepsilon_a^l = -\bar q_i \, \partial_i \Upsilon^l .
 ```
 
-Term by term this is the full-field budget evaluated on the filtered state, plus one genuinely new
-term: the cross-scale flux ``\Pi_a``, which vanishes together with ``\tau_i`` as the filter tends to
-the identity while every other term collapses onto its full-field counterpart. ``\Pi_a`` reappears
-with the opposite sign in the [Sub-filter available potential energy equation](@ref), which is what
-makes it a transfer across the filter scale rather than a source or a sink. The conversion
+Term by term this is the full-field budget evaluated on the filtered state plus extra terms
+related to the filter (``\Pi_a`` and ``-\partial_j\Upsilon^l \tau(u_i, b)``). ``\Pi_a`` reappears
+with the opposite sign in the [Sub-filter available potential energy equation](@ref), which makes
+it a transfer across the filter scale rather than a source or a sink, and the conversion
 ``\bar w \, b_r^l`` likewise reappears with the opposite sign in the
-[filtered kinetic energy](@ref "Filtered kinetic energy equation") budget, where it and
-``\bar w \, b^\star(z)``, the exchange with the background state, make up the buoyancy production
-``\bar w \bar b = \bar w \, b_r^l + \bar w \, b^\star``, mirroring the split
-``w b = w b_r + w \, b^\star`` of the full-field budget.
+[filtered kinetic energy](@ref "Filtered kinetic energy equation") budget.
 
-The advective and transport divergences again redistribute ``e_a^l`` and integrate to zero over a
-periodic or closed domain. The reference tendency does not inherit that property:
-``\int R \, \mathrm{d}V = 0`` ([Winters et al., 1995](https://doi.org/10.1017/S002211209500125X))
-constrains only the sum of ``R^l`` and its sub-filter counterpart ``R^s = \overline{R} - R^l``, that
-is, ``\int R^l \, \mathrm{d}V = -\int R^s \, \mathrm{d}V``, so an evolving reference profile
+Importantly, while ``R`` integrates to zero in a closed domain ([Winters et al., 1995](https://doi.org/10.1017/S002211209500125X)),
+``R^l`` does not inherit that property. Given its subfilter counterpart ``R^s = \overline{R} - R^l``
+appears in the [Sub-filter available potential energy equation](@ref), we get that
+``\int R^l \, \mathrm{d}V = -\int R^s \, \mathrm{d}V``. Thus, interestingly, an evolving reference profile
 redistributes APE across the filter scale as well as in space
 ([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)). With a reference profile held
-fixed in time (a [`ProfileLookup`](@ref Oceanostics.BackgroundPotentialEnergyEquation.ProfileLookup)
+fixed in time (implemented here with a [`ProfileLookup`](@ref Oceanostics.BackgroundPotentialEnergyEquation.ProfileLookup)
 holding plain arrays) ``R^l`` vanishes identically.
 
 ## Terms and diagnostics
@@ -126,85 +120,18 @@ Five of the quantities above have diagnostics; the two transport divergences, th
 | Advection | ``\partial_i(\bar u_i e_a^l)`` | not implemented |
 | Buoyancy anomaly | ``b_r^l = \bar b - b^\star(z, t)`` | not implemented |
 | APE to KE conversion | ``\bar w \, b_r^l`` | [`FilteredAvailablePotentialToKineticEnergyConversion`](@ref) |
-| Cross-scale flux | ``\Pi_a = -\tau_i \, \partial_i \Upsilon^l`` | [`AvailablePotentialEnergyCrossScaleFlux`](@ref) |
-| Sub-filter and diffusive transport | ``\partial_i\left[\Upsilon^l (\tau_i + \bar q_i)\right]`` | not implemented |
+| Cross-scale flux | ``\Pi_a = -\tau(u_i, b) \, \partial_i \Upsilon^l`` | [`AvailablePotentialEnergyCrossScaleFlux`](@ref) |
+| Sub-filter and diffusive transport | ``\partial_i\left[\Upsilon^l (\tau(u_i, b) + \bar q_i)\right]`` | not implemented |
 | Dissipation | ``\varepsilon_a^l = -\bar q_i \, \partial_i \Upsilon^l`` | [`FilteredAvailablePotentialEnergyDissipationRate`](@ref) |
 | Reference tendency | ``R^l = \int_{z^\star(\bar b)}^{z} \partial_t b^\star(\tilde z, t) \, \mathrm{d}\tilde z`` | not implemented |
 
-## The available potential energy dissipation of the filtered buoyancy
+## Summary of ``e_a^l`` equation terms
 
-The diffusive sink of the ``e_a^l`` budget is
-
-```math
-\varepsilon_a^l = -\bar q_i \, \partial_i \Upsilon^l ,
-\qquad
-\Upsilon^l = z^\star(\bar b) - z ,
-```
-
-computed by [`FilteredAvailablePotentialEnergyDissipationRate`](@ref): the full-field contraction
-``\varepsilon_a = -q_i \partial_i \Upsilon``
-([`AvailablePotentialEnergyDissipationRate`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDissipationRate))
-evaluated on the filtered state, with ``\bar q_i`` the closure's diffusive buoyancy flux low-pass
-filtered and ``\Upsilon^l`` the displacement potential
-([`DisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential))
-of the filtered buoyancy. The flux is filtered, not recomputed from ``\bar b``: the filtered buoyancy
-equation carries the divergence of the filtered flux, so ``-\bar q_i \partial_i \Upsilon^l`` is the
-dissipation that appears in the filtered-state budget. The two forms agree for a constant diffusivity
-and differ once ``\kappa`` varies in space, the same distinction the
-[Filtered kinetic energy equation](@ref) draws for the viscous flux.
+<!--TODO: Add Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergyDisplacementPotential-->
 
 ```@docs
-Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergyDissipationRate
-```
-
-## Cross-scale available potential energy flux
-
-```math
-\Pi_a = -\tau_i \, \partial_i \Upsilon^l , \qquad
-\tau_i = \overline{b u_i} - \bar b \, \bar u_i , \qquad
-\Upsilon^l = z^\star(\bar b) - z
-```
-
-is the rate at which the filter transfers available potential energy from the filtered to the
-sub-filter scales, the APE analogue of the
-[cross-scale kinetic energy flux](filtered_kinetic_energy_equation.md) ``\Pi_k = -\tau^{ij}\bar S^{ij}``:
-the sub-filter buoyancy flux takes the place of the sub-filter stress, and ``\nabla\Upsilon^l`` takes
-the place of the resolved strain. ``\Pi_a > 0`` is forward (downscale) transfer. It enters the filtered
-APE budget as ``-\Pi_a`` and the sub-filter one as ``+\Pi_a``, which is what makes it a transfer rather
-than a source or a sink ([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)).
-
-```@docs
-Oceanostics.FilteredAvailablePotentialEnergyEquation.AvailablePotentialEnergyCrossScaleFlux
-```
-
-## Conversion to filtered kinetic energy
-
-The filtered APE and the [filtered kinetic energy](@ref "Filtered kinetic energy equation") exchange
-energy at a rate
-
-```math
-\bar w \, b_r^l ,
-\qquad
-b_r^l = \bar b - b^\star(z) ,
-```
-
-computed by [`FilteredAvailablePotentialToKineticEnergyConversion`](@ref). Here ``b_r^l`` is the
-buoyancy anomaly of the filtered field against the reference state, with ``b^\star(z)`` the reference
-profile read at the parcel's **own height** ``z`` rather than at the reference height ``z^\star`` its
-buoyancy would take it to — the inverse of the map every other diagnostic on this page uses.
-
-The term appears in the filtered APE budget as ``-\bar w\,b_r^l`` and in the filtered kinetic energy
-budget as ``+\bar w\,b_r^l`` ([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879),
-Eqs. 2.10 and 3.2), so it is a reversible exchange rather than a source or a sink: ``\bar w\,b_r^l > 0``
-converts filtered APE into filtered KE.
-
-!!! note "The reference profile is not filtered"
-    ``b_r^l = \bar b - b^\star(z)`` pairs the *filtered* buoyancy with the *unfiltered* reference
-    profile, consistent with ``e_a^l`` itself being measured against the full field's reference state.
-    It is not ``\overline{b_r} = \bar b - \overline{b^\star(z)}``, which filters the reference too.
-    The two differ once the filter acts in the vertical; for a purely horizontal filter they coincide,
-    since ``b^\star`` is a function of ``z`` alone.
-
-```@docs
+Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergy
 Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialToKineticEnergyConversion
+Oceanostics.FilteredAvailablePotentialEnergyEquation.AvailablePotentialEnergyCrossScaleFlux
+Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergyDissipationRate
 ```

--- a/docs/src/filtered_available_potential_energy_equation.md
+++ b/docs/src/filtered_available_potential_energy_equation.md
@@ -116,7 +116,7 @@ Five of the quantities above have diagnostics; the two transport divergences, th
 | Quantity | Expression | Diagnostic |
 |:---|:---|:---|
 | Filtered available potential energy | ``e_a^l = e_a(\bar b, z)`` | [`FilteredAvailablePotentialEnergy`](@ref) |
-| Displacement potential | ``\Upsilon^l = z^\star(\bar b) - z`` | [`AvailablePotentialEnergyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential) on a reference height built from ``\bar b`` |
+| Displacement potential | ``\Upsilon^l = z^\star(\bar b) - z`` | [`FilteredAvailablePotentialEnergyDisplacementPotential`](@ref) |
 | Advection | ``\partial_i(\bar u_i e_a^l)`` | not implemented |
 | Buoyancy anomaly | ``b_r^l = \bar b - b^\star(z, t)`` | not implemented |
 | APE to KE conversion | ``\bar w \, b_r^l`` | [`FilteredAvailablePotentialToKineticEnergyConversion`](@ref) |
@@ -125,12 +125,17 @@ Five of the quantities above have diagnostics; the two transport divergences, th
 | Dissipation | ``\varepsilon_a^l = -\bar q_i \, \partial_i \Upsilon^l`` | [`FilteredAvailablePotentialEnergyDissipationRate`](@ref) |
 | Reference tendency | ``R^l = \int_{z^\star(\bar b)}^{z} \partial_t b^\star(\tilde z, t) \, \mathrm{d}\tilde z`` | not implemented |
 
-## Summary of ``e_a^l`` equation terms
+``\Upsilon^l`` also answers to `DisplacementPotential`, and ``\varepsilon_a^l`` to `DissipationRate`.
+Both aliases are scoped to this module, as their full-field namesakes are to
+[the available potential energy equation](available_potential_energy_equation.md): `using
+Oceanostics.FilteredAvailablePotentialEnergyEquation` brings them in, `using Oceanostics` does not,
+since unprefixed neither name says which budget it belongs to nor at which scale.
 
-<!--TODO: Add Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergyDisplacementPotential-->
+## Summary of ``e_a^l`` equation terms
 
 ```@docs
 Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergy
+Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergyDisplacementPotential
 Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialToKineticEnergyConversion
 Oceanostics.FilteredAvailablePotentialEnergyEquation.AvailablePotentialEnergyCrossScaleFlux
 Oceanostics.FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergyDissipationRate

--- a/docs/src/filtered_available_potential_energy_equation.md
+++ b/docs/src/filtered_available_potential_energy_equation.md
@@ -10,7 +10,7 @@ of the filtered flow as
 e_a^l = e_a(\bar b, z, t) = \int_{z^\star(\bar b, t)}^{z} \left[b^\star(\tilde z, t) - \bar b\right] \mathrm{d}\tilde z ,
 ```
 computed by [`FilteredAvailablePotentialEnergy`](@ref). Note that the reference profile ``b^\star(z^\star)``
-is the reference state of the *full buoyancy* ``b``, rather than sorted from ``\bar b`` itself.
+is the reference state of the *full buoyancy* ``b``, rather than sorted from ``\bar b``.
 Because of this, it is necessary to look up the position of a buoyancy parcel in the filtered fields
 in the full reference profile ``b^\star(z^\star)`` in calculating some terms, which makes it necessary
 to use [`ProfileLookup`](@ref Oceanostics.BackgroundPotentialEnergyEquation.ProfileLookup), since it's

--- a/docs/src/subfilter_available_potential_energy_equation.md
+++ b/docs/src/subfilter_available_potential_energy_equation.md
@@ -24,17 +24,16 @@ e_a(b, z) = \int_{z^\star(b)}^{z} \left[b^\star(\tilde z) - b\right] \mathrm{d}\
 ```
 
 computed by [`SubFilterAvailablePotentialEnergy`](@ref); ``e_a(\bar b, z)`` is
-[`FilteredAvailablePotentialEnergy`](@ref). Looking the filtered buoyancy up in a profile
-it did not itself produce is exactly what
+[`FilteredAvailablePotentialEnergy`](@ref).
+
+``e_a^s`` is guaranteed to be non-negative only when the filter acts in the horizontal directions.
+
+Looking the filtered buoyancy up in a profile it did not itself produce is exactly what
 [`ProfileLookup`](@ref Oceanostics.BackgroundPotentialEnergyEquation.ProfileLookup) was built for, so
 these diagnostics accept only that reference-height method: the default sorts the model's own buoyancy
 into a [`VerticalSort`](@ref Oceanostics.BackgroundPotentialEnergyEquation.VerticalSort) column on
 every `compute!`, a column you built yourself can be shared across diagnostics, and a profile given as
 plain arrays holds the reference state fixed in time (which also makes the diagnostics sort-free).
-
-Because ``e_a`` is convex in buoyancy, a filter with no vertical component keeps ``e_a^s \geq 0``
-pointwise, by Jensen's inequality; a filter that acts vertically mixes heights as well as buoyancies
-and can produce locally negative values.
 
 ```@docs
 Oceanostics.SubFilterAvailablePotentialEnergyEquation.SubFilterAvailablePotentialEnergy

--- a/src/FilteredAvailablePotentialEnergyEquation.jl
+++ b/src/FilteredAvailablePotentialEnergyEquation.jl
@@ -3,6 +3,7 @@ module FilteredAvailablePotentialEnergyEquation
 using DocStringExtensions
 
 export FilteredAvailablePotentialEnergy
+export FilteredAvailablePotentialEnergyDisplacementPotential, DisplacementPotential
 export FilteredAvailablePotentialEnergyDissipationRate, DissipationRate
 export AvailablePotentialEnergyCrossScaleFlux, CrossScaleFlux
 export FilteredAvailablePotentialToKineticEnergyConversion
@@ -27,7 +28,7 @@ using ..BackgroundPotentialEnergyEquation: SortedReferenceHeightField, reference
                                            reference_buoyancy_at_height, VerticalSort, ProfileLookup,
                                            buoyancy_field
 using ..AvailablePotentialEnergyEquation: AvailablePotentialEnergy, AvailablePotentialEnergyDisplacementPotential,
-                                          AvailablePotentialEnergyDissipationRate, local_ape_ccc,
+                                          AvailablePotentialEnergyDissipationRate, local_ape_ccc, upsilon_ccc,
                                           validate_reference_height_grid
 # `GaussianFilter` builds the convenience methods' filter; `BoxFilter` is imported only so its docstring
 # `@ref` resolves in-module.
@@ -169,6 +170,106 @@ FilteredAvailablePotentialEnergy(model; σ, dims = (1, 2, 3), boundary = :shrink
     FilteredAvailablePotentialEnergy(model, GaussianFilter(; dims, σ, boundary, N); kwargs...)
 #---
 
+#+++ Filtered displacement potential
+# Υˡ = z✶(b̄) - z, the displacement potential of the filtered buoyancy: the same `upsilon_ccc` kernel as
+# the full-field `Υ`, evaluated on the reference height `z✶ˡ` built from `b̄`. Wrapping it under a
+# distinct kernel name gives it its own type alias and `@diagnostic_show` display, exactly as
+# `FilteredAvailablePotentialEnergy` wraps `local_ape_ccc`.
+@inline filtered_upsilon_ccc(i, j, k, grid, args...) = upsilon_ccc(i, j, k, grid, args...)
+
+const FilteredAvailablePotentialEnergyDisplacementPotential = CustomKFO{<:typeof(filtered_upsilon_ccc)}
+# Short enough to read beside the other terms of an `eₐˡ` budget, and scoped to this module the way
+# `DissipationRate` is: `using Oceanostics` does not bring it in, since unprefixed it says neither which
+# budget's displacement it is nor at which scale.
+const DisplacementPotential = FilteredAvailablePotentialEnergyDisplacementPotential
+
+"""
+    $(SIGNATURES)
+
+Return the displacement potential of the filtered buoyancy field `Υˡ`, how far below its actual height
+the reference height of the filtered buoyancy sits:
+
+```
+    Υˡ = z✶(b̄) - z ,   b̄ = filter(b)
+```
+
+It is the full-field displacement potential `Υ = z✶ - z`
+([`AvailablePotentialEnergyDisplacementPotential`](@ref)) evaluated on the filtered state, and it is
+the derivative of the filtered available potential energy with respect to the filtered buoyancy,
+`Υˡ = ∂eₐˡ/∂b̄` ([`FilteredAvailablePotentialEnergy`](@ref)). That is what makes it the field the
+filtered APE budget contracts its fluxes against, following the filtered APE framework of
+[Wenegrat, Chor & Barkan (2026)](https://arxiv.org/abs/2605.15879): against the filtered diffusive
+flux it gives the dissipation
+[`FilteredAvailablePotentialEnergyDissipationRate`](@ref) `εₐˡ = -q̄ᵢ∂ᵢΥˡ`, and against the sub-filter
+buoyancy flux the cross-scale flux
+[`AvailablePotentialEnergyCrossScaleFlux`](@ref) `Πₐ = -τᵢ∂ᵢΥˡ`.
+
+As with every diagnostic here the filtered buoyancy is measured against the reference profile of the
+**full** field, so `method` has to be a [`ProfileLookup`](@ref), for the reason
+[`FilteredAvailablePotentialEnergy`](@ref) gives. The lookup also makes `z✶ˡ` a function of buoyancy
+alone, which is what differentiating `Υˡ` needs (see
+[`AvailablePotentialEnergyDisplacementPotential`](@ref)).
+
+A second method, `FilteredAvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)`, takes a reference
+height you built yourself from a filtered buoyancy, `z✶ˡ = reference_height(Field(filter(b));
+method=ProfileLookup(…))`, which is how one lookup is shared with the other filtered diagnostics. The
+filtered buoyancy is read off `z✶ˡ` itself, so no `filter` is needed there. Materialize the result with
+`Field` and hand it to those diagnostics through their `upsilon` keyword to compute a single `Υˡ` per
+output rather than one apiece.
+
+`filter` is any callable mapping a field to its low-pass-filtered counterpart, e.g. a reusable
+[`GaussianFilter`](@ref) or [`BoxFilter`](@ref). The filtered buoyancy is materialized as a `Field`
+internally (so the separable filter takes its fast staged path), and the returned object is a lazy
+operation over the reference height, ready for `Field`, `Integral` and `OutputWriter`s, re-filtering
+and re-sorting as the simulation evolves. It lives at `(Center, Center, Center)` and is a length
+(units `m`):
+
+```jldoctest
+using Oceananigans, Oceanostics
+
+grid = RectilinearGrid(size=(4, 4, 4), extent=(1, 1, 1), topology=(Periodic, Periodic, Bounded))
+model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
+
+filter = GaussianFilter(; dims=(1, 2, 3), σ=0.1)
+FilteredAvailablePotentialEnergyDisplacementPotential(model, filter)
+
+# output
+
+FilteredAvailablePotentialEnergyDisplacementPotential KernelFunctionOperation at (Center, Center, Center)
+├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
+├── kernel_function: filtered_upsilon_ccc (generic function with 1 method)
+└── arguments: ("Field",)
+└── computes: displacement potential of the filtered buoyancy  Υˡ = z✶(b̄) - z
+```
+
+`using Oceanostics.FilteredAvailablePotentialEnergyEquation` additionally brings in
+`DisplacementPotential`, short enough to read beside the other terms of an `eₐˡ` budget. That alias is
+scoped to this module, as `DissipationRate` is: `using Oceanostics` does not bring it in, since
+unprefixed it says neither which budget's displacement it names nor at which scale.
+
+A convenience method `FilteredAvailablePotentialEnergyDisplacementPotential(model; σ, dims, boundary, N)`
+builds the Gaussian `filter` for you from a standard deviation `σ` (with `σ = ℓ / (2√(2 ln 2))` for a
+FWHM `ℓ`). `geopotential_height` enters the buoyancy construction exactly as in [`reference_height`](@ref).
+"""
+function FilteredAvailablePotentialEnergyDisplacementPotential(model, filter; method = ProfileLookup(),
+                                                               geopotential_height = model_geopotential_height(model))
+    validate_gravity_is_z_aligned("FilteredAvailablePotentialEnergyDisplacementPotential", model)
+    z✶ˡ = filtered_reference_height("FilteredAvailablePotentialEnergyDisplacementPotential", model, filter, method,
+                                    geopotential_height)
+    return FilteredAvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)
+end
+
+# `AvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)` validates the gravity direction and that
+# `z✶ˡ` lives on the model grid; only the kernel name is swapped.
+function FilteredAvailablePotentialEnergyDisplacementPotential(model, z✶ˡ::SortedReferenceHeightField)
+    Υˡ = AvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)
+    return KernelFunctionOperation{Center, Center, Center}(filtered_upsilon_ccc, z✶ˡ.grid, Υˡ.arguments...)
+end
+
+FilteredAvailablePotentialEnergyDisplacementPotential(model; σ, dims = (1, 2, 3), boundary = :shrink, N = nothing, kwargs...) =
+    FilteredAvailablePotentialEnergyDisplacementPotential(model, GaussianFilter(; dims, σ, boundary, N); kwargs...)
+#---
+
 #+++ Filtered available potential energy dissipation rate
 # εₐˡ = -q̄ᵢ∂ᵢΥˡ, the `ape_dissipation_rate_ccc` contraction with the pre-filtered flux `Field`s read
 # directly in place of the inline `diffusive_flux_*` calls (the same substitution
@@ -199,7 +300,8 @@ which diffusion removes APE from the scales a low-pass `filter` keeps:
 
 It is the full-field contraction `εₐ = -qᵢ∂ᵢΥ` ([`AvailablePotentialEnergyDissipationRate`](@ref))
 evaluated on the filtered state: the closure's diffusive buoyancy flux `qᵢ` low-pass filtered, against
-the displacement potential `Υˡ` ([`AvailablePotentialEnergyDisplacementPotential`](@ref)) of the filtered buoyancy.
+the displacement potential of the filtered buoyancy `Υˡ`
+([`FilteredAvailablePotentialEnergyDisplacementPotential`](@ref)).
 It is the diffusive sink of the budget of [`FilteredAvailablePotentialEnergy`](@ref)
 ([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)), and it mirrors what
 [`FilteredKineticEnergyDissipationRate`](@ref Oceanostics.FilteredKineticEnergyEquation.FilteredKineticEnergyDissipationRate)
@@ -221,8 +323,9 @@ the closure diffuses (`BuoyancyTracer` only) and a closure that supplies a diffu
 
 A second method, `FilteredAvailablePotentialEnergyDissipationRate(model, filter, z✶ˡ; upsilon)`, takes
 a reference height you built from the filtered buoyancy (see [`FilteredAvailablePotentialEnergy`](@ref)),
-so one lookup can serve both diagnostics; `upsilon` takes a `Υˡ` you already have, so writing both out
-costs one `Υˡ` rather than two. `filter` is still needed there, to filter the fluxes.
+so one lookup can serve both diagnostics; `upsilon` takes a `Υˡ` you already have (a `Field` of
+[`FilteredAvailablePotentialEnergyDisplacementPotential`](@ref)), so writing both out costs one `Υˡ`
+rather than two. `filter` is still needed there, to filter the fluxes.
 
 `filter` is any callable mapping a field to its low-pass-filtered counterpart, e.g. a reusable
 [`GaussianFilter`](@ref) or [`BoxFilter`](@ref). The filtered fluxes, the filtered buoyancy and `Υˡ`
@@ -266,7 +369,7 @@ function FilteredAvailablePotentialEnergyDissipationRate(model, filter, z✶ˡ::
     validate_gravity_is_z_aligned("FilteredAvailablePotentialEnergyDissipationRate", model)
     validate_reference_height_grid("FilteredAvailablePotentialEnergyDissipationRate", model, z✶ˡ)
 
-    Υˡ = isnothing(upsilon) ? Field(AvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)) : upsilon
+    Υˡ = isnothing(upsilon) ? Field(FilteredAvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)) : upsilon
 
     # q̄ᵢ = filter(qᵢ(b)): the closure's diffusive fluxes of the FULL buoyancy, each low-pass filtered and
     # materialized at its staggered location. The flux operation reads the live model fields, so the
@@ -326,8 +429,7 @@ low-pass `filter` transfers available potential energy from the filtered to the 
 ```
 
 where `τᵢ` is the sub-filter buoyancy flux and `Υˡ` is the
-[`AvailablePotentialEnergyDisplacementPotential`](@ref Oceanostics.AvailablePotentialEnergyEquation.AvailablePotentialEnergyDisplacementPotential)
-of the filtered buoyancy. It is the APE analogue of
+[`FilteredAvailablePotentialEnergyDisplacementPotential`](@ref). It is the APE analogue of
 [`KineticEnergyCrossScaleFlux`](@ref Oceanostics.FilteredKineticEnergyEquation.KineticEnergyCrossScaleFlux),
 with the sub-filter buoyancy flux in place of the sub-filter stress and `∇Υˡ` in place of the resolved
 strain; `Πₐ > 0` is forward (downscale, filtered → sub-filter) transfer. It appears as `-Πₐ` in the
@@ -368,9 +470,10 @@ AvailablePotentialEnergyCrossScaleFlux KernelFunctionOperation at (Center, Cente
 
 A second method, `AvailablePotentialEnergyCrossScaleFlux(model, filter, z✶ˡ; upsilon, dims)`, takes a
 reference height you built from the filtered buoyancy (see [`FilteredAvailablePotentialEnergy`](@ref)),
-so one lookup — and, through `upsilon`, one `Υˡ` — can serve this flux and the other filtered-state
-diagnostics. The filtered buoyancy is read off `z✶ˡ` itself; `filter` is still needed there, to build
-the sub-filter buoyancy flux.
+so one lookup — and, through `upsilon`, one `Υˡ`
+([`FilteredAvailablePotentialEnergyDisplacementPotential`](@ref)) — can serve this flux and the other
+filtered-state diagnostics. The filtered buoyancy is read off `z✶ˡ` itself; `filter` is still needed
+there, to build the sub-filter buoyancy flux.
 
 A convenience method `AvailablePotentialEnergyCrossScaleFlux(model; σ, dims, boundary, N)` builds the
 Gaussian `filter` for you from a standard deviation `σ` (with `σ = ℓ / (2√(2 ln 2))` for a FWHM `ℓ`).
@@ -390,7 +493,7 @@ function AvailablePotentialEnergyCrossScaleFlux(model, filter, z✶ˡ::SortedRef
     validate_gravity_is_z_aligned("AvailablePotentialEnergyCrossScaleFlux", model)
     validate_reference_height_grid("AvailablePotentialEnergyCrossScaleFlux", model, z✶ˡ)
 
-    Υˡ = isnothing(upsilon) ? Field(AvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)) : upsilon
+    Υˡ = isnothing(upsilon) ? Field(FilteredAvailablePotentialEnergyDisplacementPotential(model, z✶ˡ)) : upsilon
 
     # The filtered buoyancy is `z✶ˡ`'s own (the field the caller filtered and looked up), so the one `b̄`
     # serves both the reference height — and so `Υˡ` — and the sub-filter buoyancy flux: the buoyancy is

--- a/src/FilteredAvailablePotentialEnergyEquation.jl
+++ b/src/FilteredAvailablePotentialEnergyEquation.jl
@@ -202,7 +202,7 @@ filtered APE budget contracts its fluxes against, following the filtered APE fra
 flux it gives the dissipation
 [`FilteredAvailablePotentialEnergyDissipationRate`](@ref) `εₐˡ = -q̄ᵢ∂ᵢΥˡ`, and against the subfilter
 buoyancy flux the cross-scale flux
-[`AvailablePotentialEnergyCrossScaleFlux`](@ref) `Πₐ = -τᵢ∂ᵢΥˡ`.
+[`AvailablePotentialEnergyCrossScaleFlux`](@ref) `Πₐ = -τ(uᵢ, b)∂ᵢΥˡ`.
 
 As with every diagnostic here the filtered buoyancy is measured against the reference profile of the
 **full** field, so `method` has to be a [`ProfileLookup`](@ref), for the reason
@@ -388,15 +388,15 @@ FilteredAvailablePotentialEnergyDissipationRate(model; σ, dims = (1, 2, 3), bou
 #---
 
 #+++ Cross-scale available-potential-energy flux
-# Πₐ = -τᵢ ∂ᵢΥˡ, the APE analogue of `KineticEnergyCrossScaleFlux`'s Πₖ = -τᵢⱼS̄ᵢⱼ. The subfilter
-# buoyancy flux τᵢ = filter(buᵢ) - b̄ūᵢ takes the place of the subfilter stress, and the gradient of
+# Πₐ = -τ(uᵢ, b) ∂ᵢΥˡ, the APE analogue of `KineticEnergyCrossScaleFlux`'s Πₖ = -τᵢⱼS̄ᵢⱼ. The subfilter
+# buoyancy flux τ(uᵢ, b) = filter(buᵢ) - b̄ūᵢ takes the place of the subfilter stress, and the gradient of
 # the filtered-state displacement potential Υˡ takes the place of the resolved strain. Every factor is
 # interpolated to (Center, Center, Center) before multiplying (via `FlowDiagnostics`' shared
 # `to_center`), matching the contraction convention of the kinetic-energy flux.
 """
     $(SIGNATURES)
 
-The subfilter buoyancy flux `τᵢ = filter(b uᵢ) - b̄ ūᵢ` for the directions in `dims`, as a `NamedTuple`
+The subfilter buoyancy flux `τ(uᵢ, b) = filter(b uᵢ) - b̄ ūᵢ` for the directions in `dims`, as a `NamedTuple`
 keyed `τ₁`, `τ₂`, `τ₃`:
 [`subfilter_covariance`](@ref Oceanostics.FlowDiagnostics.subfilter_covariance) applied per direction,
 with the caller's pre-filtered buoyancy `b̄` shared across the components through its `filtered_a`
@@ -425,10 +425,10 @@ low-pass `filter` transfers available potential energy from the filtered to the 
 ([Wenegrat, Chor & Barkan, 2026](https://arxiv.org/abs/2605.15879)):
 
 ```
-    Πₐ = -τᵢ ∂ᵢΥˡ ,   τᵢ = filter(b uᵢ) - b̄ ūᵢ ,   Υˡ = z✶(b̄) - z
+    Πₐ = -τ(uᵢ, b) ∂ᵢΥˡ ,   τ(uᵢ, b) = filter(b uᵢ) - b̄ ūᵢ ,   Υˡ = z✶(b̄) - z
 ```
 
-where `τᵢ` is the subfilter buoyancy flux and `Υˡ` is the
+where `τ(uᵢ, b)` is the subfilter buoyancy flux (the `subfilter_covariance` of `uᵢ` and `b`) and `Υˡ` is the
 [`FilteredAvailablePotentialEnergyDisplacementPotential`](@ref). It is the APE analogue of
 [`KineticEnergyCrossScaleFlux`](@ref Oceanostics.FilteredKineticEnergyEquation.KineticEnergyCrossScaleFlux),
 with the subfilter buoyancy flux in place of the subfilter stress and `∇Υˡ` in place of the resolved
@@ -465,7 +465,7 @@ AvailablePotentialEnergyCrossScaleFlux KernelFunctionOperation at (Center, Cente
 ├── grid: 4×4×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 3×3×3 halo
 ├── kernel_function: cross_scale_ape_flux_ccc (generic function with 1 method)
 └── arguments: ("Oceananigans.AbstractOperations.UnaryOperation",)
-└── computes: cross-scale available potential energy flux  -τᵢ∂ᵢΥˡ
+└── computes: cross-scale available potential energy flux  -τ(uᵢ, b)∂ᵢΥˡ
 ```
 
 A second method, `AvailablePotentialEnergyCrossScaleFlux(model, filter, z✶ˡ; upsilon, dims)`, takes a
@@ -502,7 +502,7 @@ function AvailablePotentialEnergyCrossScaleFlux(model, filter, z✶ˡ::SortedRef
     b̄ = reference_buoyancy(z✶ˡ.operand)
     τ = subfilter_buoyancy_flux(filter, b, b̄, model.velocities, dims)
 
-    ∂ᵢ = (∂x, ∂y, ∂z)   # the τᵢ are already at cell centers, so only the gradient needs collocating
+    ∂ᵢ = (∂x, ∂y, ∂z)   # the τ(uᵢ, b) are already at cell centers, so only the gradient needs collocating
     Πᵃ = -sum(τ[Symbol(:τ, ('₁', '₂', '₃')[d])] * to_center(∂ᵢ[d](Υˡ)) for d in dims)
 
     return KernelFunctionOperation{Center, Center, Center}(cross_scale_ape_flux_ccc, model.grid, Πᵃ)

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -95,7 +95,8 @@ export ReferenceBuoyancyAnomaly, AvailablePotentialToKineticEnergyConversion
 #---
 
 #+++ FilteredAvailablePotentialEnergyEquation exports
-export FilteredAvailablePotentialEnergy, FilteredAvailablePotentialEnergyDissipationRate
+export FilteredAvailablePotentialEnergy, FilteredAvailablePotentialEnergyDisplacementPotential
+export FilteredAvailablePotentialEnergyDissipationRate
 export AvailablePotentialEnergyCrossScaleFlux, FilteredAvailablePotentialToKineticEnergyConversion
 #---
 
@@ -465,6 +466,7 @@ end
 
 #+++ FilteredAvailablePotentialEnergyEquation
 @diagnostic_show FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergy                "FilteredAvailablePotentialEnergy"                "available potential energy of the filtered buoyancy  eₐˡ = eₐ(b̄, z)"
+@diagnostic_show FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergyDisplacementPotential "FilteredAvailablePotentialEnergyDisplacementPotential" "displacement potential of the filtered buoyancy  Υˡ = z✶(b̄) - z"
 @diagnostic_show FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergyDissipationRate "FilteredAvailablePotentialEnergyDissipationRate" "available potential energy dissipation rate of the filtered buoyancy  εₐˡ = -q̄ᵢ∂ᵢΥˡ"
 @diagnostic_show FilteredAvailablePotentialEnergyEquation.AvailablePotentialEnergyCrossScaleFlux            "AvailablePotentialEnergyCrossScaleFlux"            "cross-scale available potential energy flux  Πₐ = -τᵢ∂ᵢΥˡ"
 @diagnostic_show FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialToKineticEnergyConversion "FilteredAvailablePotentialToKineticEnergyConversion" "filtered APE to filtered KE conversion  w̄b_rˡ = w̄(b̄ - b✶(z))"

--- a/src/Oceanostics.jl
+++ b/src/Oceanostics.jl
@@ -468,7 +468,7 @@ end
 @diagnostic_show FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergy                "FilteredAvailablePotentialEnergy"                "available potential energy of the filtered buoyancy  eₐ(b̄, z)"
 @diagnostic_show FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergyDisplacementPotential "FilteredAvailablePotentialEnergyDisplacementPotential" "displacement potential of the filtered buoyancy  z✶(b̄) - z"
 @diagnostic_show FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialEnergyDissipationRate "FilteredAvailablePotentialEnergyDissipationRate" "available potential energy dissipation rate of the filtered buoyancy  -q̄ᵢ∂ᵢΥˡ"
-@diagnostic_show FilteredAvailablePotentialEnergyEquation.AvailablePotentialEnergyCrossScaleFlux            "AvailablePotentialEnergyCrossScaleFlux"            "cross-scale available potential energy flux  -τᵢ∂ᵢΥˡ"
+@diagnostic_show FilteredAvailablePotentialEnergyEquation.AvailablePotentialEnergyCrossScaleFlux            "AvailablePotentialEnergyCrossScaleFlux"            "cross-scale available potential energy flux  -τ(uᵢ, b)∂ᵢΥˡ"
 @diagnostic_show FilteredAvailablePotentialEnergyEquation.FilteredAvailablePotentialToKineticEnergyConversion "FilteredAvailablePotentialToKineticEnergyConversion" "filtered APE to filtered KE conversion  w̄(b̄ - b✶(z))"
 #---
 

--- a/test/test_filtered_ape_diagnostics.jl
+++ b/test/test_filtered_ape_diagnostics.jl
@@ -265,9 +265,9 @@ end
 
 
 """
-Πₐ = -τᵢ ∂ᵢΥˡ rebuilt from raw filter calls (`filter(b uᵢ) - b̄ ūᵢ`, every factor collocated at cell
+Πₐ = -τ(uᵢ, b) ∂ᵢΥˡ rebuilt from raw filter calls (`filter(b uᵢ) - b̄ ūᵢ`, every factor collocated at cell
 centers) contracted with the gradient of the filtered-state displacement potential. The diagnostic
-itself builds τᵢ through `subfilter_covariance`, so the manual construction here deliberately does
+itself builds τ(uᵢ, b) through `subfilter_covariance`, so the manual construction here deliberately does
 not: the comparison pins the covariance, the sign, the directions summed over, and the co-location of
 every factor independently — which no approximate check could separate.
 """
@@ -300,7 +300,7 @@ end
 
 """
 The flux is a *transfer*: with no motion there is no subfilter buoyancy flux to carry APE across the
-filter scale, so τᵢ and hence Πₐ vanish identically however sharp the buoyancy is. This is the check
+filter scale, so τ(uᵢ, b) and hence Πₐ vanish identically however sharp the buoyancy is. This is the check
 that a stray sign or a leftover term would break, since Υˡ itself is nowhere near zero here.
 """
 function test_ape_cross_scale_flux_vanishes_without_motion(grid, filt)

--- a/test/test_filtered_ape_diagnostics.jl
+++ b/test/test_filtered_ape_diagnostics.jl
@@ -5,6 +5,7 @@ using Oceananigans.Fields: location, compute_at!
 
 using Oceanostics
 using Oceanostics: FilteredAvailablePotentialEnergy, FilteredAvailablePotentialEnergyDissipationRate
+using Oceanostics: FilteredAvailablePotentialEnergyDisplacementPotential
 using Oceanostics: AvailablePotentialEnergyCrossScaleFlux, subfilter_covariance
 using Oceanostics: FilteredAvailablePotentialToKineticEnergyConversion
 using Oceanostics.BackgroundPotentialEnergyEquation: reference_buoyancy_at_height
@@ -130,6 +131,52 @@ function test_filtered_ape_fixed_profile(model, filt)
     return nothing
 end
 
+# Υˡ = z✶(b̄) - z: display/type checks, plus the identity that it is the full-field `Υ` kernel evaluated
+# on the reference height of the filtered buoyancy — which is how the tests here have always built the
+# `Υˡ` they hand the other diagnostics through `upsilon`, so the wrapper has to agree with it to the bit.
+function test_filtered_displacement_potential(model, filt)
+    Υˡ = FilteredAvailablePotentialEnergyDisplacementPotential(model, filt)
+    @test location(Υˡ) == (Center, Center, Center)
+    @test Υˡ isa FilteredAvailablePotentialEnergyDisplacementPotential
+    @test occursin("FilteredAvailablePotentialEnergyDisplacementPotential", sprint(show, Υˡ))
+    @test occursin("computes:", sprint(show, MIME("text/plain"), Υˡ))
+    @test all(isfinite, interior(Field(Υˡ)))
+    @test maximum(abs, interior(Field(Υˡ))) > 0   # otherwise the checks below would hold trivially
+
+    lookup = shared_lookup(model)
+    z✶ˡ = reference_height(Field(filt(model.tracers.b)); method=lookup)
+    @test interior(Field(FilteredAvailablePotentialEnergyDisplacementPotential(model, z✶ˡ))) ==
+          interior(Field(DisplacementPotential(model, z✶ˡ)))
+    @test interior(Field(FilteredAvailablePotentialEnergyDisplacementPotential(model, filt; method=lookup))) ==
+          interior(Field(DisplacementPotential(model, z✶ˡ)))
+
+    # Υˡ is what the dissipation and the cross-scale flux contract their fluxes against, so passing this
+    # diagnostic through `upsilon` has to reproduce what they build internally.
+    Υˡ_field = Field(FilteredAvailablePotentialEnergyDisplacementPotential(model, z✶ˡ))
+    @test interior(Field(FilteredAvailablePotentialEnergyDissipationRate(model, filt, z✶ˡ; upsilon=Υˡ_field))) ≈
+          interior(Field(FilteredAvailablePotentialEnergyDissipationRate(model, filt, z✶ˡ)))
+    @test interior(Field(AvailablePotentialEnergyCrossScaleFlux(model, filt, z✶ˡ; upsilon=Υˡ_field))) ≈
+          interior(Field(AvailablePotentialEnergyCrossScaleFlux(model, filt, z✶ˡ)))
+
+    σ = 0.12
+    conv = ψ -> GaussianFilter(ψ; dims=(1, 2, 3), σ, boundary=:shrink) # :shrink is the convenience default
+    @test interior(Field(FilteredAvailablePotentialEnergyDisplacementPotential(model; σ))) ≈
+          interior(Field(FilteredAvailablePotentialEnergyDisplacementPotential(model, conv)))
+
+    @test_throws ArgumentError FilteredAvailablePotentialEnergyDisplacementPotential(model, filt; method=HeavisideIntegral())
+    return nothing
+end
+
+# An identity-scale filter leaves the buoyancy alone, so Υˡ collapses onto the full field's Υ measured
+# against the same shared profile — the same bit-for-bit check the other filtered diagnostics get.
+function test_filtered_displacement_potential_identity_filter(model)
+    identity_filter = ψ -> GaussianFilter(ψ; dims=(1, 2, 3), σ=1e-6, N=3, boundary=:edge)
+    lookup = shared_lookup(model)
+    @test interior(Field(FilteredAvailablePotentialEnergyDisplacementPotential(model, identity_filter; method=lookup))) ≈
+          interior(Field(DisplacementPotential(model, reference_height(model; method=lookup))))
+    return nothing
+end
+
 # εₐˡ display/type checks, and the low-level `(model, filter, z✶ˡ; upsilon)` form sharing a Υˡ.
 function test_filtered_ape_dissipation_basics(model, filt)
     εₐˡ = FilteredAvailablePotentialEnergyDissipationRate(model, filt)
@@ -207,6 +254,7 @@ end
 # machinery so it can be used on its own.
 function test_filtered_ape_module_reexports()
     @test FilteredAvailablePotentialEnergyEquation.DissipationRate === FilteredAvailablePotentialEnergyDissipationRate
+    @test FilteredAvailablePotentialEnergyEquation.DisplacementPotential === FilteredAvailablePotentialEnergyDisplacementPotential
     @test FilteredAvailablePotentialEnergyEquation.ProfileLookup === ProfileLookup
     @test FilteredAvailablePotentialEnergyEquation.VerticalSort === VerticalSort
     @test FilteredAvailablePotentialEnergyEquation.reference_height === reference_height
@@ -469,6 +517,10 @@ end
 
     @info "    Fixed profile (arrays) agrees with borrowing the live column"
     test_filtered_ape_fixed_profile(model, filt)
+
+    @info "    Filtered displacement potential Υˡ = z✶(b̄) - z"
+    test_filtered_displacement_potential(model, filt)
+    test_filtered_displacement_potential_identity_filter(model)
 
     @info "    Filtered APE dissipation εₐˡ = -q̄ᵢ∂ᵢΥˡ basics and shared Υˡ"
     test_filtered_ape_dissipation_basics(model, filt)


### PR DESCRIPTION
Adds the derivation of the filtered APE budget to the `FilteredAvailablePotentialEnergyEquation` docs page.
