### PR TITLE
Check APE non-negativity where it was untested

### DIFF
--- a/docs/examples/lock_release.jl
+++ b/docs/examples/lock_release.jl
@@ -211,6 +211,7 @@ Z3 = ds["z✶_ranked"][:, :, :]
 ZH = ds["z✶_heaviside"][:, :, :]
 Z1 = ds["z✶_column"][:, :, :]            # (1, N, time): the column keeps the model's Flat y, dropped here
 B1 = ds["b✶_column"][:, :, :]
+E1 = ds["eₐ_column"][:, :, :]           # the column's own eₐ, checked for sign below   #hide
 close(ds)
 
 ## pair a reference-height map with the buoyancy map and order by z✶
@@ -352,6 +353,8 @@ eₐL_t = FieldTimeSeries(filepath, "eₐ_lookup")
 for A in (eₐ3_t, eₐH_t, eₐL_t)                                                                  #hide
     @test minimum(minimum(interior(A[n])) for n in 1:length(times)) ≥ -1e-6 * maximum(interior(A[end]))  #hide
 end                                                                                                #hide
+## and on the sorted column too, where eₐ is ordered by rank rather than by position             #hide
+@test minimum(E1) ≥ -1e-6 * maximum(E1)                                                           #hide
 ## the three model-grid methods agree cell by cell, not merely in the integral                     #hide
 for n in 1:length(times)                                                                           #hide
     @test interior(eₐH_t[n]) ≈ interior(eₐ3_t[n]) atol=1e-12                                     #hide

--- a/test/test_filtered_ape_diagnostics.jl
+++ b/test/test_filtered_ape_diagnostics.jl
@@ -85,10 +85,15 @@ end
 # term can dip below zero by at most half a class gap times the displacement — a discretization-sized
 # amount, not roundoff. Looking b̄ up in a profile sorted from b̄ itself puts it on the profile, and
 # there eₐˡ ≥ 0 to roundoff, which is the sharp check that the kernel's sign is right.
-function test_filtered_ape_nonnegative(grid, filt_horizontal)
+#
+# Neither bound depends on which way the filter cuts: b̄ is a convex combination of the field's own
+# buoyancies whatever `dims` is, so it lands between the same profile entries. That makes this test the
+# one place the vertical direction can be exercised, unlike `eₐˢ ≥ 0` in the subfilter suite, which
+# rests on Jensen at fixed z and genuinely fails once the filter averages across heights.
+function test_filtered_ape_nonnegative(grid, filt)
     model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b)
     set!(model, b=random_stratified_b)
-    b̄ = Field(filt_horizontal(model.tracers.b))
+    b̄ = Field(filt(model.tracers.b))
 
     # against the full field's profile: bounded by the profile's resolution
     col = reference_height(model, method=VerticalSort())
@@ -448,6 +453,7 @@ end
     grid = RectilinearGrid(arch, size=(8, 8, 8), extent=(1, 1, 1), topology=(Periodic, Periodic, Bounded))
     filt = ψ -> GaussianFilter(ψ; dims=(1, 2, 3), σ=0.1, boundary=:edge)
     filt_horizontal = ψ -> GaussianFilter(ψ; dims=(1, 2), σ=0.1)
+    filt_vertical = ψ -> GaussianFilter(ψ; dims=(3,), σ=0.1, boundary=:edge)
 
     model = NonhydrostaticModel(grid; buoyancy=BuoyancyTracer(), tracers=:b, closure=ScalarDiffusivity(κ=1e-4))
     set!(model, b=random_stratified_b)
@@ -463,6 +469,8 @@ end
 
     @info "    eₐˡ ≥ 0 (to the profile's resolution against the full field's profile; to roundoff against its own)"
     test_filtered_ape_nonnegative(grid, filt_horizontal)
+    test_filtered_ape_nonnegative(grid, filt_vertical)
+    test_filtered_ape_nonnegative(grid, filt)
 
     @info "    Gaussian convenience methods"
     test_filtered_ape_convenience(model)


### PR DESCRIPTION
Two gaps in the APE sign coverage: the lock release example wrote `eₐ_column` without checking it, and `test_filtered_ape_nonnegative` only ever saw a horizontal filter. The eₐˡ bound comes from the lookup, not the filter's direction, so it now runs for a horizontal, a vertical and a 3D filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cu2MDgon2SpqGk7gLaFo1h